### PR TITLE
Enforce Scope imports and Round-trip Namespace Scoping

### DIFF
--- a/src/frontend/assembly.ts
+++ b/src/frontend/assembly.ts
@@ -674,6 +674,48 @@ class TypedeclTypeDecl extends AbstractEntityTypeDecl {
     }
 }
 
+class RegexValidatorTypeDecl extends AbstractEntityTypeDecl {
+    readonly regex: string;
+
+    constructor(file: string, sinfo: SourceInfo, attributes: DeclarationAttibute[], ns: FullyQualifiedNamespace, name: string, regex: string) {
+        super(file, sinfo, attributes, ns, name, AdditionalTypeDeclTag.Std);
+
+        this.regex = regex;
+    }
+
+    emit(fmt: CodeFormatter): string {
+        return fmt.indent(`${this.emitAttributes()}validator ${this.name} = ${this.regex};`);
+    }
+}
+
+class CRegexValidatorTypeDecl extends AbstractEntityTypeDecl {
+    readonly regex: string;
+
+    constructor(file: string, sinfo: SourceInfo, attributes: DeclarationAttibute[], ns: FullyQualifiedNamespace, name: string, regex: string) {
+        super(file, sinfo, attributes, ns, name, AdditionalTypeDeclTag.Std);
+
+        this.regex = regex;
+    }
+
+    emit(fmt: CodeFormatter): string {
+        return fmt.indent(`${this.emitAttributes()}validator ${this.name} = ${this.regex};`);
+    }
+}
+
+class PathValidatorTypeDecl extends AbstractEntityTypeDecl {
+    readonly pathglob: string;
+
+    constructor(file: string, sinfo: SourceInfo, attributes: DeclarationAttibute[], ns: FullyQualifiedNamespace, name: string, pathglob: string) {
+        super(file, sinfo, attributes, ns, name, AdditionalTypeDeclTag.Std);
+
+        this.pathglob = pathglob;
+    }
+
+    emit(fmt: CodeFormatter): string {
+        return fmt.indent(`${this.emitAttributes()}validator ${this.name} = ${this.pathglob};`);
+    }
+}
+
 abstract class InternalEntityTypeDecl extends AbstractEntityTypeDecl {
     constructor(file: string, sinfo: SourceInfo, attributes: DeclarationAttibute[], name: string) {
         super(file, sinfo, attributes, new FullyQualifiedNamespace(["Core"]) , name, AdditionalTypeDeclTag.Std);
@@ -693,48 +735,6 @@ class PrimitiveEntityTypeDecl extends InternalEntityTypeDecl {
         fmt.indentPop();
 
         return attrs + "entity " + this.name + this.emitProvides() + " {\n" + this.joinBodyGroups(bg) + fmt.indent("\n}");
-    }
-}
-
-class RegexValidatorTypeDecl extends InternalEntityTypeDecl {
-    readonly regex: string;
-
-    constructor(file: string, sinfo: SourceInfo, attributes: DeclarationAttibute[], name: string, regex: string) {
-        super(file, sinfo, attributes, name);
-
-        this.regex = regex;
-    }
-
-    emit(fmt: CodeFormatter): string {
-        return fmt.indent(`${this.emitAttributes()}validator ${this.name} = ${this.regex};`);
-    }
-}
-
-class CRegexValidatorTypeDecl extends InternalEntityTypeDecl {
-    readonly regex: string;
-
-    constructor(file: string, sinfo: SourceInfo, attributes: DeclarationAttibute[], name: string, regex: string) {
-        super(file, sinfo, attributes, name);
-
-        this.regex = regex;
-    }
-
-    emit(fmt: CodeFormatter): string {
-        return fmt.indent(`${this.emitAttributes()}validator ${this.name} = ${this.regex};`);
-    }
-}
-
-class PathValidatorTypeDecl extends InternalEntityTypeDecl {
-    readonly pathglob: string;
-
-    constructor(file: string, sinfo: SourceInfo, attributes: DeclarationAttibute[], name: string, pathglob: string) {
-        super(file, sinfo, attributes, name);
-
-        this.pathglob = pathglob;
-    }
-
-    emit(fmt: CodeFormatter): string {
-        return fmt.indent(`${this.emitAttributes()}validator ${this.name} = ${this.pathglob};`);
     }
 }
 

--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -69,17 +69,17 @@ class TypeChecker {
 
     private getStringOfType(oftype: TypeSignature): TypeSignature {
         const stringofdecl = this.relations.assembly.getCoreNamespace().typedecls.find((td) => td.name === "StringOf") as StringOfTypeDecl;
-        return new NominalTypeSignature(oftype.sinfo, stringofdecl, [oftype]);
+        return new NominalTypeSignature(oftype.sinfo, undefined, stringofdecl, [oftype]);
     }
 
     private getCStringOfType(oftype: TypeSignature): TypeSignature {
         const cstringofdecl = this.relations.assembly.getCoreNamespace().typedecls.find((td) => td.name === "CStringOf") as CStringOfTypeDecl;
-        return new NominalTypeSignature(oftype.sinfo, cstringofdecl, [oftype]);
+        return new NominalTypeSignature(oftype.sinfo, undefined, cstringofdecl, [oftype]);
     }
 
     private getEventListOf(oftype: TypeSignature): TypeSignature {
         const eventlistdecl = this.relations.assembly.getCoreNamespace().typedecls.find((td) => td.name === "EventList") as EventListTypeDecl;
-        return new NominalTypeSignature(oftype.sinfo, eventlistdecl, [oftype]);
+        return new NominalTypeSignature(oftype.sinfo, undefined, eventlistdecl, [oftype]);
     }
 
     private isBooleanType(t: TypeSignature): boolean {
@@ -929,7 +929,7 @@ class TypeChecker {
         }
 
         if(exp.rop === "some") {
-            return exp.setType(new NominalTypeSignature(exp.sinfo, corens.typedecls.find((td) => td.name === "Some") as SomeTypeDecl, [etype]));
+            return exp.setType(new NominalTypeSignature(exp.sinfo, undefined, corens.typedecls.find((td) => td.name === "Some") as SomeTypeDecl, [etype]));
         }
         else {
             this.reportError(exp.sinfo, "Cannot infer type for special Ok/Err constructor");
@@ -3655,7 +3655,7 @@ class TypeChecker {
         this.checkProvides(tdecl.provides);
  
         //Make sure that any provides types are not adding on fields, consts, or functions
-        const etype = new NominalTypeSignature(tdecl.sinfo, tdecl, []);
+        const etype = new NominalTypeSignature(tdecl.sinfo, undefined, tdecl, []);
         const providesdecls = this.relations.resolveTransitiveProvidesDecls(etype, this.constraints);
         for(let i = 0; i < providesdecls.length; ++i) {
             const pdecl = providesdecls[i];
@@ -3670,7 +3670,7 @@ class TypeChecker {
         this.checkError(tdecl.sinfo, tdecl.consts.length !== 0, "Enums cannot have consts");
         this.checkError(tdecl.sinfo, tdecl.functions.length !== 0, "Enums cannot have functions");
 
-        const rcvr = new NominalTypeSignature(tdecl.sinfo, tdecl, []);
+        const rcvr = new NominalTypeSignature(tdecl.sinfo, undefined, tdecl, []);
         this.checkMethodDecls(tdecl, rcvr, tdecl.methods);
 
         this.checkAbstractNominalTypeDeclVCallAndInheritance(tdecl, [], true);
@@ -3694,7 +3694,7 @@ class TypeChecker {
         this.checkProvides(tdecl.provides);
 
         //Make sure that any provides types are not adding on fields!
-        const rcvr = new NominalTypeSignature(tdecl.sinfo, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
+        const rcvr = new NominalTypeSignature(tdecl.sinfo, undefined, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
         const providesdecls = this.relations.resolveTransitiveProvidesDecls(rcvr, this.constraints);
         for(let i = 0; i < providesdecls.length; ++i) {
             const pdecl = providesdecls[i];
@@ -3724,7 +3724,7 @@ class TypeChecker {
     }
 
     private checkInteralSimpleTypeDeclHelper(ns: NamespaceDeclaration, tdecl: InternalEntityTypeDecl, isentity: boolean) {
-        const rcvr = new NominalTypeSignature(tdecl.sinfo, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
+        const rcvr = new NominalTypeSignature(tdecl.sinfo, undefined, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
         this.checkAbstractNominalTypeDeclHelper([], rcvr, tdecl, undefined, isentity);
     }
 
@@ -3828,7 +3828,7 @@ class TypeChecker {
 
     private checkEntityTypeDecl(ns: NamespaceDeclaration, tdecl: EntityTypeDecl) {
         this.file = tdecl.file;
-        const rcvr = new NominalTypeSignature(tdecl.sinfo, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
+        const rcvr = new NominalTypeSignature(tdecl.sinfo, undefined, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
         const bnames = this.relations.generateAllFieldBNamesInfo(rcvr, this.constraints, tdecl.fields);
 
         this.checkAbstractNominalTypeDeclHelper(bnames, rcvr, tdecl, tdecl.fields, true);
@@ -3887,7 +3887,7 @@ class TypeChecker {
 
     private checkConceptTypeDecl(ns: NamespaceDeclaration, tdecl: ConceptTypeDecl) {
         this.file = tdecl.file;
-        const rcvr = new NominalTypeSignature(tdecl.sinfo, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
+        const rcvr = new NominalTypeSignature(tdecl.sinfo, undefined, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
         const bnames = this.relations.generateAllFieldBNamesInfo(rcvr, this.constraints, tdecl.fields);
 
         this.checkAbstractNominalTypeDeclHelper(bnames, rcvr, tdecl, tdecl.fields, false);
@@ -3895,7 +3895,7 @@ class TypeChecker {
     }
 
     private checkDatatypeMemberEntityTypeDecl(ns: NamespaceDeclaration, parent: DatatypeTypeDecl, tdecl: DatatypeMemberEntityTypeDecl) {
-        const rcvr = new NominalTypeSignature(tdecl.sinfo, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
+        const rcvr = new NominalTypeSignature(tdecl.sinfo, undefined, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
         const bnames = this.relations.generateAllFieldBNamesInfo(rcvr, this.constraints, tdecl.fields);
 
         this.checkAbstractNominalTypeDeclHelper(bnames, rcvr, tdecl, tdecl.fields, true);
@@ -3903,7 +3903,7 @@ class TypeChecker {
 
     private checkDatatypeTypeDecl(ns: NamespaceDeclaration, tdecl: DatatypeTypeDecl) {
         this.file = tdecl.file;
-        const rcvr = new NominalTypeSignature(tdecl.sinfo, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
+        const rcvr = new NominalTypeSignature(tdecl.sinfo, undefined, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
         const bnames = this.relations.generateAllFieldBNamesInfo(rcvr, this.constraints, tdecl.fields);
 
         this.checkAbstractNominalTypeDeclHelper(bnames, rcvr, tdecl, tdecl.fields, true);
@@ -3958,7 +3958,7 @@ class TypeChecker {
             this.constraints.pushConstraintScope(tdecl.terms);
         }
 
-        const rcvr = new NominalTypeSignature(tdecl.sinfo, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
+        const rcvr = new NominalTypeSignature(tdecl.sinfo, undefined, tdecl, tdecl.terms.map((tt) => new TemplateTypeSignature(tdecl.sinfo, tt.name)));
         const bnames = tdecl.fields.map((f) => { return {name: f.name, type: f.declaredType}; });
 
         //make sure all of the invariants on this typecheck
@@ -4202,7 +4202,7 @@ class TypeChecker {
         const tdecl = ccore.typedecls.find((td) => td.name === name);
         assert(tdecl !== undefined, "Failed to find well known type");
 
-        wellknownTypes.set(name, new NominalTypeSignature(tdecl.sinfo, tdecl, []));
+        wellknownTypes.set(name, new NominalTypeSignature(tdecl.sinfo, undefined, tdecl, []));
     }
 
     static checkAssembly(assembly: Assembly): TypeError[] {

--- a/src/frontend/checker_relations.ts
+++ b/src/frontend/checker_relations.ts
@@ -61,7 +61,7 @@ class TypeCheckerRelations {
             return [this.wellknowntypes.get("PathValidator") as NominalTypeSignature];
         }
         else if(t.decl instanceof DatatypeMemberEntityTypeDecl) {
-            return [new NominalTypeSignature(t.sinfo, t.decl.parentTypeDecl, t.alltermargs)];
+            return [new NominalTypeSignature(t.sinfo, t.altns, t.decl.parentTypeDecl, t.alltermargs)];
         }
         else if(t.decl instanceof TypedeclTypeDecl) {
             let provides: NominalTypeSignature[] = [this.wellknowntypes.get("Any") as NominalTypeSignature];
@@ -126,7 +126,7 @@ class TypeCheckerRelations {
             res = rr === undefined ? tsig : rr.tconstraint;
         }
         else if(tsig instanceof NominalTypeSignature) {
-            res = new NominalTypeSignature(tsig.sinfo, tsig.decl, tsig.alltermargs.map((tt) => this.normalizeTypeSignatureHelper(tt, tconstrain, alltemplates, alltemplates)));
+            res = new NominalTypeSignature(tsig.sinfo, tsig.altns, tsig.decl, tsig.alltermargs.map((tt) => this.normalizeTypeSignatureHelper(tt, tconstrain, alltemplates, alltemplates)));
         }
         else if(tsig instanceof EListTypeSignature) {
             res = new EListTypeSignature(tsig.sinfo, tsig.entries.map((tt) => this.normalizeTypeSignatureHelper(tt, tconstrain, alltemplates, alltemplates)));
@@ -352,14 +352,14 @@ class TypeCheckerRelations {
                 const hasnone = ptl.some((t) => t.decl.name === "None");
                 const some = ptl.find((t) => t.decl instanceof SomeTypeDecl);
                 if(hasnone && some !== undefined) {
-                    return new NominalTypeSignature(sinfo, corens.typedecls.find((tdecl) => tdecl.name === "Option") as TypedeclTypeDecl, some.alltermargs);
+                    return new NominalTypeSignature(sinfo, undefined, corens.typedecls.find((tdecl) => tdecl.name === "Option") as TypedeclTypeDecl, some.alltermargs);
                 }
 
                 //check for special case of Ok+Err -> Result
                 const okopt = ptl.find((t) => t.decl instanceof OkTypeDecl);
                 const erropt = ptl.find((t) => t.decl instanceof ErrTypeDecl);
                 if(okopt && erropt && this.areSameTypeSignatureLists(okopt.alltermargs, erropt.alltermargs, tconstrain)) {
-                    return new NominalTypeSignature(sinfo, corens.typedecls.find((tdecl) => tdecl.name === "Result") as TypedeclTypeDecl, okopt.alltermargs);
+                    return new NominalTypeSignature(sinfo, undefined, corens.typedecls.find((tdecl) => tdecl.name === "Result") as TypedeclTypeDecl, okopt.alltermargs);
                 }
             }
 
@@ -367,7 +367,7 @@ class TypeCheckerRelations {
                 //check for complete set of datatype members
                 const dptl = ttl as NominalTypeSignature[];
 
-                const pptype = new NominalTypeSignature(dptl[0].sinfo, (dptl[0].decl as DatatypeMemberEntityTypeDecl).parentTypeDecl, dptl[0].alltermargs);
+                const pptype = new NominalTypeSignature(dptl[0].sinfo, dptl[0].altns, (dptl[0].decl as DatatypeMemberEntityTypeDecl).parentTypeDecl, dptl[0].alltermargs);
                 const allsameparents = dptl.every((t) => this.isSubtypeOf(t, pptype, tconstrain));
             
                 if(allsameparents) {
@@ -503,18 +503,18 @@ class TypeCheckerRelations {
             const corens = this.assembly.getCoreNamespace();
 
             if(t.decl instanceof OptionTypeDecl) {
-                const some = new NominalTypeSignature(t.sinfo, corens.typedecls.find((tdecl) => tdecl.name === "Some") as SomeTypeDecl, t.alltermargs);
+                const some = new NominalTypeSignature(t.sinfo, undefined, corens.typedecls.find((tdecl) => tdecl.name === "Some") as SomeTypeDecl, t.alltermargs);
                 return [this.wellknowntypes.get("None") as TypeSignature, some];
             }
             else if(t.decl instanceof ResultTypeDecl) {
                 const tresult = corens.typedecls.find((tdecl) => tdecl.name === "Result") as ResultTypeDecl;
-                const tok = new NominalTypeSignature(t.sinfo, tresult.getOkType(), t.alltermargs);
-                const terr = new NominalTypeSignature(t.sinfo, tresult.getErrType(), t.alltermargs);
+                const tok = new NominalTypeSignature(t.sinfo, undefined, tresult.getOkType(), t.alltermargs);
+                const terr = new NominalTypeSignature(t.sinfo, undefined, tresult.getErrType(), t.alltermargs);
 
                 return [tok, terr];
             }
             else if(t.decl instanceof DatatypeTypeDecl) {
-                return t.decl.associatedMemberEntityDecls.map((mem) => new NominalTypeSignature(mem.sinfo, mem, t.alltermargs));
+                return t.decl.associatedMemberEntityDecls.map((mem) => new NominalTypeSignature(mem.sinfo, t.altns, mem, t.alltermargs));
             }
             else {
                 return [t];

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -1568,8 +1568,8 @@ class Parser {
             return ach !== undefined ? {altScope: undefined, nsScope: ach.nsScope, typeTokens: ach.typeTokens} : undefined;
         }
         else if(this.env.currentNamespace.declaredNames.has(nsroot)) {
-            const ach = this.parseIdentifierAccessChainHelper(false, this.env.currentNamespace, [nsroot]);
-            return ach !== undefined ? {altScope: undefined, nsScope: ach.nsScope, typeTokens: ach.typeTokens} : undefined;
+            const ach = this.parseIdentifierAccessChainHelper(false, this.env.currentNamespace, []);
+            return ach !== undefined ? {altScope: ach.scopeTokens, nsScope: ach.nsScope, typeTokens: ach.typeTokens} : undefined;
         }
         else if(this.env.currentNamespace.usings.find((nsuse) => nsuse.asns === nsroot) !== undefined) {
             const uns = (this.env.currentNamespace.usings.find((nsuse) => nsuse.asns === nsroot) as NamespaceUsing).fromns.ns;

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -1542,26 +1542,34 @@ class Parser {
         }
     }
 
-    private parseIdentifierAccessChain(): {nsScope: NamespaceDeclaration, typeTokens: {tname: string, tterms: TypeSignature[]}[]} | undefined {
+    private parseIdentifierAccessChain(): {altScope: string[] | undefined, nsScope: NamespaceDeclaration, typeTokens: {tname: string, tterms: TypeSignature[]}[]} | undefined {
         assert(isParsePhase_Enabled(this.currentPhase, ParsePhase_CompleteParsing));
 
         const nsroot = this.peekTokenData();
+        if(!/^[A-Z][_a-zA-Z0-9]+/.test(nsroot)) {
+            return undefined; //not a valid namespace or type name
+        }
 
         const coredecl = this.env.assembly.getCoreNamespace();
         if (nsroot === "Core") {
             this.consumeToken();
-            if(this.testToken(SYM_coloncolon)) {
-                return this.parseIdentifierAccessChainHelper(true, coredecl, ["Core"]);
-            }
-            else {
-                return {nsScope: coredecl, typeTokens: []};
-            }
+            
+            const ach = this.parseIdentifierAccessChainHelper(this.testToken(SYM_coloncolon), coredecl, ["Core"]);
+            return ach !== undefined ? {altScope: undefined, nsScope: ach.nsScope, typeTokens: ach.typeTokens} : undefined;
         }
         else if(coredecl.declaredNames.has(nsroot)) {
-            return this.parseIdentifierAccessChainHelper(false, coredecl, ["Core"]);
+            const ach = this.parseIdentifierAccessChainHelper(false, coredecl, ["Core"]);
+            return ach !== undefined ? {altScope: undefined, nsScope: ach.nsScope, typeTokens: ach.typeTokens} : undefined;
+        }
+        else if(this.env.currentNamespace.name === nsroot) {
+            this.consumeToken();
+            
+            const ach = this.parseIdentifierAccessChainHelper(this.testToken(SYM_coloncolon), this.env.currentNamespace, [nsroot]);
+            return ach !== undefined ? {altScope: undefined, nsScope: ach.nsScope, typeTokens: ach.typeTokens} : undefined;
         }
         else if(this.env.currentNamespace.declaredNames.has(nsroot)) {
-            return this.parseIdentifierAccessChainHelper(false, this.env.currentNamespace, [nsroot]);
+            const ach = this.parseIdentifierAccessChainHelper(false, this.env.currentNamespace, [nsroot]);
+            return ach !== undefined ? {altScope: undefined, nsScope: ach.nsScope, typeTokens: ach.typeTokens} : undefined;
         }
         else if(this.env.currentNamespace.usings.find((nsuse) => nsuse.asns === nsroot) !== undefined) {
             const uns = (this.env.currentNamespace.usings.find((nsuse) => nsuse.asns === nsroot) as NamespaceUsing).fromns.ns;
@@ -1577,28 +1585,35 @@ class Parser {
             if(rrns === undefined) {
                 return undefined;
             }
-
-            if(this.testToken(SYM_coloncolon)) {
-                return this.parseIdentifierAccessChainHelper(true, rrns, [nsroot]);
-            }
-            else {
-                return {nsScope: rrns, typeTokens: []};
-            }
+                
+            const ach = this.parseIdentifierAccessChainHelper(this.testToken(SYM_coloncolon), rrns, [nsroot]);
+            return ach !== undefined ? {altScope: ach.scopeTokens, nsScope: ach.nsScope, typeTokens: ach.typeTokens} : undefined;
         }
         else {
             this.consumeToken();
 
-            const tlns = this.env.assembly.getToplevelNamespace(nsroot);
-            if(tlns === undefined) {
-                return undefined;
-            }
-            else {
-                if(this.testToken(SYM_coloncolon)) {
-                    return this.parseIdentifierAccessChainHelper(true, tlns, [nsroot]);
+            const hasimport = this.env.currentNamespace.usings.find((nsuse) => nsuse.fromns.ns[0] === nsroot) !== undefined
+            if(hasimport) {
+                const tlns = this.env.assembly.getToplevelNamespace(nsroot);
+                if(tlns === undefined) {
+                    return undefined;
                 }
                 else {
-                    return {nsScope: tlns, typeTokens: []};
+                    const ach = this.parseIdentifierAccessChainHelper(this.testToken(SYM_coloncolon), tlns, [nsroot]);
+                    return ach !== undefined ? {altScope: undefined, nsScope: ach.nsScope, typeTokens: ach.typeTokens} : undefined;
                 }
+            }
+            else {
+                //hmm missing import -- see if it exists but not imported or just not there at all
+                const tlns = this.env.assembly.getToplevelNamespace(nsroot);
+                if(tlns === undefined) {
+                    this.recordErrorGeneral(this.peekToken().getSourceInfo(), `Unknown namespace ${nsroot}`);
+                }
+                else {
+                    this.recordErrorGeneral(this.peekToken().getSourceInfo(), `Missing import for namespace ${nsroot}`);
+                }
+
+                return undefined;
             }
         }
     }
@@ -2414,7 +2429,7 @@ class Parser {
         let ttype = tbase
         while(this.testAndConsumeTokenIf(SYM_question)) {
             const odecl = this.env.assembly.getCoreNamespace().typedecls.find((td) => td.name === "Option") as OptionTypeDecl;
-            ttype = new NominalTypeSignature(ttype.sinfo, odecl, [ttype]);
+            ttype = new NominalTypeSignature(ttype.sinfo, undefined, odecl, [ttype]);
         }
         return ttype;
     }
@@ -2452,7 +2467,8 @@ class Parser {
                 return new ErrorTypeSignature(sinfo, nsr.nsScope.fullnamespace);
             }
             else {
-                return new NominalTypeSignature(sinfo, resolved, nsr.typeTokens.flatMap((te) => te.tterms));
+                const altns = nsr.altScope !== undefined ? new FullyQualifiedNamespace(nsr.altScope) : undefined;
+                return new NominalTypeSignature(sinfo, altns, resolved, nsr.typeTokens.flatMap((te) => te.tterms));
             }
         }
     }
@@ -2760,11 +2776,12 @@ class Parser {
         }
     }
 
-    private parseTypeScopedFirstExpression(access: {nsScope: NamespaceDeclaration, typeTokens: {tname: string, tterms: TypeSignature[]}[]}): Expression {
+    private parseTypeScopedFirstExpression(access: {altScope: string[] | undefined, nsScope: NamespaceDeclaration, typeTokens: {tname: string, tterms: TypeSignature[]}[]}): Expression {
         const sinfo = this.peekToken().getSourceInfo();
 
+        const altns = access.altScope !== undefined ? new FullyQualifiedNamespace(access.altScope) : undefined;
         const resolved = this.normalizeTypeNameChain(sinfo, access.nsScope, access.typeTokens);
-        const tsig = (resolved === undefined)  ? new ErrorTypeSignature(sinfo, access.nsScope.fullnamespace) : new NominalTypeSignature(sinfo, resolved, access.typeTokens.flatMap((te) => te.tterms));
+        const tsig = (resolved === undefined)  ? new ErrorTypeSignature(sinfo, access.nsScope.fullnamespace) : new NominalTypeSignature(sinfo, altns, resolved, access.typeTokens.flatMap((te) => te.tterms));
         const nnsig = this.parseNoneableOfType(tsig);
 
         if(this.testToken(SYM_hash)) {
@@ -4526,6 +4543,7 @@ class Parser {
                     }
                 }
                 else {
+                    this.consumeToken();
                     this.ensureToken(TokenStrings.IdentifierName, "namespace import");
                     const asns = this.parseIdentifierAsNamespaceOrTypeName();
 
@@ -4765,7 +4783,7 @@ class Parser {
             const corens = this.env.assembly.getCoreNamespace();
             const otype = corens.typedecls.find((td) => td.name === "Object") as AbstractNominalTypeDecl;
 
-            provides.push(new NominalTypeSignature(sinfo, otype, []));
+            provides.push(new NominalTypeSignature(sinfo, undefined, otype, []));
         }
 
         return provides;
@@ -5357,11 +5375,11 @@ class Parser {
 
                 //parser just reads the string, we will need to validate it later
                 if(vregex.endsWith("/")) {
-                    const vdecl = new RegexValidatorTypeDecl(this.env.currentFile, sinfo, attributes, iname, vregex);
+                    const vdecl = new RegexValidatorTypeDecl(this.env.currentFile, sinfo, attributes, this.env.currentNamespace.fullnamespace, iname, vregex);
                     this.env.currentNamespace.typedecls.push(vdecl);
                 }
                 else {
-                    const vdecl = new CRegexValidatorTypeDecl(this.env.currentFile, sinfo, attributes, iname, vregex);
+                    const vdecl = new CRegexValidatorTypeDecl(this.env.currentFile, sinfo, attributes, this.env.currentNamespace.fullnamespace, iname, vregex);
                     this.env.currentNamespace.typedecls.push(vdecl);
                 }
             }
@@ -5373,7 +5391,7 @@ class Parser {
                 }
 
                 //parser just reads the string, we will need to validate it later
-                const vdecl = new PathValidatorTypeDecl(this.env.currentFile, sinfo, attributes, iname, pthglb);
+                const vdecl = new PathValidatorTypeDecl(this.env.currentFile, sinfo, attributes, this.env.currentNamespace.fullnamespace, iname, pthglb);
                 this.env.currentNamespace.typedecls.push(vdecl);
             }
             else {
@@ -5844,7 +5862,7 @@ class Parser {
         const tdecl = ccore.typedecls.find((td) => td.name === name);
         assert(tdecl !== undefined, "Failed to find well known type");
 
-        this.wellknownTypes.set(name, new NominalTypeSignature(tdecl.sinfo, tdecl, []));
+        this.wellknownTypes.set(name, new NominalTypeSignature(tdecl.sinfo, undefined, tdecl, []));
     }
 
     private static _s_lcre = /^%%[^\n]*/y;

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -6009,7 +6009,24 @@ class Parser {
         }
 
         const ns = assembly.getToplevelNamespace("Main") as NamespaceDeclaration;
-        const sffdecl = ns.functions.find((f) => f.name === "main");
+        const sffdecl = ns.functions.find((f) => f.name === fname);
+
+        return sffdecl !== undefined ? sffdecl.emit(new CodeFormatter()) : "**ERROR**";
+    }
+
+    static test_parseSFunctionInFilePlus(core: CodeFileInfo[], macrodefs: string[], ctxfiles: CodeFileInfo[], code: string, fname: string): string | ParserError[] {
+        let assembly = new Assembly();
+
+        let registeredNamespaces = new Set<string>();
+        const coreerrors = Parser.parsefiles(true, core, macrodefs, assembly, registeredNamespaces);
+        const ferrors = Parser.parsefiles(false, [...ctxfiles, {srcpath: "main.bsq", filename: "main.bsq", contents: code}], macrodefs, assembly, registeredNamespaces);
+        
+        if(coreerrors.length !== 0 || ferrors.length !== 0) {
+            return [...coreerrors, ...ferrors];
+        }
+
+        const ns = assembly.getToplevelNamespace("Main") as NamespaceDeclaration;
+        const sffdecl = ns.functions.find((f) => f.name === fname);
 
         return sffdecl !== undefined ? sffdecl.emit(new CodeFormatter()) : "**ERROR**";
     }

--- a/src/frontend/type.ts
+++ b/src/frontend/type.ts
@@ -168,8 +168,9 @@ class TemplateTypeSignature extends TypeSignature {
 class NominalTypeSignature extends TypeSignature {
     readonly decl: AbstractNominalTypeDecl;
     readonly alltermargs: TypeSignature[];
+    readonly altns: FullyQualifiedNamespace | undefined;
 
-    private static computeTKeyStr(decl: AbstractNominalTypeDecl, alltermargs: TypeSignature[]): string {
+    private static computeTKeyStr(altns: FullyQualifiedNamespace | undefined, decl: AbstractNominalTypeDecl, alltermargs: TypeSignature[]): string {
         const tscope = alltermargs.length !== 0 ? ("<" + alltermargs.map((tt) => tt.tkeystr).join(", ") + ">") : "";
         if(decl instanceof OptionTypeDecl) {
             const oftype = alltermargs[0].tkeystr;
@@ -192,15 +193,15 @@ class NominalTypeSignature extends TypeSignature {
                 nscope = decl.ns.ns.slice(1).join("::");
             }
             else {
-                nscope = decl.ns.ns.join("::");
+                nscope = altns !== undefined ? altns.ns.join("::") : decl.ns.ns.join("::");
             }
 
             return nscope + (nscope !== "" ? "::" : "") + decl.name + tscope;
         }
     }
 
-    constructor(sinfo: SourceInfo, decl: AbstractNominalTypeDecl, alltermargs: TypeSignature[]) {
-        super(sinfo, NominalTypeSignature.computeTKeyStr(decl, alltermargs));
+    constructor(sinfo: SourceInfo, altns: FullyQualifiedNamespace | undefined, decl: AbstractNominalTypeDecl, alltermargs: TypeSignature[]) {
+        super(sinfo, NominalTypeSignature.computeTKeyStr(altns, decl, alltermargs));
         this.decl = decl;
         this.alltermargs = alltermargs;
     }
@@ -208,7 +209,7 @@ class NominalTypeSignature extends TypeSignature {
     remapTemplateBindings(mapper: TemplateNameMapper): TypeSignature {
         const rtall = this.alltermargs.map((tt) => tt.remapTemplateBindings(mapper));
 
-        return new NominalTypeSignature(this.sinfo, this.decl, rtall);
+        return new NominalTypeSignature(this.sinfo, this.altns, this.decl, rtall);
     }
 }
 

--- a/src/frontend/type.ts
+++ b/src/frontend/type.ts
@@ -192,7 +192,7 @@ class NominalTypeSignature extends TypeSignature {
                 nscope = decl.ns.ns.slice(1).join("::");
             }
             else {
-                nscope = decl.ns.ns.join("::") + "::";
+                nscope = decl.ns.ns.join("::");
             }
 
             return nscope + (nscope !== "" ? "::" : "") + decl.name + tscope;

--- a/test/parser/access_exps/ns_scope.test.js
+++ b/test/parser/access_exps/ns_scope.test.js
@@ -1,0 +1,28 @@
+import { parseTestFunctionInFilePlus, parseTestFunctionInFilePlusError } from "../../../bin/test/parser/parse_nf.js";
+import { describe, it } from "node:test";
+
+const ctxcode = [
+    'declare namespace NSOther; validator V1RE = /("ab")"c"+/; entity Foo { }'
+];
+
+describe ("Parser -- access argument", () => {
+    it("should parse implicit access", function () {
+        parseTestFunctionInFilePlus("declare namespace Main; [FUNC]", 'function main(x: Int): Int { return x; }', undefined, ...ctxcode);  //Core is always ok
+        parseTestFunctionInFilePlus("declare namespace Main; entity Bar { } [FUNC]", 'function main(): Bar? { return none; }', 'function main(): Main::Bar? { return none; }', ...ctxcode);  //Implicit same namespace is ok
+        parseTestFunctionInFilePlus("declare namespace Main; entity Bar { } [FUNC]", 'function main(): Main::Bar? { return none; }', undefined, ...ctxcode);  //Explicit same namespace is ok
+    });
+
+    it("should parse imported access", function () {
+        parseTestFunctionInFilePlus("declare namespace Main { using NSOther; } [FUNC]", 'function main(): NSOther::Foo? { return none; }', undefined, ...ctxcode);  //Import no rename
+        parseTestFunctionInFilePlus("declare namespace Main { using NSOther as Other; } [FUNC]", 'function main(): Other::Foo? { return none; }', undefined, ...ctxcode);  //Import with rename
+        parseTestFunctionInFilePlus("declare namespace Main { using NSOther; } [FUNC]", 'function main(): StringOf<NSOther::V1RE> { return ""_NSOther::V1RE; }', undefined, ...ctxcode);  //Import validator
+    });
+
+    it("should fail undefined namespace", function () {
+        parseTestFunctionInFilePlusError('declare namespace Main; function main(): Other::Foo? { return none; }', "err1", ...ctxcode);  //NS does not exist
+    });
+
+    it("should fail not-imported namespace", function () {
+        parseTestFunctionInFilePlusError('declare namespace Main; function main(): Other::Foo? { return none; }', "err2", ...ctxcode);  //NS exists but not imported
+    });
+});

--- a/test/parser/access_exps/ns_scope.test.js
+++ b/test/parser/access_exps/ns_scope.test.js
@@ -8,7 +8,7 @@ const ctxcode = [
 describe ("Parser -- access argument", () => {
     it("should parse implicit access", function () {
         parseTestFunctionInFilePlus("declare namespace Main; [FUNC]", 'function main(x: Int): Int { return x; }', undefined, ...ctxcode);  //Core is always ok
-        parseTestFunctionInFilePlus("declare namespace Main; entity Bar { } [FUNC]", 'function main(): Bar? { return none; }', 'function main(): Main::Bar? { return none; }', ...ctxcode);  //Implicit same namespace is ok
+        parseTestFunctionInFilePlus("declare namespace Main; entity Bar { } [FUNC]", 'function main(): Bar? { return none; }', 'function main(): Bar? { return none; }', ...ctxcode);  //Implicit same namespace is ok
         parseTestFunctionInFilePlus("declare namespace Main; entity Bar { } [FUNC]", 'function main(): Main::Bar? { return none; }', undefined, ...ctxcode);  //Explicit same namespace is ok
     });
 

--- a/test/parser/access_exps/ns_scope.test.js
+++ b/test/parser/access_exps/ns_scope.test.js
@@ -19,10 +19,10 @@ describe ("Parser -- access argument", () => {
     });
 
     it("should fail undefined namespace", function () {
-        parseTestFunctionInFilePlusError('declare namespace Main; function main(): Other::Foo? { return none; }', "err1", ...ctxcode);  //NS does not exist
+        parseTestFunctionInFilePlusError('declare namespace Main; function main(): Other::Foo? { return none; }', "Unknown namespace Other", ...ctxcode);  //NS does not exist
     });
 
     it("should fail not-imported namespace", function () {
-        parseTestFunctionInFilePlusError('declare namespace Main; function main(): Other::Foo? { return none; }', "err2", ...ctxcode);  //NS exists but not imported
+        parseTestFunctionInFilePlusError('declare namespace Main; function main(): NSOther::Foo? { return none; }', "Missing import for namespace NSOther", ...ctxcode);  //NS exists but not imported
     });
 });

--- a/test/parser/parse_nf.ts
+++ b/test/parser/parse_nf.ts
@@ -27,6 +27,25 @@ function parseFunctionInFile(code: string): string {
     return wsnorm(Array.isArray(rr) ? rr[0].message : rr);
 }
 
+function parseFunctionInFilePlus(code: string, ctxcode: string[]): string {
+    const src = workflowLoadCoreSrc();
+    if(src === undefined) {
+        return "**ERROR**";
+    }
+
+    const ctxfiles = ctxcode.map((c, i) => {
+        return { 
+            srcpath: `/src/code_${i}.bsq`, 
+            filename: `code_${i}.bsq`, 
+            contents: c
+        };
+    });
+
+    const rr = Parser.test_parseSFunctionInFilePlus(src, ["EXEC_LIBS"], ctxfiles, code, "main");
+    return wsnorm(Array.isArray(rr) ? rr[0].message : rr);
+
+}
+
 function generateExpFunction(exp: string, type: string): string {
     return `function main(): ${type} { return ${exp}; }`;
 }
@@ -58,8 +77,17 @@ function parseTestFunctionInFileError(code: string, error: string) {
     assert.equal(parseFunctionInFile(code), error);
 }
 
+function parseTestFunctionInFilePlus(code: string, rff: string, eres: string | undefined, ...ctxcode: string[]) {
+    assert.equal(parseFunctionInFilePlus(code.replace("[FUNC]", rff), ctxcode), wsnorm(eres || rff));
+}
+
+function parseTestFunctionInFilePlusError(code: string, error: string, ...ctxcode: string[]) {
+    assert.equal(parseFunctionInFilePlus(code, ctxcode), error);
+}
+
 export {
     parseTestExp, parseTestExpError,
     parseTestFunction, parseTestFunctionError,
-    parseTestFunctionInFile, parseTestFunctionInFileError
+    parseTestFunctionInFile, parseTestFunctionInFileError,
+    parseTestFunctionInFilePlus, parseTestFunctionInFilePlusError
 };


### PR DESCRIPTION
Now imports are enforced:
```
NSOther::Foo
```
is now an error -- requires a using
```
declare namespace Main {
    using NSOther;
}
```
or
```
declare namespace Main {
    using ReallyLong::Scoped::Namespace as NSOther;
}
```
