### PR TITLE
StringOf and CStringOf Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@bosque/jsbrex": "0.7.0",
+                "@bosque/jsbrex": "0.8.0",
                 "@types/node": "20.14.2"
             },
             "bin": {
@@ -22,7 +22,7 @@
         },
         "../JsBREX": {
             "name": "@bosque/jsbrex",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@bosque/jsbrex": "0.5.0",
+                "@bosque/jsbrex": "0.6.0",
                 "@types/node": "20.14.2"
             },
             "bin": {
@@ -21,11 +21,10 @@
             }
         },
         "node_modules/@bosque/jsbrex": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@bosque/jsbrex/-/jsbrex-0.5.0.tgz",
-            "integrity": "sha512-n7vc6A62Y88f4kByDw5AvWIGECDUTU4G+YW6MVyFa7vVFsDh1xUWhpiXOKPQQhIB8seb3IzxJDHo18/T684uXA==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@bosque/jsbrex/-/jsbrex-0.6.0.tgz",
+            "integrity": "sha512-ty5/dQHd2aZXTNPRpkkMjgt2JcnQylBl7d9kKQe7ldO/GtdoZwcUAdTMU7vgvdQ7sSLfETQpYk6BXKl1oGOJRw==",
             "hasInstallScript": true,
-            "license": "MIT",
             "dependencies": {
                 "node-addon-api": "8.0.0"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@bosque/jsbrex": "0.6.0",
+                "@bosque/jsbrex": "0.7.0",
                 "@types/node": "20.14.2"
             },
             "bin": {
@@ -20,14 +20,18 @@
                 "typescript": ">=5.3.0"
             }
         },
-        "node_modules/@bosque/jsbrex": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@bosque/jsbrex/-/jsbrex-0.6.0.tgz",
-            "integrity": "sha512-ty5/dQHd2aZXTNPRpkkMjgt2JcnQylBl7d9kKQe7ldO/GtdoZwcUAdTMU7vgvdQ7sSLfETQpYk6BXKl1oGOJRw==",
+        "../JsBREX": {
+            "name": "@bosque/jsbrex",
+            "version": "0.7.0",
             "hasInstallScript": true,
+            "license": "MIT",
             "dependencies": {
                 "node-addon-api": "8.0.0"
             }
+        },
+        "node_modules/@bosque/jsbrex": {
+            "resolved": "../JsBREX",
+            "link": true
         },
         "node_modules/@types/node": {
             "version": "20.14.2",
@@ -35,14 +39,6 @@
             "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
             "dependencies": {
                 "undici-types": "~5.26.4"
-            }
-        },
-        "node_modules/node-addon-api": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.0.0.tgz",
-            "integrity": "sha512-ipO7rsHEBqa9STO5C5T10fj732ml+5kLN1cAG8/jdHd56ldQeGj3Q7+scUS+VHK/qy1zLEwC4wMK5+yM0btPvw==",
-            "engines": {
-                "node": "^18 || ^20 || >= 21"
             }
         },
         "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@bosque/jsbrex": "0.4.0",
+                "@bosque/jsbrex": "0.5.0",
                 "@types/node": "20.14.2"
             },
             "bin": {
@@ -21,9 +21,9 @@
             }
         },
         "node_modules/@bosque/jsbrex": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@bosque/jsbrex/-/jsbrex-0.4.0.tgz",
