### PR TITLE
Update to Brex lib + scope resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@bosque/jsbrex": "0.9.0",
+                "@bosque/jsbrex": "0.10.0",
                 "@types/node": "20.14.2"
             },
             "bin": {
@@ -21,9 +21,9 @@
             }
         },
         "node_modules/@bosque/jsbrex": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@bosque/jsbrex/-/jsbrex-0.9.0.tgz",
-            "integrity": "sha512-qFxoMJQbFb2pPuFIuMea90YmW08hPWhHxhqCjFg0GteeijoxZTUFZlDSb/E4yHbcZiKumpXi95OCvql+KCWx1A==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@bosque/jsbrex/-/jsbrex-0.10.0.tgz",
+            "integrity": "sha512-WKfBerWY3hOced3FYsz9MBlFJRdBoK8T7Tiycci18mGClt6gcFvNldZQ89eeKPT9DRAnwpUxEIUDkMCPchj0ww==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@bosque/jsbrex": "0.8.0",
+                "@bosque/jsbrex": "0.9.0",
                 "@types/node": "20.14.2"
             },
             "bin": {
@@ -21,9 +21,9 @@
             }
         },
         "node_modules/@bosque/jsbrex": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@bosque/jsbrex/-/jsbrex-0.8.0.tgz",
-            "integrity": "sha512-tgEHCwdf8NPlNjy+lWTlfuQjhrWlEsHBjV+qNMA0VU+qy/Kxzk0d4bAWZakHiiHNwmyoxFFARLbpeRWyjSnBlw==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@bosque/jsbrex/-/jsbrex-0.9.0.tgz",
+            "integrity": "sha512-qFxoMJQbFb2pPuFIuMea90YmW08hPWhHxhqCjFg0GteeijoxZTUFZlDSb/E4yHbcZiKumpXi95OCvql+KCWx1A==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@types/node": "20.14.2",
-        "@bosque/jsbrex": "0.8.0"
+        "@bosque/jsbrex": "0.9.0"
     },
     "scripts": {
         "build": "node ./build/build_all.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@types/node": "20.14.2",
-        "@bosque/jsbrex": "0.9.0"
+        "@bosque/jsbrex": "0.10.0"
     },
     "scripts": {
         "build": "node ./build/build_all.js",

--- a/src/backend/jsemitter.ts
+++ b/src/backend/jsemitter.ts
@@ -51,7 +51,7 @@ class JSEmitter {
 
     private getCurrentINNS(): string {
         assert(this.currentns !== undefined, "Current namespace is not set");
-        return this.currentns.fullnamespace.ns.join("::");
+        return '"' + this.currentns.fullnamespace.ns.join("::") + '"';
     }
 
     private getErrorInfo(msg: string, sinfo: SourceInfo, diagnosticTag: string | undefined): string | undefined {
@@ -1933,12 +1933,12 @@ class JSEmitter {
                     return `_$formatchk(_$accepts(${this.emitLiteralUnicodeRegexExpression(reexp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
                 }
                 else if(reexp.tag === ExpressionTag.LiteralCRegexExpression) {
-                    return `_$formatchk(accepts(${this.emitLiteralCRegexExpression(reexp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
+                    return `_$formatchk(_$accepts(${this.emitLiteralCRegexExpression(reexp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
                 }
                 else {
                     const nsaccess = this.emitAccessNamespaceConstantExpression(reexp as AccessNamespaceConstantExpression);
                     const retag = `'${(reexp as AccessNamespaceConstantExpression).ns.ns.join("::")}::${(reexp as AccessNamespaceConstantExpression).name}'`;
-                    return `_$formatchk(accepts(${nsaccess}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex -- " + (reexp as AccessNamespaceConstantExpression).name, reexp.sinfo, retag)});`;
+                    return `_$formatchk(_$accepts(${nsaccess}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex -- " + (reexp as AccessNamespaceConstantExpression).name, reexp.sinfo, retag)});`;
                 }
             });
         }
@@ -1964,15 +1964,15 @@ class JSEmitter {
         let rechks: string[] = [];
         if(tdecl.optofexp !== undefined) {
             if(tdecl.optofexp.exp.tag === ExpressionTag.LiteralUnicodeRegexExpression) {
-                rechks.push(`_$formatchk(accepts(${this.emitLiteralUnicodeRegexExpression(tdecl.optofexp.exp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", tdecl.optofexp.exp.sinfo, undefined)});`);
+                rechks.push(`_$formatchk(_$accepts(${this.emitLiteralUnicodeRegexExpression(tdecl.optofexp.exp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", tdecl.optofexp.exp.sinfo, undefined)});`);
             }
             else if(tdecl.optofexp.exp.tag === ExpressionTag.LiteralCRegexExpression) {
-                rechks.push(`_$formatchk(accepts(${this.emitLiteralCRegexExpression(tdecl.optofexp.exp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", tdecl.optofexp.exp.sinfo, undefined)});`);
+                rechks.push(`_$formatchk(_$accepts(${this.emitLiteralCRegexExpression(tdecl.optofexp.exp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", tdecl.optofexp.exp.sinfo, undefined)});`);
             }
             else {
                 const nsaccess = this.emitAccessNamespaceConstantExpression(tdecl.optofexp.exp as AccessNamespaceConstantExpression);
                 const retag = `'${(tdecl.optofexp.exp as AccessNamespaceConstantExpression).ns.ns.join("::")}::${(tdecl.optofexp.exp as AccessNamespaceConstantExpression).name}'`;
-                rechks.push(`_$formatchk(accepts(${nsaccess}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex -- " + (tdecl.optofexp.exp as AccessNamespaceConstantExpression).name, tdecl.optofexp.exp.sinfo, retag)});`);
+                rechks.push(`_$formatchk(_$accepts(${nsaccess}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex -- " + (tdecl.optofexp.exp as AccessNamespaceConstantExpression).name, tdecl.optofexp.exp.sinfo, retag)});`);
             }
         }
 
@@ -2001,15 +2001,15 @@ class JSEmitter {
         if(tdecl instanceof TypedeclTypeDecl) {
             rechks = tdecl.allOfExps.map((reexp) => {
                 if(reexp.tag === ExpressionTag.LiteralUnicodeRegexExpression) {
-                    return `_$formatchk(accepts(${this.emitLiteralUnicodeRegexExpression(reexp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
+                    return `_$formatchk(_$accepts(${this.emitLiteralUnicodeRegexExpression(reexp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
                 }
                 else if(reexp.tag === ExpressionTag.LiteralCRegexExpression) {
-                    return `_$formatchk(accepts(${this.emitLiteralCRegexExpression(reexp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
+                    return `_$formatchk(_$accepts(${this.emitLiteralCRegexExpression(reexp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
                 }
                 else {
                     const nsaccess = this.emitAccessNamespaceConstantExpression(reexp as AccessNamespaceConstantExpression);
                     const retag = `'${(reexp as AccessNamespaceConstantExpression).ns.ns.join("::")}::${(reexp as AccessNamespaceConstantExpression).name}'`;
-                    return `$formatchk(accepts(${nsaccess}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex -- " + (reexp as AccessNamespaceConstantExpression).name, reexp.sinfo, retag)});`;
+                    return `$formatchk(_$accepts(${nsaccess}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex -- " + (reexp as AccessNamespaceConstantExpression).name, reexp.sinfo, retag)});`;
                 }
             });
         }
@@ -2616,12 +2616,18 @@ class JSEmitter {
             imports = `import * as $Core from "./Core.mjs";\n\n`;
         }
 
+        let loadop = "";
         let mainop = "\n";
         if(decl.name === "Main") {
+
+            const asmreinfo = this.assembly.toplevelNamespaces.flatMap((ns) => this.assembly.loadConstantsAndValidatorREs(ns));
+
+            //Now process the regexs
+            loadop = `\nimport { loadConstAndValidateRESystem } from "@bosque/jsbrex";\nloadConstAndValidateRESystem(${JSON.stringify(asmreinfo, undefined, 4)});`
             mainop = "\n\ntry { process.stdout.write(`${main()}\\n`); } catch(e) { process.stdout.write(`Error -- ${e.$info || e}\\n`); }\n";
         }
 
-        return {contents: prefix + imports + ddecls + supers + mainop, tests: tests};
+        return {contents: prefix + imports + ddecls + supers + loadop + mainop, tests: tests};
     }
 
     static emitAssembly(assembly: Assembly, mode: "release" | "testing" | "debug", buildlevel: BuildLevel, asminstantiation: NamespaceInstantiationInfo[]): [{ns: FullyQualifiedNamespace, contents: string}[], string[]] {

--- a/src/backend/jsemitter.ts
+++ b/src/backend/jsemitter.ts
@@ -11,8 +11,7 @@ const prefix =
 '"use strict";\n' +
 'const JSMap = Map;\n' +
 '\n' +
-'import { accepts } from "@bosque/jsbrex";\n' +
-'import {_$softfails, _$supertypes, _$b, _$rc_i, _$rc_n, _$rc_N, _$rc_f, _$dc_i, _$dc_n, _$dc_I, _$dc_N, _$dc_f, _$abort, _$assert, _$formatchk, _$invariant, _$validate, _$precond, _$softprecond, _$postcond, _$softpostcond, _$memoconstval} from "./runtime.mjs";\n' +
+'import {_$softfails, _$supertypes, _$b, _$rc_i, _$rc_n, _$rc_N, _$rc_f, _$dc_i, _$dc_n, _$dc_I, _$dc_N, _$dc_f, _$abort, _$assert, _$formatchk, _$invariant, _$validate, _$precond, _$softprecond, _$postcond, _$softpostcond, _$memoconstval, _$accepts} from "./runtime.mjs";\n' +
 '\n'
 ;
 
@@ -48,6 +47,11 @@ class JSEmitter {
     private getCurrentNamespace(): NamespaceDeclaration {
         assert(this.currentns !== undefined, "Current namespace is not set");
         return this.currentns;
+    }
+
+    private getCurrentINNS(): string {
+        assert(this.currentns !== undefined, "Current namespace is not set");
+        return this.currentns.fullnamespace.ns.join("::");
     }
 
     private getErrorInfo(msg: string, sinfo: SourceInfo, diagnosticTag: string | undefined): string | undefined {
@@ -1926,15 +1930,15 @@ class JSEmitter {
         if(tdecl instanceof TypedeclTypeDecl) {
             rechks = tdecl.allOfExps.map((reexp) => {
                 if(reexp.tag === ExpressionTag.LiteralUnicodeRegexExpression) {
-                    return `_$formatchk(accepts(${this.emitLiteralUnicodeRegexExpression(reexp as LiteralRegexExpression)}, $value), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
+                    return `_$formatchk(_$accepts(${this.emitLiteralUnicodeRegexExpression(reexp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
                 }
                 else if(reexp.tag === ExpressionTag.LiteralCRegexExpression) {
-                    return `_$formatchk(accepts(${this.emitLiteralCRegexExpression(reexp as LiteralRegexExpression)}, $value), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
+                    return `_$formatchk(accepts(${this.emitLiteralCRegexExpression(reexp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
                 }
                 else {
                     const nsaccess = this.emitAccessNamespaceConstantExpression(reexp as AccessNamespaceConstantExpression);
                     const retag = `'${(reexp as AccessNamespaceConstantExpression).ns.ns.join("::")}::${(reexp as AccessNamespaceConstantExpression).name}'`;
-                    return `_$formatchk(accepts(${nsaccess}, $value), ${this.getErrorInfo("failed regex -- " + (reexp as AccessNamespaceConstantExpression).name, reexp.sinfo, retag)});`;
+                    return `_$formatchk(accepts(${nsaccess}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex -- " + (reexp as AccessNamespaceConstantExpression).name, reexp.sinfo, retag)});`;
                 }
             });
         }
@@ -1960,15 +1964,15 @@ class JSEmitter {
         let rechks: string[] = [];
         if(tdecl.optofexp !== undefined) {
             if(tdecl.optofexp.exp.tag === ExpressionTag.LiteralUnicodeRegexExpression) {
-                rechks.push(`_$formatchk(accepts(${this.emitLiteralUnicodeRegexExpression(tdecl.optofexp.exp as LiteralRegexExpression)}, $value), ${this.getErrorInfo("failed regex", tdecl.optofexp.exp.sinfo, undefined)});`);
+                rechks.push(`_$formatchk(accepts(${this.emitLiteralUnicodeRegexExpression(tdecl.optofexp.exp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", tdecl.optofexp.exp.sinfo, undefined)});`);
             }
             else if(tdecl.optofexp.exp.tag === ExpressionTag.LiteralCRegexExpression) {
-                rechks.push(`_$formatchk(accepts(${this.emitLiteralCRegexExpression(tdecl.optofexp.exp as LiteralRegexExpression)}, $value), ${this.getErrorInfo("failed regex", tdecl.optofexp.exp.sinfo, undefined)});`);
+                rechks.push(`_$formatchk(accepts(${this.emitLiteralCRegexExpression(tdecl.optofexp.exp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", tdecl.optofexp.exp.sinfo, undefined)});`);
             }
             else {
                 const nsaccess = this.emitAccessNamespaceConstantExpression(tdecl.optofexp.exp as AccessNamespaceConstantExpression);
                 const retag = `'${(tdecl.optofexp.exp as AccessNamespaceConstantExpression).ns.ns.join("::")}::${(tdecl.optofexp.exp as AccessNamespaceConstantExpression).name}'`;
-                rechks.push(`_$formatchk(accepts(${nsaccess}, $value), ${this.getErrorInfo("failed regex -- " + (tdecl.optofexp.exp as AccessNamespaceConstantExpression).name, tdecl.optofexp.exp.sinfo, retag)});`);
+                rechks.push(`_$formatchk(accepts(${nsaccess}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex -- " + (tdecl.optofexp.exp as AccessNamespaceConstantExpression).name, tdecl.optofexp.exp.sinfo, retag)});`);
             }
         }
 
@@ -1997,15 +2001,15 @@ class JSEmitter {
         if(tdecl instanceof TypedeclTypeDecl) {
             rechks = tdecl.allOfExps.map((reexp) => {
                 if(reexp.tag === ExpressionTag.LiteralUnicodeRegexExpression) {
-                    return `_$formatchk(accepts(${this.emitLiteralUnicodeRegexExpression(reexp as LiteralRegexExpression)}, $value), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
+                    return `_$formatchk(accepts(${this.emitLiteralUnicodeRegexExpression(reexp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
                 }
                 else if(reexp.tag === ExpressionTag.LiteralCRegexExpression) {
-                    return `_$formatchk(accepts(${this.emitLiteralCRegexExpression(reexp as LiteralRegexExpression)}, $value), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
+                    return `_$formatchk(accepts(${this.emitLiteralCRegexExpression(reexp as LiteralRegexExpression)}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex", reexp.sinfo, undefined)});`;
                 }
                 else {
                     const nsaccess = this.emitAccessNamespaceConstantExpression(reexp as AccessNamespaceConstantExpression);
                     const retag = `'${(reexp as AccessNamespaceConstantExpression).ns.ns.join("::")}::${(reexp as AccessNamespaceConstantExpression).name}'`;
-                    return `$formatchk(accepts(${nsaccess}, $value), ${this.getErrorInfo("failed regex -- " + (reexp as AccessNamespaceConstantExpression).name, reexp.sinfo, retag)});`;
+                    return `$formatchk(accepts(${nsaccess}, $value, ${this.getCurrentINNS()}), ${this.getErrorInfo("failed regex -- " + (reexp as AccessNamespaceConstantExpression).name, reexp.sinfo, retag)});`;
                 }
             });
         }

--- a/src/backend/runtime/runtime.mjs
+++ b/src/backend/runtime/runtime.mjs
@@ -1,5 +1,7 @@
 "use strict;"
 
+import { accepts } from "@bosque/jsbrex";
+
 /**
  * @constant
  * @type {string[]}
@@ -35,6 +37,12 @@ const $Unwind_NumericRange = Symbol("NumericRangeFailed");
  * @type {Symbol}
  **/
 const $Unwind_DivZero = Symbol("DivZeroFailed");
+
+/**
+ * @constant
+ * @type {Symbol}
+ **/
+const $Unwind_BadRegex = Symbol("BadRegexFailed");
 
 /**
  * @constant
@@ -558,11 +566,29 @@ function _$memoconstval(memmap, key, comp) {
     return nval;
 }
 
+/**
+ * @function
+ * @param {string} pattern
+ * @param {string} input
+ * @param {string} inns
+ * @throws {$Unwind}
+ * @returns {boolean}
+ **/
+function _$accepts(pattern, input, inns) {
+    try {
+        return accepts(pattern, input, inns);
+    }
+    catch(e) {
+        throw new $Unwind($Unwind_TypeAs, `Invalid regex pattern -- ${e.msg}`);
+    }
+}
+
 export {
     _$softfails,
     _$supertypes,
     _$b, 
     _$rc_i, _$rc_n, _$rc_N, _$rc_f, _$dc_i, _$dc_n, _$dc_I, _$dc_N, _$dc_f,
     _$abort, _$assert, _$formatchk, _$invariant, _$validate, _$precond, _$softprecond, _$postcond, _$softpostcond,
-    _$memoconstval
+    _$memoconstval,
+    _$accepts
 };

--- a/src/frontend/assembly.ts
+++ b/src/frontend/assembly.ts
@@ -1,6 +1,6 @@
 
 import { FullyQualifiedNamespace, TypeSignature, LambdaTypeSignature, RecursiveAnnotation, TemplateTypeSignature, VoidTypeSignature, LambdaParameterSignature, AutoTypeSignature, NominalTypeSignature } from "./type.js";
-import { Expression, BodyImplementation, ConstantExpressionValue, LiteralExpressionValue, ExpressionTag, AccessNamespaceConstantExpression } from "./body.js";
+import { Expression, BodyImplementation, ConstantExpressionValue, LiteralExpressionValue, ExpressionTag, AccessNamespaceConstantExpression, LiteralRegexExpression } from "./body.js";
 
 import { BuildLevel, CodeFormatter, SourceInfo } from "./build_decls.js";
 
@@ -1594,6 +1594,28 @@ class Assembly {
         }
 
         return curns;
+    }
+
+    resolveConstantRegexExpressionValue(exp: LiteralRegexExpression | AccessNamespaceConstantExpression): string | undefined {
+        if(exp instanceof LiteralRegexExpression) {
+            return exp.value;
+        }
+        else {
+            const nsconst = this.resolveNamespaceConstant(exp.ns, exp.name);
+            if(nsconst === undefined) {
+                return undefined;
+            }
+
+            if(nsconst.value.exp instanceof LiteralRegexExpression) {
+                return nsconst.value.exp.value;
+            }
+            else if(nsconst.value.exp instanceof AccessNamespaceConstantExpression) {
+                return this.resolveConstantRegexExpressionValue(nsconst.value.exp);
+            }
+            else {
+                return undefined;
+            }
+        }
     }
 
     resolveValidatorLiteral(exp: Expression): Expression | undefined {

--- a/src/frontend/assembly.ts
+++ b/src/frontend/assembly.ts
@@ -1383,10 +1383,13 @@ class NamespaceConstDecl extends AbstractCoreDecl {
 class NamespaceUsing {
     readonly file: string;
 
-    readonly fromns: FullyQualifiedNamespace;
+    //
+    //TODO: want to add a module/package scope component here too!!
+    //
+    readonly fromns: string;
     readonly asns: string | undefined;
 
-    constructor(file: string, fromns: FullyQualifiedNamespace, asns: string | undefined) {
+    constructor(file: string, fromns: string, asns: string | undefined) {
         this.file = file;
 
         this.fromns = fromns;
@@ -1395,10 +1398,10 @@ class NamespaceUsing {
 
     emit(): string {
         if(this.asns === undefined) {
-            return `using ${this.fromns.emit()};`;
+            return `using ${this.fromns};`;
         }
         else {
-            return `using ${this.fromns.emit()} as ${this.asns};`;
+            return `using ${this.fromns} as ${this.asns};`;
         }
     }
 }
@@ -1419,8 +1422,8 @@ type NSRegexInfo = {
 }
 
 class NamespaceDeclaration {
-    readonly istoplevel: boolean;
     readonly name: string; 
+    readonly topnamespace: string;
     readonly fullnamespace: FullyQualifiedNamespace;
 
     usings: NamespaceUsing[] = [];
@@ -1438,10 +1441,14 @@ class NamespaceDeclaration {
     apis: APIDecl[] = [];
     tasks: TaskDecl[] = [];
 
-    constructor(istoplevel: boolean, name: string, fullnamespace: FullyQualifiedNamespace) {
-        this.istoplevel = istoplevel;
+    constructor(name: string, topnamespace: string, fullnamespace: FullyQualifiedNamespace) {
         this.name = name;
+        this.topnamespace = topnamespace;
         this.fullnamespace = fullnamespace;
+    }
+
+    isTopNamespace(): boolean {
+        return this.name === this.topnamespace;
     }
 
     checkDeclNameClashNS(rname: string): boolean {
@@ -1484,7 +1491,7 @@ class NamespaceDeclaration {
     emit(fmt: CodeFormatter): string {
         let res = "";
 
-        if(this.istoplevel) {
+        if(this.isTopNamespace()) {
             res += `declare namespace ${this.name}`;
         
             fmt.indentPush();
@@ -1548,7 +1555,7 @@ class NamespaceDeclaration {
             res = res.slice(0, res.length - 1);
         }
 
-        if(!this.istoplevel) {
+        if(!this.isTopNamespace()) {
             fmt.indentPop();
             res += fmt.indent("}\n");
         }
@@ -1574,7 +1581,7 @@ class Assembly {
 
     ensureToplevelNamespace(ns: string): NamespaceDeclaration {
         if (!this.hasToplevelNamespace(ns)) {
-            this.toplevelNamespaces.push(new NamespaceDeclaration(true, ns, new FullyQualifiedNamespace([ns])));
+            this.toplevelNamespaces.push(new NamespaceDeclaration(ns, ns, new FullyQualifiedNamespace([ns])));
         }
 
         return this.getToplevelNamespace(ns) as NamespaceDeclaration;

--- a/src/frontend/body.ts
+++ b/src/frontend/body.ts
@@ -797,7 +797,7 @@ class ParseAsTypeExpression extends Expression {
     }
 
     emit(toplevel: boolean, fmt: CodeFormatter): string {
-        return `${this.ttype.emit()}(${this.exp.emit(toplevel, fmt)})`;
+        return `<${this.ttype.emit()}>(${this.exp.emit(toplevel, fmt)})`;
     }
 }
 

--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -4204,7 +4204,7 @@ class TypeChecker {
 
     private loadConstantsAndValidatorREs(nsdecl: NamespaceDeclaration): NSRegexInfo[] {
         const inns = nsdecl.fullnamespace.ns.join("::");
-        const nsmappings = nsdecl.usings.filter((u) => u.asns !== undefined).map((u) => [u.fromns.emit(), u.asns as string] as [string, string]);
+        const nsmappings = nsdecl.usings.filter((u) => u.asns !== undefined).map((u) => [u.fromns, u.asns as string] as [string, string]);
         const nsinfo: NSRegexNameInfo = {inns: inns, nsmappings: nsmappings};
 
         const reinfos: NSRegexREInfoEntry[] = [];

--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import { APIDecl, APIErrorTypeDecl, APIFailedTypeDecl, APIRejectedTypeDecl, APIResultTypeDecl, APISuccessTypeDecl, AbstractNominalTypeDecl, Assembly, ConceptTypeDecl, ConstMemberDecl, DatatypeMemberEntityTypeDecl, DatatypeTypeDecl, EntityTypeDecl, EnumTypeDecl, EnvironmentVariableInformation, FailTypeDecl, EventListTypeDecl, ExplicitInvokeDecl, InternalEntityTypeDecl, InvariantDecl, InvokeExample, InvokeExampleDeclFile, InvokeExampleDeclInline, InvokeTemplateTermDecl, ListTypeDecl, MapEntryTypeDecl, MapTypeDecl, MemberFieldDecl, MethodDecl, NamespaceConstDecl, NamespaceDeclaration, NamespaceFunctionDecl, OkTypeDecl, OptionTypeDecl, PostConditionDecl, PreConditionDecl, PrimitiveEntityTypeDecl, QueueTypeDecl, ResourceInformation, ResultTypeDecl, SetTypeDecl, StackTypeDecl, TaskActionDecl, TaskDecl, TaskMethodDecl, TypeFunctionDecl, TypeTemplateTermDecl, TypedeclTypeDecl, ValidateDecl, WELL_KNOWN_EVENTS_VAR_NAME, WELL_KNOWN_RETURN_VAR_NAME, TemplateTermDeclExtraTag, SomeTypeDecl, NSRegexREInfoEntry, NSRegexInfo, NSRegexNameInfo, InvokeParameterDecl, AbstractCollectionTypeDecl, ConstructableTypeDecl, MAX_SAFE_NAT, MIN_SAFE_INT, MAX_SAFE_INT } from "./assembly.js";
+import { APIDecl, APIErrorTypeDecl, APIFailedTypeDecl, APIRejectedTypeDecl, APIResultTypeDecl, APISuccessTypeDecl, AbstractNominalTypeDecl, Assembly, ConceptTypeDecl, ConstMemberDecl, DatatypeMemberEntityTypeDecl, DatatypeTypeDecl, EntityTypeDecl, EnumTypeDecl, EnvironmentVariableInformation, FailTypeDecl, EventListTypeDecl, ExplicitInvokeDecl, InternalEntityTypeDecl, InvariantDecl, InvokeExample, InvokeExampleDeclFile, InvokeExampleDeclInline, InvokeTemplateTermDecl, ListTypeDecl, MapEntryTypeDecl, MapTypeDecl, MemberFieldDecl, MethodDecl, NamespaceConstDecl, NamespaceDeclaration, NamespaceFunctionDecl, OkTypeDecl, OptionTypeDecl, PostConditionDecl, PreConditionDecl, PrimitiveEntityTypeDecl, QueueTypeDecl, ResourceInformation, ResultTypeDecl, SetTypeDecl, StackTypeDecl, TaskActionDecl, TaskDecl, TaskMethodDecl, TypeFunctionDecl, TypeTemplateTermDecl, TypedeclTypeDecl, ValidateDecl, WELL_KNOWN_EVENTS_VAR_NAME, WELL_KNOWN_RETURN_VAR_NAME, TemplateTermDeclExtraTag, SomeTypeDecl, InvokeParameterDecl, AbstractCollectionTypeDecl, ConstructableTypeDecl, MAX_SAFE_NAT, MIN_SAFE_INT, MAX_SAFE_INT } from "./assembly.js";
 import { CodeFormatter, SourceInfo } from "./build_decls.js";
 import { AutoTypeSignature, EListTypeSignature, ErrorTypeSignature, LambdaTypeSignature, NominalTypeSignature, TemplateConstraintScope, TemplateNameMapper, TemplateTypeSignature, TypeSignature, VoidTypeSignature } from "./type.js";
 import { AbortStatement, AbstractBodyImplementation, AccessEnumExpression, AccessEnvValueExpression, AccessNamespaceConstantExpression, AccessStaticFieldExpression, AccessVariableExpression, ArgumentValue, AssertStatement, BinAddExpression, BinDivExpression, BinKeyEqExpression, BinKeyNeqExpression, BinLogicAndExpression, BinLogicIFFExpression, BinLogicImpliesExpression, BinLogicOrExpression, BinMultExpression, BinSubExpression, BinderInfo, BlockStatement, BodyImplementation, BuiltinBodyImplementation, CallNamespaceFunctionExpression, CallRefSelfExpression, CallRefThisExpression, CallTaskActionExpression, CallTypeFunctionExpression, ConstructorEListExpression, ConstructorLambdaExpression, ConstructorPrimaryExpression, DebugStatement, EmptyStatement, EnvironmentBracketStatement, EnvironmentUpdateStatement, Expression, ExpressionBodyImplementation, ExpressionTag, ITest, ITestFail, ITestNone, ITestOk, ITestSome, ITestType, IfElifElseStatement, IfElseStatement, IfExpression, IfStatement, LambdaInvokeExpression, LetExpression, LiteralExpressionValue, LiteralNoneExpression, LiteralRegexExpression, LiteralSimpleExpression, LiteralTypeDeclValueExpression, LogicActionAndExpression, LogicActionOrExpression, MapEntryConstructorExpression, MatchStatement, NamedArgumentValue, NumericEqExpression, NumericGreaterEqExpression, NumericGreaterExpression, NumericLessEqExpression, NumericLessExpression, NumericNeqExpression, ParseAsTypeExpression, PositionalArgumentValue, PostfixAccessFromIndex, PostfixAccessFromName, PostfixAsConvert, PostfixAssignFields, PostfixInvoke, PostfixIsTest, PostfixLiteralKeyAccess, PostfixOp, PostfixOpTag, PostfixProjectFromNames, PredicateUFBodyImplementation, PrefixNegateOrPlusOpExpression, PrefixNotOpExpression, RefArgumentValue, ReturnMultiStatement, ReturnSingleStatement, ReturnVoidStatement, SelfUpdateStatement, SpecialConstructorExpression, SpecialConverterExpression, SpreadArgumentValue, StandardBodyImplementation, Statement, StatementTag, SwitchStatement, SynthesisBodyImplementation, TaskAccessInfoExpression, TaskAllExpression, TaskDashExpression, TaskEventEmitStatement, TaskMultiExpression, TaskRaceExpression, TaskRunExpression, TaskStatusStatement, TaskYieldStatement, ThisUpdateStatement, ValidateStatement, VarUpdateStatement, VariableAssignmentStatement, VariableDeclarationStatement, VariableInitializationStatement, VariableMultiAssignmentStatement, VariableMultiDeclarationStatement, VariableMultiInitializationStatement, VariableRetypeStatement, VoidRefCallStatement } from "./body.js";
@@ -49,7 +49,7 @@ class TypeChecker {
         return cond;
     }
 
-    private doRegexValidation(sinfo: SourceInfo, ofexp: LiteralRegexExpression | AccessNamespaceConstantExpression, input: string): void {
+    private doRegexValidation(sinfo: SourceInfo, ofexp: LiteralRegexExpression | AccessNamespaceConstantExpression, input: string, literalstring: string): void {
         try {
             const pattern = this.relations.assembly.resolveConstantRegexExpressionValue(ofexp);
             if(pattern === undefined) {
@@ -57,7 +57,7 @@ class TypeChecker {
             }
             else {
                 const isok = accepts(pattern, input, this.inns);
-                this.checkError(sinfo, !isok, `Value ${input} does not match regex pattern ${pattern}`);
+                this.checkError(sinfo, !isok, `Literal value "${literalstring}" does not match regex -- ${pattern}`);
             }
         }
         catch(e) {
@@ -103,7 +103,7 @@ class TypeChecker {
                             this.reportError(exp.sinfo, `Invalid regex validator -- expected literal or namespace constant`);
                         }
                         else {
-                            this.doRegexValidation(exp.sinfo, vexp, vs);
+                            this.doRegexValidation(exp.sinfo, vexp, vs, (exp as LiteralSimpleExpression).value.slice(1, -1));
                         }
                     }
                 }
@@ -127,7 +127,7 @@ class TypeChecker {
                             this.reportError(exp.sinfo, `Invalid regex validator -- expected literal or namespace constant`);
                         }
                         else {
-                            this.doRegexValidation(exp.sinfo, vexp, vs);
+                            this.doRegexValidation(exp.sinfo, vexp, vs, (exp as LiteralSimpleExpression).value.slice(1, -1));
                         }
                     }
                 }
@@ -4185,43 +4185,8 @@ class TypeChecker {
         this.inns = CLEAR_NSNAME;
     }
 
-    private tryReduceConstantExpressionToRE(exp: Expression): LiteralRegexExpression | undefined {
-        if(exp instanceof LiteralRegexExpression) {
-            return exp;
-        }
-        else if (exp instanceof AccessNamespaceConstantExpression) {
-            const nsresl = this.relations.assembly.resolveNamespaceConstant(exp.ns, exp.name);
-            if(nsresl === undefined) {
-                return undefined;
-            }
-
-            return this.tryReduceConstantExpressionToRE(nsresl.value.exp);
-        }
-        else {
-            return undefined;
-        }
-    }
-
-    private loadConstantsAndValidatorREs(nsdecl: NamespaceDeclaration): NSRegexInfo[] {
-        const inns = nsdecl.fullnamespace.ns.join("::");
-        const nsmappings = nsdecl.usings.filter((u) => u.asns !== undefined).map((u) => [u.fromns, u.asns as string] as [string, string]);
-        const nsinfo: NSRegexNameInfo = {inns: inns, nsmappings: nsmappings};
-
-        const reinfos: NSRegexREInfoEntry[] = [];
-        nsdecl.consts.forEach((c) => {
-            const re = this.tryReduceConstantExpressionToRE(c.value.exp);
-            if(re !== undefined) {
-                reinfos.push({name: c.name, restr: re.value});
-            }
-        });
-
-        const subnsinfo = nsdecl.subns.flatMap((ns) => this.loadConstantsAndValidatorREs(ns));
-
-        return [{nsinfo: nsinfo, reinfos:  reinfos}, ...subnsinfo];
-    }
-
     private processConstsAndValidatorREs(assembly: Assembly) {
-        const asmreinfo = assembly.toplevelNamespaces.flatMap((ns) => this.loadConstantsAndValidatorREs(ns));
+        const asmreinfo = assembly.toplevelNamespaces.flatMap((ns) => assembly.loadConstantsAndValidatorREs(ns));
 
         //Now process the regexs
         loadConstAndValidateRESystem(asmreinfo);

--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -7,7 +7,7 @@ import { AbortStatement, AbstractBodyImplementation, AccessEnumExpression, Acces
 import { EListStyleTypeInferContext, SimpleTypeInferContext, TypeEnvironment, TypeInferContext, VarInfo } from "./checker_environment.js";
 import { TypeCheckerRelations } from "./checker_relations.js";
 
-import { validateStringLiteral, validateCStringLiteral, loadConstAndValidateRESystem, accepts, runNamedRegexAccepts } from "@bosque/jsbrex";
+import { validateStringLiteral, validateCStringLiteral, loadConstAndValidateRESystem, accepts } from "@bosque/jsbrex";
 
 class TypeError {
     readonly file: string;

--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 
 import { APIDecl, APIErrorTypeDecl, APIFailedTypeDecl, APIRejectedTypeDecl, APIResultTypeDecl, APISuccessTypeDecl, AbstractNominalTypeDecl, Assembly, ConceptTypeDecl, ConstMemberDecl, DatatypeMemberEntityTypeDecl, DatatypeTypeDecl, EntityTypeDecl, EnumTypeDecl, EnvironmentVariableInformation, FailTypeDecl, EventListTypeDecl, ExplicitInvokeDecl, InternalEntityTypeDecl, InvariantDecl, InvokeExample, InvokeExampleDeclFile, InvokeExampleDeclInline, InvokeTemplateTermDecl, ListTypeDecl, MapEntryTypeDecl, MapTypeDecl, MemberFieldDecl, MethodDecl, NamespaceConstDecl, NamespaceDeclaration, NamespaceFunctionDecl, OkTypeDecl, OptionTypeDecl, PostConditionDecl, PreConditionDecl, PrimitiveEntityTypeDecl, QueueTypeDecl, ResourceInformation, ResultTypeDecl, SetTypeDecl, StackTypeDecl, TaskActionDecl, TaskDecl, TaskMethodDecl, TypeFunctionDecl, TypeTemplateTermDecl, TypedeclTypeDecl, ValidateDecl, WELL_KNOWN_EVENTS_VAR_NAME, WELL_KNOWN_RETURN_VAR_NAME, TemplateTermDeclExtraTag, SomeTypeDecl, NSRegexREInfoEntry, NSRegexInfo, NSRegexNameInfo, InvokeParameterDecl, AbstractCollectionTypeDecl, ConstructableTypeDecl, MAX_SAFE_NAT, MIN_SAFE_INT, MAX_SAFE_INT } from "./assembly.js";
-import { SourceInfo } from "./build_decls.js";
+import { CodeFormatter, SourceInfo } from "./build_decls.js";
 import { AutoTypeSignature, EListTypeSignature, ErrorTypeSignature, LambdaTypeSignature, NominalTypeSignature, TemplateConstraintScope, TemplateNameMapper, TemplateTypeSignature, TypeSignature, VoidTypeSignature } from "./type.js";
 import { AbortStatement, AbstractBodyImplementation, AccessEnumExpression, AccessEnvValueExpression, AccessNamespaceConstantExpression, AccessStaticFieldExpression, AccessVariableExpression, ArgumentValue, AssertStatement, BinAddExpression, BinDivExpression, BinKeyEqExpression, BinKeyNeqExpression, BinLogicAndExpression, BinLogicIFFExpression, BinLogicImpliesExpression, BinLogicOrExpression, BinMultExpression, BinSubExpression, BinderInfo, BlockStatement, BodyImplementation, BuiltinBodyImplementation, CallNamespaceFunctionExpression, CallRefSelfExpression, CallRefThisExpression, CallTaskActionExpression, CallTypeFunctionExpression, ConstructorEListExpression, ConstructorLambdaExpression, ConstructorPrimaryExpression, DebugStatement, EmptyStatement, EnvironmentBracketStatement, EnvironmentUpdateStatement, Expression, ExpressionBodyImplementation, ExpressionTag, ITest, ITestFail, ITestNone, ITestOk, ITestSome, ITestType, IfElifElseStatement, IfElseStatement, IfExpression, IfStatement, LambdaInvokeExpression, LetExpression, LiteralExpressionValue, LiteralNoneExpression, LiteralRegexExpression, LiteralSimpleExpression, LiteralTypeDeclValueExpression, LogicActionAndExpression, LogicActionOrExpression, MapEntryConstructorExpression, MatchStatement, NamedArgumentValue, NumericEqExpression, NumericGreaterEqExpression, NumericGreaterExpression, NumericLessEqExpression, NumericLessExpression, NumericNeqExpression, ParseAsTypeExpression, PositionalArgumentValue, PostfixAccessFromIndex, PostfixAccessFromName, PostfixAsConvert, PostfixAssignFields, PostfixInvoke, PostfixIsTest, PostfixLiteralKeyAccess, PostfixOp, PostfixOpTag, PostfixProjectFromNames, PredicateUFBodyImplementation, PrefixNegateOrPlusOpExpression, PrefixNotOpExpression, RefArgumentValue, ReturnMultiStatement, ReturnSingleStatement, ReturnVoidStatement, SelfUpdateStatement, SpecialConstructorExpression, SpecialConverterExpression, SpreadArgumentValue, StandardBodyImplementation, Statement, StatementTag, SwitchStatement, SynthesisBodyImplementation, TaskAccessInfoExpression, TaskAllExpression, TaskDashExpression, TaskEventEmitStatement, TaskMultiExpression, TaskRaceExpression, TaskRunExpression, TaskStatusStatement, TaskYieldStatement, ThisUpdateStatement, ValidateStatement, VarUpdateStatement, VariableAssignmentStatement, VariableDeclarationStatement, VariableInitializationStatement, VariableMultiAssignmentStatement, VariableMultiDeclarationStatement, VariableMultiInitializationStatement, VariableRetypeStatement, VoidRefCallStatement } from "./body.js";
 import { EListStyleTypeInferContext, SimpleTypeInferContext, TypeEnvironment, TypeInferContext, VarInfo } from "./checker_environment.js";
@@ -22,9 +22,11 @@ class TypeError {
 }
 
 const CLEAR_FILENAME = "[GLOBAL]";
+const CLEAR_NSNAME = "[MISSING_NS]";
 
 class TypeChecker {
     private file: string = CLEAR_FILENAME;
+    private inns: string = CLEAR_NSNAME;
     readonly errors: TypeError[] = [];
 
     readonly constraints: TemplateConstraintScope;
@@ -45,6 +47,22 @@ class TypeChecker {
         }
 
         return cond;
+    }
+
+    private doRegexValidation(sinfo: SourceInfo, ofexp: LiteralRegexExpression | AccessNamespaceConstantExpression, input: string): void {
+        try {
+            const pattern = this.relations.assembly.resolveConstantRegexExpressionValue(ofexp);
+            if(pattern === undefined) {
+                this.reportError(sinfo, `Unable to resolve regex pattern -- ${ofexp.emit(true, new CodeFormatter())}`);
+            }
+            else {
+                const isok = accepts(pattern, input, this.inns);
+                this.checkError(sinfo, !isok, `Value ${input} does not match regex pattern ${pattern}`);
+            }
+        }
+        catch(e) {
+            this.reportError(sinfo, `Invalid regex pattern -- ${(e as TypeError).msg}`);
+        }
     }
 
     private static safeTypePrint(tsig: TypeSignature | undefined): string {
@@ -81,13 +99,11 @@ class TypeChecker {
                 else {
                     for(let i = 0; i < reexp.length; ++i) {
                         const vexp = reexp[i][1];
-                        if(vexp.tag === ExpressionTag.LiteralUnicodeRegexExpression) {
-                            this.checkError(exp.sinfo, !accepts((vexp as LiteralRegexExpression).value, vs), `Literal value ${(exp as LiteralSimpleExpression).value} does not match regex -- ${(vexp as LiteralRegexExpression).value}`);
+                        if(!(vexp instanceof LiteralRegexExpression) && !(vexp instanceof AccessNamespaceConstantExpression)) {
+                            this.reportError(exp.sinfo, `Invalid regex validator -- expected literal or namespace constant`);
                         }
                         else {
-                            const nsaccess = vexp as AccessNamespaceConstantExpression;
-                            const rename = nsaccess.ns.ns.join("::") + "::" + nsaccess.name;
-                            this.checkError(exp.sinfo, !runNamedRegexAccepts(rename, vs, true), `Literal value ${(exp as LiteralSimpleExpression).value} does not match regex -- ${rename}`);
+                            this.doRegexValidation(exp.sinfo, vexp, vs);
                         }
                     }
                 }
@@ -107,16 +123,11 @@ class TypeChecker {
                 else {
                     for(let i = 0; i < reexp.length; ++i) {
                         const vexp = reexp[i][1];
-                        if(vexp.tag === ExpressionTag.LiteralCRegexExpression) {
-                            const acpt = accepts((vexp as LiteralRegexExpression).value, vs);
-                            console.log(acpt);
-                            
-                            this.checkError(exp.sinfo, !accepts((vexp as LiteralRegexExpression).value, vs), `Literal value ${(exp as LiteralSimpleExpression).value} does not match cregex -- ${(vexp as LiteralRegexExpression).value}`);
+                        if(!(vexp instanceof LiteralRegexExpression) && !(vexp instanceof AccessNamespaceConstantExpression)) {
+                            this.reportError(exp.sinfo, `Invalid regex validator -- expected literal or namespace constant`);
                         }
                         else {
-                            const nsaccess = vexp as AccessNamespaceConstantExpression;
-                            const rename = nsaccess.ns.ns.join("::") + "::" + nsaccess.name;
-                            this.checkError(exp.sinfo, !runNamedRegexAccepts(rename, vs, false), `Literal value ${(exp as LiteralSimpleExpression).value} does not match cregex -- ${rename}`);
+                            this.doRegexValidation(exp.sinfo, vexp, vs);
                         }
                     }
                 }
@@ -4151,6 +4162,8 @@ class TypeChecker {
     }
 
     private checkNamespaceDeclaration(decl: NamespaceDeclaration) {
+        this.inns = decl.fullnamespace.ns.join("::");
+
         //all usings should be resolved and valid so nothing to do there
 
         this.checkNamespaceConstDecls(decl.consts);
@@ -4168,6 +4181,8 @@ class TypeChecker {
         for(let i = 0; i < decl.subns.length; ++i) {
             this.checkNamespaceDeclaration(decl.subns[i]);
         }
+
+        this.inns = CLEAR_NSNAME;
     }
 
     private tryReduceConstantExpressionToRE(exp: Expression): LiteralRegexExpression | undefined {

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -699,14 +699,14 @@ class Lexer {
 
     private tryLexBSQONLiteral(): boolean {
         let ncpos = this.jsStrPos;
-        if(this.input.startsWith("bsqon(|", this.jsStrPos)) {
-            ncpos += 7;
+        if(this.input.startsWith("bsqon`", this.jsStrPos)) {
+            ncpos += 6;
         }
         else {
             return false;
         }
 
-        let jepos = this.input.indexOf("|)", ncpos); //TODO: this is a bit of a hack for closed parens -- might be ok, just require internal escaping or maybe we rework a bit
+        let jepos = this.input.indexOf("`", ncpos); //TODO: this is a bit of a hack for closed parens -- might be ok, just require internal escaping or maybe we rework a bit
         if(jepos === -1) {
             this.pushError(new SourceInfo(this.cline, this.linestart, this.jsStrPos, this.jsStrEnd - this.jsStrPos), "Unterminated bsqon literal");
             this.recordLexToken(this.jsStrEnd, TokenStrings.Error);
@@ -4628,6 +4628,7 @@ class Parser {
 
             const nsdecl = this.env.currentNamespace.subns.find((ns) => ns.name === nsname) as NamespaceDeclaration;
             this.env.currentNamespace = nsdecl;
+            xxxx;
             this.ensureAndConsumeTokenAlways(SYM_lbrace, "nested namespace declaration");
             this.parseNamespaceMembers(SYM_rbrace);
             this.ensureAndConsumeTokenAlways(SYM_rbrace, "nested namespace declaration");

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -9,7 +9,7 @@ import { APIDecl, APIResultTypeDecl, AbstractNominalTypeDecl, AdditionalTypeDecl
 import { BuildLevel, CodeFileInfo, CodeFormatter, SourceInfo } from "./build_decls.js";
 import { AllAttributes, CoreOnlyAttributes, KW__debug, KW_abort, KW_action, KW_api, KW_as, KW_assert, KW_chktest, KW_concept, KW_const, KW_datatype, KW_debug, KW_declare, KW_elif, KW_else, KW_ensures, KW_entity, KW_enum, KW_env, KW_fail, KW_errtest, KW_event, KW_example, KW_false, KW_field, KW_fn, KW_function, KW_if, KW_implements, KW_in, KW_invariant, KW_let, KW_match, KW_method, KW_namespace, KW_none, KW_of, KW_ok, KW_pred, KW_predicate, KW_provides, KW_recursive, KW_recursive_q, KW_ref, KW_release, KW_requires, KW_resource, KW_return, KW_safety, KW_self, KW_softcheck, KW_some, KW_spec, KW_status, KW_switch, KW_task, KW_test, KW_then, KW_this, KW_true, KW_type, KW_under, KW_using, KW_validate, KW_var, KW_when, KeywordStrings, LeftScanParens, ParenSymbols, RightScanParens, SYM_HOLE, SYM_amp, SYM_ampamp, SYM_arrow, SYM_at, SYM_atat, SYM_bang, SYM_bangeq, SYM_bangeqeq, SYM_bar, SYM_barbar, SYM_bigarrow, SYM_colon, SYM_coloncolon, SYM_coma, SYM_div, SYM_dot, SYM_dotdotdot, SYM_eq, SYM_eqeq, SYM_eqeqeq, SYM_gt, SYM_gteq, SYM_hash, SYM_iff, SYM_implies, SYM_langle, SYM_lbrace, SYM_lbrack, SYM_lbrackbar, SYM_lparen, SYM_lparenbar, SYM_lt, SYM_lteq, SYM_minus, SYM_negate, SYM_plus, SYM_positive, SYM_question, SYM_rangle, SYM_rbrace, SYM_rbrack, SYM_rparen, SYM_rparenbar, SYM_semicolon, SYM_times, SYM_wildcard, SpaceFrontSymbols, SpaceRequiredSymbols, StandardSymbols, TermRestrictions } from "./parser_kw.js";
 
-import { accepts, initializeLexer, lexFront } from "@bosque/jsbrex";
+import { lexAccepts, initializeLexer, lexFront } from "@bosque/jsbrex";
 
 type ParsePhase = number;
 const ParsePhase_RegisterNames: ParsePhase = 1;
@@ -349,7 +349,7 @@ class Lexer {
 
     private static readonly _s_templateNameRe = '/[A-Z]/';
     private static isTemplateName(str: string): boolean {
-        return accepts(Lexer._s_templateNameRe, str);
+        return lexAccepts(Lexer._s_templateNameRe, str);
     }
 
     private static readonly _s_literalTDOnlyTagRE = `"<"`;

--- a/test/runtime/cons_exps/cons_type.test.js
+++ b/test/runtime/cons_exps/cons_type.test.js
@@ -27,7 +27,7 @@ describe ("Exec -- type decl of strings w/ stacked constraints", () => {
 
         runMainCode('const re2: Regex = /[a-z]+/; type SV1 = String of Main::re2; type SV2 = SV1 of /[a-c]+/; public function main(): String { return SV2{"abc"}.primitive; }', ["abc", "String"]);  
 
-        //runMainCode("type SV1 = CString of /[a-z]+/c; type SV2 = SV1 of /[a-c]+/c; public function main(): CString { return SV2{'abc'<SV1>}.value.value; }", ["abc", "CString"]);
+        runMainCode("type SV1 = CString of /[a-z]+/c; type SV2 = SV1 of /[a-c]+/c; public function main(): CString { return SV2{'abc'<SV1>}.value.value; }", ["abc", "CString"]);
     });
 
     it("should fail string constraints", function () {
@@ -36,6 +36,6 @@ describe ("Exec -- type decl of strings w/ stacked constraints", () => {
 
         runMainCodeError('const re2: Regex = /[a-z]/; type SV1 = String of Main::re2; type SV2 = SV1 of /[a-c]+/; public function main(): String { return SV2{"abc"}.primitive; }', "Error -- failed regex -- re2['Main::re2'] @ test.bsq:3");
 
-        //runMainCodeError("const re2: Regex = /[a-z]/c; type SV1 = String of Main::re2; type SV2 = SV1 of /[a-c]+/c; public function main(): CString { return SV2{'abc'}.primitive; }", "Error -- failed regex -- re2['Main::re2'] @ test.bsq:3");
+        runMainCodeError("const re2: CRegex = /[a-z]/c; type SV1 = CString of Main::re2; type SV2 = SV1 of /[a-c]+/c; public function main(): CString { return SV2{'abc'}.primitive; }", "Error -- failed regex -- re2['Main::re2'] @ test.bsq:3");
     });
 });

--- a/test/typecheck/type/stringish_no_ops.test.js
+++ b/test/typecheck/type/stringish_no_ops.test.js
@@ -31,7 +31,7 @@ describe ("Checker -- type decl of strings w/ constraints", () => {
 
     it("should fail string constraints", function () {
         checkTestFunctionError('type SV1 = String of /[a-z]+/; function main(): SV1 { return "ab3"<SV1>; }', 'Literal value "ab3" does not match regex -- /[a-z]+/');  
-        checkTestFunctionError("const re2: CRegex = /[0-9]/c; type SV2 = CString of Main::re2; function main(): SV2 { return '345'<SV2>; }", "Literal value '345' does not match cregex -- Main::re2");  
+        checkTestFunctionError("const re2: CRegex = /[0-9]/c; type SV2 = CString of Main::re2; function main(): SV2 { return '345'<SV2>; }", 'Literal value "345" does not match regex -- /[0-9]/c');  
     });
 });
 


### PR DESCRIPTION
Updated Brex library support for consistent use between compile/runtime

1. Named regex works at runtime
2. CRegex now supported

Updated Namespace scoping to fix bugs

- Only implicit lookups for top-level namespace name (not full prefixes so sub-namespaces must scope from top-level)
- Tidy up import setup and make notes about extending for package/module scoping as well