-            "integrity": "sha512-FDu6D9KDjtQU7apTRmXwK4twplfNKxKUya16w5RiX/ofcKzUxpfUlVV8LnXSYqcNn25KAcfC73fUgYmYAlV02g==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@bosque/jsbrex/-/jsbrex-0.5.0.tgz",
+            "integrity": "sha512-n7vc6A62Y88f4kByDw5AvWIGECDUTU4G+YW6MVyFa7vVFsDh1xUWhpiXOKPQQhIB8seb3IzxJDHo18/T684uXA==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@types/node": "20.14.2",
-        "@bosque/jsbrex": "0.6.0"
+        "@bosque/jsbrex": "0.7.0"
     },
     "scripts": {
         "build": "node ./build/build_all.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@types/node": "20.14.2",
-        "@bosque/jsbrex": "0.4.0"
+        "@bosque/jsbrex": "0.5.0"
     },
     "scripts": {
         "build": "node ./build/build_all.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@types/node": "20.14.2",
-        "@bosque/jsbrex": "0.5.0"
+        "@bosque/jsbrex": "0.6.0"
     },
     "scripts": {
         "build": "node ./build/build_all.js",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     },
     "engines": {
         "node": ">=20.10.0",
-        "typescript": ">=5.3.0"
+        "typescript": ">=5.4.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@types/node": "20.14.2",
-        "@bosque/jsbrex": "0.7.0"
+        "@bosque/jsbrex": "0.8.0"
     },
     "scripts": {
         "build": "node ./build/build_all.js",

--- a/src/frontend/assembly.ts
+++ b/src/frontend/assembly.ts
@@ -1559,30 +1559,6 @@ class NamespaceDeclaration {
         return this.declaredNames.has(rname);
     }
 
-    loadConstantsAndValidatorREs(): NSRegexInfo[] {
-        const inns = this.fullnamespace.emit();
-        const nsmappings = this.usings.filter((u) => u.asns !== undefined).map((u) => [u.fromns.emit(), u.asns as string]);
-
-        const reinfos: NSRegexREInfoEntry[] = [];
-        this.typedecls.forEach((td) => {
-            if(td instanceof RegexValidatorTypeDecl) {
-                reinfos.push({name: td.name, restr: td.regex});
-            }
-            if(td instanceof CRegexValidatorTypeDecl) {
-                reinfos.push({name: td.name, restr: td.regex});
-            }
-        });
-        this.consts.forEach((c) => {
-            xxxx;
-
-            if(c.declaredType instanceof CRegexValidatorTypeDecl) {
-                reinfos.push({name: c.name, restr: c.value.regex});
-            }
-        });
-
-        const subnsinfo = this.subns.map((ns) => ns.loadConstantsAndValidatorREs());
-    }
-
     emit(fmt: CodeFormatter): string {
         let res = "";
 

--- a/src/frontend/assembly.ts
+++ b/src/frontend/assembly.ts
@@ -1481,6 +1481,21 @@ class NamespaceUsing {
     }
 }
 
+type NSRegexNameInfo = {
+    inns: string,
+    nsmappings: [string, string][]
+}
+
+type NSRegexREInfoEntry = {
+    name: string,
+    restr: string
+}
+
+type NSRegexInfo = {
+    nsinfo: NSRegexNameInfo,
+    reinfos: NSRegexREInfoEntry[]
+}
+
 class NamespaceDeclaration {
     readonly istoplevel: boolean;
     readonly name: string; 
@@ -1542,6 +1557,30 @@ class NamespaceDeclaration {
 
     checkDeclNameClashMember(rname: string): boolean {
         return this.declaredNames.has(rname);
+    }
+
+    loadConstantsAndValidatorREs(): NSRegexInfo[] {
+        const inns = this.fullnamespace.emit();
+        const nsmappings = this.usings.filter((u) => u.asns !== undefined).map((u) => [u.fromns.emit(), u.asns as string]);
+
+        const reinfos: NSRegexREInfoEntry[] = [];
+        this.typedecls.forEach((td) => {
+            if(td instanceof RegexValidatorTypeDecl) {
+                reinfos.push({name: td.name, restr: td.regex});
+            }
+            if(td instanceof CRegexValidatorTypeDecl) {
+                reinfos.push({name: td.name, restr: td.regex});
+            }
+        });
+        this.consts.forEach((c) => {
+            xxxx;
+
+            if(c.declaredType instanceof CRegexValidatorTypeDecl) {
+                reinfos.push({name: c.name, restr: c.value.regex});
+            }
+        });
+
+        const subnsinfo = this.subns.map((ns) => ns.loadConstantsAndValidatorREs());
     }
 
     emit(fmt: CodeFormatter): string {
@@ -1674,5 +1713,6 @@ export {
     EnvironmentVariableInformation, ResourceAccessModes, ResourceInformation, APIDecl,
     TaskDecl,
     NamespaceConstDecl, NamespaceUsing, NamespaceDeclaration,
+    NSRegexInfo, NSRegexNameInfo, NSRegexREInfoEntry,
     Assembly
 };

--- a/src/frontend/body.ts
+++ b/src/frontend/body.ts
@@ -2112,7 +2112,7 @@ class SelfUpdateStatement extends Statement {
 }
 
 class EnvironmentUpdateStatement extends Statement {
-    readonly updates: [LiteralExpressionValue, Expression][]; //exchange strings
+    readonly updates: [LiteralExpressionValue, Expression][];
 
     constructor(sinfo: SourceInfo, updates: [LiteralExpressionValue, Expression][]) {
         super(StatementTag.EnvironmentUpdateStatement, sinfo);

--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -3718,6 +3718,8 @@ class TypeChecker {
 
     private checkPathValidatorTypeDecl(ns: NamespaceDeclaration, tdecl: PathValidatorTypeDecl) {
         this.checkInteralSimpleTypeDeclHelper(ns, tdecl, true);
+
+        assert(false, "Not implemented -- checkPathValidatorTypeDecl");
     }
 
     private checkStringOfTypeDecl(ns: NamespaceDeclaration, tdecl: StringOfTypeDecl) {

--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -728,6 +728,11 @@ class TypeChecker {
             return exp.setType(new ErrorTypeSignature(exp.stype.sinfo, undefined));
         }
 
+        if(!this.relations.isSubtypeOf(exp.stype, this.getWellKnownType("RegexValidator"), this.constraints)) {
+            this.reportError(exp.sinfo, `Bad Validator type for StringOf -- expected a RegexValidator`);
+            return exp.setType(new ErrorTypeSignature(exp.stype.sinfo, undefined));
+        }
+
         try {
             const vs = validateStringLiteral(exp.value.slice(1, exp.value.length - 1));
             this.runValidatorRegex(exp.sinfo, revalidator, vs as string); 
@@ -751,6 +756,11 @@ class TypeChecker {
 
         if(revalidator === undefined) {
             this.reportError(exp.sinfo, `Bad Validator type for CStringOf -- could not resolve to a valid regex`);
+            return exp.setType(new ErrorTypeSignature(exp.stype.sinfo, undefined));
+        }
+
+        if(!this.relations.isSubtypeOf(exp.stype, this.getWellKnownType("CRegexValidator"), this.constraints)) {
+            this.reportError(exp.sinfo, `Bad Validator type for CStringOf -- expected a CRegexValidator`);
             return exp.setType(new ErrorTypeSignature(exp.stype.sinfo, undefined));
         }
 

--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -1,13 +1,13 @@
 import assert from "node:assert";
 
-import { APIDecl, APIErrorTypeDecl, APIFailedTypeDecl, APIRejectedTypeDecl, APIResultTypeDecl, APISuccessTypeDecl, CRegexValidatorTypeDecl, CStringOfTypeDecl, AbstractNominalTypeDecl, Assembly, ConceptTypeDecl, ConstMemberDecl, DatatypeMemberEntityTypeDecl, DatatypeTypeDecl, EntityTypeDecl, EnumTypeDecl, EnvironmentVariableInformation, ErrTypeDecl, EventListTypeDecl, ExpandoableTypeDecl, ExplicitInvokeDecl, InternalEntityTypeDecl, InvariantDecl, InvokeExample, InvokeExampleDeclFile, InvokeExampleDeclInline, InvokeTemplateTermDecl, ListTypeDecl, MapEntryTypeDecl, MapTypeDecl, MemberFieldDecl, MethodDecl, NamespaceConstDecl, NamespaceDeclaration, NamespaceFunctionDecl, OkTypeDecl, OptionTypeDecl, PathFragmentOfTypeDecl, PathGlobOfTypeDecl, PathOfTypeDecl, PathValidatorTypeDecl, PostConditionDecl, PreConditionDecl, PrimitiveConceptTypeDecl, PrimitiveEntityTypeDecl, QueueTypeDecl, RegexValidatorTypeDecl, ResourceInformation, ResultTypeDecl, SetTypeDecl, StackTypeDecl, StringOfTypeDecl, TaskActionDecl, TaskDecl, TaskMethodDecl, TypeFunctionDecl, TypeTemplateTermDecl, TypedeclTypeDecl, ValidateDecl, WELL_KNOWN_EVENTS_VAR_NAME, WELL_KNOWN_RETURN_VAR_NAME, TemplateTermDeclExtraTag, PairTypeDecl, SomeTypeDecl } from "./assembly.js";
+import { APIDecl, APIErrorTypeDecl, APIFailedTypeDecl, APIRejectedTypeDecl, APIResultTypeDecl, APISuccessTypeDecl, CRegexValidatorTypeDecl, CStringOfTypeDecl, AbstractNominalTypeDecl, Assembly, ConceptTypeDecl, ConstMemberDecl, DatatypeMemberEntityTypeDecl, DatatypeTypeDecl, EntityTypeDecl, EnumTypeDecl, EnvironmentVariableInformation, ErrTypeDecl, EventListTypeDecl, ExpandoableTypeDecl, ExplicitInvokeDecl, InternalEntityTypeDecl, InvariantDecl, InvokeExample, InvokeExampleDeclFile, InvokeExampleDeclInline, InvokeTemplateTermDecl, ListTypeDecl, MapEntryTypeDecl, MapTypeDecl, MemberFieldDecl, MethodDecl, NamespaceConstDecl, NamespaceDeclaration, NamespaceFunctionDecl, OkTypeDecl, OptionTypeDecl, PathFragmentOfTypeDecl, PathGlobOfTypeDecl, PathOfTypeDecl, PathValidatorTypeDecl, PostConditionDecl, PreConditionDecl, PrimitiveConceptTypeDecl, PrimitiveEntityTypeDecl, QueueTypeDecl, RegexValidatorTypeDecl, ResourceInformation, ResultTypeDecl, SetTypeDecl, StackTypeDecl, StringOfTypeDecl, TaskActionDecl, TaskDecl, TaskMethodDecl, TypeFunctionDecl, TypeTemplateTermDecl, TypedeclTypeDecl, ValidateDecl, WELL_KNOWN_EVENTS_VAR_NAME, WELL_KNOWN_RETURN_VAR_NAME, TemplateTermDeclExtraTag, PairTypeDecl, SomeTypeDecl, NSRegexREInfoEntry, NSRegexInfo, NSRegexNameInfo } from "./assembly.js";
 import { SourceInfo } from "./build_decls.js";
 import { AutoTypeSignature, EListTypeSignature, ErrorTypeSignature, LambdaTypeSignature, NominalTypeSignature, StringTemplateTypeSignature, TemplateConstraintScope, TemplateTypeSignature, TypeSignature, VoidTypeSignature } from "./type.js";
 import { AbortStatement, AbstractBodyImplementation, AccessEnumExpression, AccessEnvValueExpression, AccessNamespaceConstantExpression, AccessStaticFieldExpression, AccessVariableExpression, AssertStatement, BinAddExpression, BinDivExpression, BinKeyEqExpression, BinKeyNeqExpression, BinLogicAndExpression, BinLogicIFFExpression, BinLogicImpliesExpression, BinLogicOrExpression, BinMultExpression, BinSubExpression, BinderInfo, BlockStatement, BodyImplementation, BuiltinBodyImplementation, CallNamespaceFunctionExpression, CallRefSelfExpression, CallRefThisExpression, CallTaskActionExpression, CallTypeFunctionExpression, ConstructorEListExpression, ConstructorLambdaExpression, ConstructorPrimaryExpression, ConstructorRecordExpression, ConstructorTupleExpression, DebugStatement, EmptyStatement, EnvironmentBracketStatement, EnvironmentUpdateStatement, Expression, ExpressionBodyImplementation, ExpressionTag, ITest, ITestErr, ITestNone, ITestOk, ITestSome, ITestType, IfElifElseStatement, IfElseStatement, IfExpression, IfStatement, InterpolateExpression, LambdaInvokeExpression, LetExpression, LiteralExpressionValue, LiteralNoneExpression, LiteralPathExpression, LiteralRegexExpression, LiteralSimpleExpression, LiteralTemplateStringExpression, LiteralTypeDeclFloatPointValueExpression, LiteralTypeDeclIntegralValueExpression, LiteralTypeDeclValueExpression, LiteralTypedStringExpression, LogicActionAndExpression, LogicActionOrExpression, MapEntryConstructorExpression, MatchStatement, NumericEqExpression, NumericGreaterEqExpression, NumericGreaterExpression, NumericLessEqExpression, NumericLessExpression, NumericNeqExpression, ParseAsTypeExpression, PostfixAccessFromName, PostfixAsConvert, PostfixAssignFields, PostfixInvoke, PostfixIsTest, PostfixLiteralKeyAccess, PostfixOp, PostfixOpTag, PostfixProjectFromNames, PredicateUFBodyImplementation, PrefixNegateOrPlusOpExpression, PrefixNotOpExpression, ReturnStatement, SelfUpdateStatement, SpecialConstructorExpression, SpecialConverterExpression, StandardBodyImplementation, Statement, StatementTag, SwitchStatement, SynthesisBodyImplementation, TaskAccessInfoExpression, TaskAllExpression, TaskDashExpression, TaskEventEmitStatement, TaskMultiExpression, TaskRaceExpression, TaskRunExpression, TaskStatusStatement, TaskYieldStatement, ThisUpdateStatement, ValidateStatement, VarUpdateStatement, VariableAssignmentStatement, VariableDeclarationStatement, VariableInitializationStatement, VariableMultiAssignmentStatement, VariableMultiDeclarationStatement, VariableMultiInitializationStatement, VariableRetypeStatement, VoidRefCallStatement } from "./body.js";
 import { EListStyleTypeInferContext, SimpleTypeInferContext, TypeEnvironment, TypeInferContext, VarInfo } from "./checker_environment.js";
 import { TypeCheckerRelations } from "./checker_relations.js";
 
-import { accepts, validateStringLiteral, validateCStringLiteral } from "@bosque/jsbrex";
+import { validateStringLiteral, validateCStringLiteral, loadConstAndValidateRESystem, runNamedRegexAccepts } from "@bosque/jsbrex";
 
 const MIN_SAFE_INT = -9223372036854775807n;
 const MAX_SAFE_INT = 9223372036854775807n;
@@ -709,8 +709,8 @@ class TypeChecker {
         return exp.setType(this.getWellKnownType("CString"));
     }
 
-    private runValidatorRegex(sinfo: SourceInfo, restr: string, litstr: string): boolean {
-        return accepts(restr, litstr);
+    private runValidatorRegex(sinfo: SourceInfo, rename: string, litstr: string): boolean {
+        return runNamedRegexAccepts(rename, litstr.slice(1, litstr.length - 1), litstr.startsWith('"'));
     }
 
     private checkLiteralTypedStringExpression(env: TypeEnvironment, exp: LiteralTypedStringExpression): TypeSignature {
@@ -4120,13 +4120,54 @@ class TypeChecker {
         }
     }
 
-    private static processConstsAndValidatorREs(assembly: Assembly) {
-        for(let i = 0; i < assembly.toplevelNamespaces.length; ++i) {
-            const ns = assembly.toplevelNamespaces[i];
-            const nsinfo = ns.loadConstantsAndValidatorREs();
-
-            xxxx;
+    private tryReduceConstantExpressionToRE(exp: Expression): LiteralRegexExpression | undefined {
+        if(exp instanceof LiteralRegexExpression) {
+            return exp;
         }
+        else if (exp instanceof AccessNamespaceConstantExpression) {
+            const nsresl = this.relations.resolveNamespaceConstant(exp.ns, exp.name);
+            if(nsresl === undefined) {
+                return undefined;
+            }
+
+            return this.tryReduceConstantExpressionToRE(nsresl.value.exp);
+        }
+        else {
+            return undefined;
+        }
+    }
+
+    private loadConstantsAndValidatorREs(nsdecl: NamespaceDeclaration): NSRegexInfo[] {
+        const inns = nsdecl.fullnamespace.emit();
+        const nsmappings = nsdecl.usings.filter((u) => u.asns !== undefined).map((u) => [u.fromns.emit(), u.asns as string] as [string, string]);
+        const nsinfo: NSRegexNameInfo = {inns: inns, nsmappings: nsmappings};
+
+        const reinfos: NSRegexREInfoEntry[] = [];
+        nsdecl.typedecls.forEach((td) => {
+            if(td instanceof RegexValidatorTypeDecl) {
+                reinfos.push({name: td.name, restr: td.regex});
+            }
+            if(td instanceof CRegexValidatorTypeDecl) {
+                reinfos.push({name: td.name, restr: td.regex});
+            }
+        });
+        nsdecl.consts.forEach((c) => {
+            const re = this.tryReduceConstantExpressionToRE(c.value.exp);
+            if(re !== undefined) {
+                reinfos.push({name: c.name, restr: re.value});
+            }
+        });
+
+        const subnsinfo = nsdecl.subns.flatMap((ns) => this.loadConstantsAndValidatorREs(ns));
+
+        return [{nsinfo: nsinfo, reinfos:  reinfos}, ...subnsinfo];
+    }
+
+    private processConstsAndValidatorREs(assembly: Assembly) {
+        const asmreinfo = assembly.toplevelNamespaces.flatMap((ns) => this.loadConstantsAndValidatorREs(ns));
+
+        //Now process the regexs
+        loadConstAndValidateRESystem(asmreinfo);
     }
 
     private static loadWellKnownType(assembly: Assembly, name: string, wellknownTypes: Map<string, TypeSignature>) {
@@ -4172,11 +4213,12 @@ class TypeChecker {
         TypeChecker.loadWellKnownType(assembly, "String", wellknownTypes);
         TypeChecker.loadWellKnownType(assembly, "CString", wellknownTypes);
 
+        const checker = new TypeChecker(new TemplateConstraintScope(), new TypeCheckerRelations(assembly, wellknownTypes));
+
         //Gather all the const and validator regexs, make sure they are valid and generate the compiled versions
-        TypeChecker.processConstsAndValidatorREs(assembly);
+        checker.processConstsAndValidatorREs(assembly);
 
         //Type-check each of the assemblies
-        const checker = new TypeChecker(new TemplateConstraintScope(), new TypeCheckerRelations(assembly, wellknownTypes));
         for(let i = 0; i < assembly.toplevelNamespaces.length; ++i) {
             checker.checkNamespaceDeclaration(assembly.toplevelNamespaces[i]);
         }

--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -4115,9 +4115,17 @@ class TypeChecker {
             this.checkTaskDecl(decl, decl.tasks[i]);
         }
 
-
         for(let i = 0; i < decl.subns.length; ++i) {
             this.checkNamespaceDeclaration(decl.subns[i]);
+        }
+    }
+
+    private static processConstsAndValidatorREs(assembly: Assembly) {
+        for(let i = 0; i < assembly.toplevelNamespaces.length; ++i) {
+            const ns = assembly.toplevelNamespaces[i];
+            const nsinfo = ns.loadConstantsAndValidatorREs();
+
+            xxxx;
         }
     }
 
@@ -4164,8 +4172,11 @@ class TypeChecker {
         TypeChecker.loadWellKnownType(assembly, "String", wellknownTypes);
         TypeChecker.loadWellKnownType(assembly, "CString", wellknownTypes);
 
-        const checker = new TypeChecker(new TemplateConstraintScope(), new TypeCheckerRelations(assembly, wellknownTypes));
+        //Gather all the const and validator regexs, make sure they are valid and generate the compiled versions
+        TypeChecker.processConstsAndValidatorREs(assembly);
 
+        //Type-check each of the assemblies
+        const checker = new TypeChecker(new TemplateConstraintScope(), new TypeCheckerRelations(assembly, wellknownTypes));
         for(let i = 0; i < assembly.toplevelNamespaces.length; ++i) {
             checker.checkNamespaceDeclaration(assembly.toplevelNamespaces[i]);
         }

--- a/src/frontend/checker_relations.ts
+++ b/src/frontend/checker_relations.ts
@@ -845,13 +845,13 @@ class TypeCheckerRelations {
         return curns;
     }
 
-    resolveStringRegexValidatorInfo(ttype: TypeSignature): string | undefined {
+    resolveStringRegexValidatorInfo(inns: FullyQualifiedNamespace, ttype: TypeSignature): string | undefined {
         if(ttype instanceof NominalTypeSignature) {
             if(ttype.decl instanceof RegexValidatorTypeDecl) {
-                return ttype.decl.ns.ns.join("::") + "::" + ttype.decl.name;
+                return inns.ns.join("::") + "::" + ttype.decl.name;
             }
             else if(ttype.decl instanceof CRegexValidatorTypeDecl) {
-                return ttype.decl.ns.ns.join("::") + "::" + ttype.decl.name;
+                return inns.ns.join("::") + "::" + ttype.decl.name;
             }
             else {
                 return undefined;

--- a/src/frontend/checker_relations.ts
+++ b/src/frontend/checker_relations.ts
@@ -848,10 +848,10 @@ class TypeCheckerRelations {
     resolveStringRegexValidatorInfo(ttype: TypeSignature): string | undefined {
         if(ttype instanceof NominalTypeSignature) {
             if(ttype.decl instanceof RegexValidatorTypeDecl) {
-                return ttype.decl.regex;
+                return ttype.decl.ns.emit() + "::" + ttype.decl.name;
             }
             else if(ttype.decl instanceof CRegexValidatorTypeDecl) {
-                return ttype.decl.regex;
+                return ttype.decl.ns.emit() + "::" + ttype.decl.name;
             }
             else {
                 return undefined;

--- a/src/frontend/checker_relations.ts
+++ b/src/frontend/checker_relations.ts
@@ -848,10 +848,10 @@ class TypeCheckerRelations {
     resolveStringRegexValidatorInfo(ttype: TypeSignature): string | undefined {
         if(ttype instanceof NominalTypeSignature) {
             if(ttype.decl instanceof RegexValidatorTypeDecl) {
-                return ttype.decl.ns.emit() + "::" + ttype.decl.name;
+                return ttype.decl.ns.ns.join("::") + "::" + ttype.decl.name;
             }
             else if(ttype.decl instanceof CRegexValidatorTypeDecl) {
-                return ttype.decl.ns.emit() + "::" + ttype.decl.name;
+                return ttype.decl.ns.ns.join("::") + "::" + ttype.decl.name;
             }
             else {
                 return undefined;

--- a/test/parser/literals/stringof.test.js
+++ b/test/parser/literals/stringof.test.js
@@ -10,7 +10,6 @@ describe ("Parser -- StringOf", () => {
         parseTestFunctionInFile('validator Foo = /[0-9]*/; [FUNC]', 'function main(): StringOf<Foo> { return "a🌵c"_Foo; }');
     });
 
-    /*
     it("should fail missing under", function () {
         parseTestExpError('"abc"Foo', 'Expected ";" but got "Foo" when parsing "line statement"', "StringOf<Foo>");
     });
@@ -18,7 +17,6 @@ describe ("Parser -- StringOf", () => {
     it("should fail missing typename", function () {
         parseTestExpError('"abc"_', 'err2', "StringOf<Foo>");
     });
-    */
 });
 
 describe ("Parser -- CStringOf", () => {
@@ -27,9 +25,7 @@ describe ("Parser -- CStringOf", () => {
         parseTestFunctionInFile('validator Foo = /[0-9]*/; [FUNC]', "function main(): CStringOf<Foo> { return '123'_Foo; }");
     });
 
-    /*
     it("should fail missing under", function () {
         parseTestExpError("'abc'Foo", 'Expected ";" but got "Foo" when parsing "line statement"', "CStringOf<Foo>");
     });
-    */
 });

--- a/test/parser/literals/stringof.test.js
+++ b/test/parser/literals/stringof.test.js
@@ -1,0 +1,35 @@
+"use strict";
+
+import { parseTestFunctionInFile } from "../../../bin/test/parser/parse_nf.js";
+import { describe, it } from "node:test";
+
+describe ("Parser -- StringOf", () => {
+    it("should parse simple stringof", function () {
+        parseTestFunctionInFile('validator Foo = /[0-9]*/; [FUNC]', 'function main(): StringOf<Foo> { return ""_Foo; }');
+        parseTestFunctionInFile('validator Foo = /[0-9]*/; [FUNC]', 'function main(): StringOf<Foo> { return "123"_Foo; }');
+        parseTestFunctionInFile('validator Foo = /[0-9]*/; [FUNC]', 'function main(): StringOf<Foo> { return "a🌵c"_Foo; }');
+    });
+
+    /*
+    it("should fail missing under", function () {
+        parseTestExpError('"abc"Foo', 'Expected ";" but got "Foo" when parsing "line statement"', "StringOf<Foo>");
+    });
+
+    it("should fail missing typename", function () {
+        parseTestExpError('"abc"_', 'err2', "StringOf<Foo>");
+    });
+    */
+});
+
+describe ("Parser -- CStringOf", () => {
+    it("should parse simple cstringof", function () {
+        parseTestFunctionInFile('validator Foo = /[0-9]*/; [FUNC]', "function main(): CStringOf<Foo> { return ''_Foo; }");
+        parseTestFunctionInFile('validator Foo = /[0-9]*/; [FUNC]', "function main(): CStringOf<Foo> { return '123'_Foo; }");
+    });
+
+    /*
+    it("should fail missing under", function () {
+        parseTestExpError("'abc'Foo", 'Expected ";" but got "Foo" when parsing "line statement"', "CStringOf<Foo>");
+    });
+    */
+});

--- a/test/parser/literals/stringof.test.js
+++ b/test/parser/literals/stringof.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { parseTestFunctionInFile } from "../../../bin/test/parser/parse_nf.js";
+import { parseTestFunctionInFile, parseTestFunctionInFileError } from "../../../bin/test/parser/parse_nf.js";
 import { describe, it } from "node:test";
 
 describe ("Parser -- StringOf", () => {
@@ -11,21 +11,17 @@ describe ("Parser -- StringOf", () => {
     });
 
     it("should fail missing under", function () {
-        parseTestExpError('"abc"Foo', 'Expected ";" but got "Foo" when parsing "line statement"', "StringOf<Foo>");
-    });
-
-    it("should fail missing typename", function () {
-        parseTestExpError('"abc"_', 'err2', "StringOf<Foo>");
+        parseTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "123"Foo; }', 'Expected ";" but got "Foo" when parsing "line statement"');
     });
 });
 
 describe ("Parser -- CStringOf", () => {
     it("should parse simple cstringof", function () {
-        parseTestFunctionInFile('validator Foo = /[0-9]*/; [FUNC]', "function main(): CStringOf<Foo> { return ''_Foo; }");
-        parseTestFunctionInFile('validator Foo = /[0-9]*/; [FUNC]', "function main(): CStringOf<Foo> { return '123'_Foo; }");
+        parseTestFunctionInFile("validator Foo = /[0-9]*/c; [FUNC]", "function main(): CStringOf<Foo> { return ''_Foo; }");
+        parseTestFunctionInFile("validator Foo = /[0-9]*/c; [FUNC]", "function main(): CStringOf<Foo> { return '123'_Foo; }");
     });
 
     it("should fail missing under", function () {
-        parseTestExpError("'abc'Foo", 'Expected ";" but got "Foo" when parsing "line statement"', "CStringOf<Foo>");
+        parseTestFunctionInFileError("validator Foo = /[0-9]*/c; function main(): StringOf<Foo> { return '123'Foo; }", 'Expected ";" but got "Foo" when parsing "line statement"');
     });
 });

--- a/test/parser/parse_nf.ts
+++ b/test/parser/parse_nf.ts
@@ -17,6 +17,16 @@ function parseFunction(ff: string): string {
     return wsnorm(Array.isArray(rr) ? rr[0].message : rr);
 }
 
+function parseFunctionInFile(code: string): string {
+    const src = workflowLoadCoreSrc();
+    if(src === undefined) {
+        return "**ERROR**";
+    }
+
+    const rr = Parser.test_parseSFunctionInFile(src, ["EXEC_LIBS"], code, "main");
+    return wsnorm(Array.isArray(rr) ? rr[0].message : rr);
+}
+
 function generateExpFunction(exp: string, type: string): string {
     return `function main(): ${type} { return ${exp}; }`;
 }
@@ -40,7 +50,12 @@ function parseTestFunctionError(ff: string, error: string) {
     assert.equal(parseFunction(ff), error);
 }
 
+function parseTestFunctionInFile(code: string, rff: string) {
+    assert.equal(parseFunctionInFile(code.replace("[FUNC]", rff)), wsnorm(rff));
+}
+
 export {
     parseTestExp, parseTestExpError,
-    parseTestFunction, parseTestFunctionError
+    parseTestFunction, parseTestFunctionError,
+    parseTestFunctionInFile
 };

--- a/test/parser/parse_nf.ts
+++ b/test/parser/parse_nf.ts
@@ -54,8 +54,12 @@ function parseTestFunctionInFile(code: string, rff: string) {
     assert.equal(parseFunctionInFile(code.replace("[FUNC]", rff)), wsnorm(rff));
 }
 
+function parseTestFunctionInFileError(code: string, error: string) {
+    assert.equal(parseFunctionInFile(code), error);
+}
+
 export {
     parseTestExp, parseTestExpError,
     parseTestFunction, parseTestFunctionError,
-    parseTestFunctionInFile
+    parseTestFunctionInFile, parseTestFunctionInFileError
 };

--- a/test/typecheck/literals/stringof.test.js
+++ b/test/typecheck/literals/stringof.test.js
@@ -11,7 +11,7 @@ describe("Checker -- StringOf", () => {
 
     it("should check simple stringof fails", function () {
         checkTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "a"_Foo; }', "Literal value does not match regex validator Main::Foo");
-        checkTestFunctionInFileError('validator Foo = /[0-9]+/; function main(): StringOf<Foo> { return ""_Foo; }', "errLiteral value does not match regex validator Main::Foo2");
+        checkTestFunctionInFileError('validator Foo = /[0-9]+/; function main(): StringOf<Foo> { return ""_Foo; }', "Literal value does not match regex validator Main::Foo");
         checkTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "a🌵c"_Foo; }', "Literal value does not match regex validator Main::Foo");
     });
 

--- a/test/typecheck/literals/stringof.test.js
+++ b/test/typecheck/literals/stringof.test.js
@@ -1,0 +1,45 @@
+"use strict";
+
+import { checkTestFunctionInFile, checkTestFunctionInFileError } from "../../../bin/test/typecheck/typecheck_nf.js";
+import { describe, it } from "node:test";
+
+describe("Checker -- StringOf", () => {
+    it("should check simple stringof", function () {
+        checkTestFunctionInFile('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return ""_Foo; }');
+        checkTestFunctionInFile('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "123"_Foo; }');
+    });
+
+    it("should check simple stringof fails", function () {
+        checkTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "a"_Foo; }', "err1");
+        checkTestFunctionInFileError('validator Foo = /[0-9]+/; function main(): StringOf<Foo> { return ""_Foo; }', "err2");
+        checkTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "a🌵c"_Foo; }', "err3");
+    });
+
+    it("should fail mismatch regex", function () {
+        checkTestFunctionInFileError('validator Foo = /[0-9]*/c; function main(): StringOf<Foo> { return "123"_Foo; }', "Template argument T is not a subtype of RegexValidator");
+    });
+
+    it("should fail missing typename", function () {
+        checkTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "123"; }', "Expected a return value of type StringOf<Foo> but got String");
+    });
+});
+
+describe("Checker -- CStringOf", () => {
+    it("should check simple cstringof", function () {
+        checkTestFunctionInFile("validator Foo = /[0-9]*/c; function main(): CStringOf<Foo> { return ''_Foo; }");
+        checkTestFunctionInFile("validator Foo = /[0-9]*/c; function main(): CStringOf<Foo> { return '123'_Foo; }");
+    });
+
+    it("should check simple cstringof fails", function () {
+        checkTestFunctionInFileError("validator Foo = /[0-9]+/c; function main(): CStringOf<Foo> { return ''_Foo; }", "err7");
+        checkTestFunctionInFileError("validator Foo = /[0-9]*/c; function main(): CStringOf<Foo> { return 'a'_Foo; }", "err8");
+    });
+
+    it("should fail mismatch regex", function () {
+        checkTestFunctionInFileError("validator Foo = /[0-9]*/; function main(): CStringOf<Foo> { return '123'_Foo; }", "Template argument T is not a subtype of CRegexValidator");
+    });
+
+    it("should fail missing typename", function () {
+        checkTestFunctionInFileError("validator Foo = /[0-9]*/c; function main(): CStringOf<Foo> { return '123'; }", "Expected a return value of type CStringOf<Foo> but got CString");
+    });
+});

--- a/test/typecheck/literals/stringof.test.js
+++ b/test/typecheck/literals/stringof.test.js
@@ -5,21 +5,21 @@ import { describe, it } from "node:test";
 
 describe("Checker -- StringOf", () => {
     it("should check simple stringof", function () {
-        //checkTestFunctionInFile('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return ""_Foo; }');
+        checkTestFunctionInFile('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return ""_Foo; }');
         checkTestFunctionInFile('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "123"_Foo; }');
     });
 
-    it.skip("should check simple stringof fails", function () {
-        checkTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "a"_Foo; }', "err1");
-        checkTestFunctionInFileError('validator Foo = /[0-9]+/; function main(): StringOf<Foo> { return ""_Foo; }', "err2");
-        checkTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "a🌵c"_Foo; }', "err3");
+    it("should check simple stringof fails", function () {
+        checkTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "a"_Foo; }', "Literal value does not match regex validator Main::Foo");
+        checkTestFunctionInFileError('validator Foo = /[0-9]+/; function main(): StringOf<Foo> { return ""_Foo; }', "errLiteral value does not match regex validator Main::Foo2");
+        checkTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "a🌵c"_Foo; }', "Literal value does not match regex validator Main::Foo");
     });
 
-    it.skip("should fail mismatch regex", function () {
+    it("should fail mismatch regex", function () {
         checkTestFunctionInFileError('validator Foo = /[0-9]*/c; function main(): StringOf<Foo> { return "123"_Foo; }', "Template argument T is not a subtype of RegexValidator");
     });
 
-    it.skip("should fail missing typename", function () {
+    it("should fail missing typename", function () {
         checkTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "123"; }', "Expected a return value of type StringOf<Foo> but got String");
     });
 });
@@ -30,16 +30,16 @@ describe("Checker -- CStringOf", () => {
         checkTestFunctionInFile("validator Foo = /[0-9]*/c; function main(): CStringOf<Foo> { return '123'_Foo; }");
     });
 
-    it.skip("should check simple cstringof fails", function () {
-        checkTestFunctionInFileError("validator Foo = /[0-9]+/c; function main(): CStringOf<Foo> { return ''_Foo; }", "err7");
-        checkTestFunctionInFileError("validator Foo = /[0-9]*/c; function main(): CStringOf<Foo> { return 'a'_Foo; }", "err8");
+    it("should check simple cstringof fails", function () {
+        checkTestFunctionInFileError("validator Foo = /[0-9]+/c; function main(): CStringOf<Foo> { return ''_Foo; }", "Literal value does not match regex validator Main::Foo");
+        checkTestFunctionInFileError("validator Foo = /[0-9]*/c; function main(): CStringOf<Foo> { return 'a'_Foo; }", "Literal value does not match regex validator Main::Foo");
     });
 
-    it.skip("should fail mismatch regex", function () {
+    it("should fail mismatch regex", function () {
         checkTestFunctionInFileError("validator Foo = /[0-9]*/; function main(): CStringOf<Foo> { return '123'_Foo; }", "Template argument T is not a subtype of CRegexValidator");
     });
 
-    it.skip("should fail missing typename", function () {
+    it("should fail missing typename", function () {
         checkTestFunctionInFileError("validator Foo = /[0-9]*/c; function main(): CStringOf<Foo> { return '123'; }", "Expected a return value of type CStringOf<Foo> but got CString");
     });
 });

--- a/test/typecheck/literals/stringof.test.js
+++ b/test/typecheck/literals/stringof.test.js
@@ -5,21 +5,21 @@ import { describe, it } from "node:test";
 
 describe("Checker -- StringOf", () => {
     it("should check simple stringof", function () {
-        checkTestFunctionInFile('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return ""_Foo; }');
+        //checkTestFunctionInFile('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return ""_Foo; }');
         checkTestFunctionInFile('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "123"_Foo; }');
     });
 
-    it("should check simple stringof fails", function () {
+    it.skip("should check simple stringof fails", function () {
         checkTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "a"_Foo; }', "err1");
         checkTestFunctionInFileError('validator Foo = /[0-9]+/; function main(): StringOf<Foo> { return ""_Foo; }', "err2");
         checkTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "a🌵c"_Foo; }', "err3");
     });
 
-    it("should fail mismatch regex", function () {
+    it.skip("should fail mismatch regex", function () {
         checkTestFunctionInFileError('validator Foo = /[0-9]*/c; function main(): StringOf<Foo> { return "123"_Foo; }', "Template argument T is not a subtype of RegexValidator");
     });
 
-    it("should fail missing typename", function () {
+    it.skip("should fail missing typename", function () {
         checkTestFunctionInFileError('validator Foo = /[0-9]*/; function main(): StringOf<Foo> { return "123"; }', "Expected a return value of type StringOf<Foo> but got String");
     });
 });
@@ -30,16 +30,16 @@ describe("Checker -- CStringOf", () => {
         checkTestFunctionInFile("validator Foo = /[0-9]*/c; function main(): CStringOf<Foo> { return '123'_Foo; }");
     });
 
-    it("should check simple cstringof fails", function () {
+    it.skip("should check simple cstringof fails", function () {
         checkTestFunctionInFileError("validator Foo = /[0-9]+/c; function main(): CStringOf<Foo> { return ''_Foo; }", "err7");
         checkTestFunctionInFileError("validator Foo = /[0-9]*/c; function main(): CStringOf<Foo> { return 'a'_Foo; }", "err8");
     });
 
-    it("should fail mismatch regex", function () {
+    it.skip("should fail mismatch regex", function () {
         checkTestFunctionInFileError("validator Foo = /[0-9]*/; function main(): CStringOf<Foo> { return '123'_Foo; }", "Template argument T is not a subtype of CRegexValidator");
     });
 
-    it("should fail missing typename", function () {
+    it.skip("should fail missing typename", function () {
         checkTestFunctionInFileError("validator Foo = /[0-9]*/c; function main(): CStringOf<Foo> { return '123'; }", "Expected a return value of type CStringOf<Foo> but got CString");
     });
 });

--- a/test/typecheck/typecheck_nf.ts
+++ b/test/typecheck/typecheck_nf.ts
@@ -6,7 +6,7 @@ import { Parser } from '../../src/frontend/parser.js';
 
 import assert from "node:assert";
 
-function loadFunction(ff: string): Assembly | string {
+function loadContents(ff: string): Assembly | string {
     const src = workflowLoadCoreSrc();
     if(src === undefined) {
         return "**ERROR**";
@@ -22,9 +22,13 @@ function generateExpFunctionContents(exp: string, type: string): string {
     return `declare namespace Main; function main(): ${type} { return ${exp}; }`;
 }
 
+function generateFileContents(contents: string): string {
+    return `declare namespace Main; ${contents}`;
+}
+
 function checkTestExp(exp: string, type: string) {
     const ff = generateExpFunctionContents(exp, type);
-    const assembly = loadFunction(ff);
+    const assembly = loadContents(ff);
 
     if(typeof(assembly) === "string") {
         assert.fail(assembly);
@@ -38,7 +42,7 @@ function checkTestExp(exp: string, type: string) {
 
 function checkTestExpError(exp: string, type: string, msg: string) {
     const ff = generateExpFunctionContents(exp, type);
-    const assembly = loadFunction(ff);
+    const assembly = loadContents(ff);
 
     if(typeof(assembly) === "string") {
         assert.fail(assembly);
@@ -53,7 +57,7 @@ function generateFunctionContents(ff: string): string {
 }
 
 function checkTestFunction(ff: string) {
-    const assembly = loadFunction(generateFunctionContents(ff));
+    const assembly = loadContents(generateFunctionContents(ff));
 
     if(typeof(assembly) === "string") {
         assert.fail(assembly);
@@ -66,7 +70,32 @@ function checkTestFunction(ff: string) {
 }
 
 function checkTestFunctionError(ff: string, msg: string) {
-    const assembly = loadFunction(generateFunctionContents(ff));
+    const assembly = loadContents(generateFunctionContents(ff));
+
+    if(typeof(assembly) === "string") {
+        assert.fail(assembly);
+    }
+
+    const errors = TypeChecker.checkAssembly(assembly);
+    assert.equal(errors[0].msg, msg);
+}
+
+
+function checkTestFunctionInFile(code: string) {
+    const assembly = loadContents(generateFileContents(code));
+
+    if(typeof(assembly) === "string") {
+        assert.fail(assembly);
+    }
+
+    const errors = TypeChecker.checkAssembly(assembly);
+    if(errors.length > 0) {
+        assert.fail(errors.map(e => e.msg).join("\n"));
+    }
+}
+
+function checkTestFunctionInFileError(code: string, msg: string) {
+    const assembly = loadContents(generateFileContents(code));
 
     if(typeof(assembly) === "string") {
         assert.fail(assembly);
@@ -78,5 +107,6 @@ function checkTestFunctionError(ff: string, msg: string) {
 
 export {
     checkTestExp, checkTestExpError,
-    checkTestFunction, checkTestFunctionError
+    checkTestFunction, checkTestFunctionError,
+    checkTestFunctionInFile, checkTestFunctionInFileError
 };


### PR DESCRIPTION
Parser and checker support for StringOf and CStringOf literals + validator declarations.

Can now write code like the following:
```
validator NumberRE = /[0-9]+/; 

function fok(): StringOf<NumberRE> { 
    return "123"_NumberRE; //ok validates with regex at compile time
}

function ferr(): StringOf<NumberRE> { 
    return ""_NumberRE; //fails regex => compiler error 
}
```

The Regex language that can be used for these validators is the [BREX Structured Text Processing format](https://github.com/BosqueLanguage/BREX).