### PR TITLE
List Deletion

### DIFF
--- a/src/core/list.bsq
+++ b/src/core/list.bsq
@@ -80,6 +80,12 @@ __internal entity List<T> {
         return ListOps::s_list_insert<T>(this, i, v);
     }
 
+    method delete(i: Nat): List<T>
+        requires i <= this.size();
+    {
+        return ListOps::s_list_delete<T>(this, i);
+    }
+
     method append(l: List<T>): List<T> {
         return ListOps::s_concat2<T>(this, l);
     }

--- a/src/core/xcore_list_exec.bsq
+++ b/src/core/xcore_list_exec.bsq
@@ -48,6 +48,10 @@ namespace ListOps {
         return XCore::s_createDirect<Tree<T>, List<T>>(insert<T>(l.value, idx, v));
     }
 
+    function s_list_delete<T>(l: List<T>, idx: Nat): List<T> {
+        return XCore::s_createDirect<Tree<T>, List<T>>(delete<T>(l.value, idx));
+    }
+
     function s_list_create_empty<T>(): List<T> {
         return XCore::s_createDirect<Tree<T>, List<T>>(Tree<T>::emptyTree);
     }
@@ -617,21 +621,21 @@ namespace ListOps {
         match(t)@ {
             Leaf<T> => { 
                 if(idx == 0n) {
-                    return Tree<T>::createNode(Color#Black, Tree<T>::createLeaf(v), $t);
+                    return Tree<T>::createNode(Color#Red, Tree<T>::createLeaf(v), $t);
                 }
                 else {
-                    return Tree<T>::createNode(Color#Black, $t, Tree<T>::createLeaf(v));
+                    return Tree<T>::createNode(Color#Red, $t, Tree<T>::createLeaf(v));
                 }
             }
             | Node<T> => { 
                 let count = size<T>($t.l);
                 if(idx < count) {
                     let nr = insert_helper[recursive]<T>($t.l, idx, v);
-                    return balance<T>(Color#Black, nr, $t.r); 
+                    return balance<T>($t.c, nr, $t.r); 
                 }
                 else {
                     let nr = insert_helper[recursive]<T>($t.r, idx - count, v);
-                    return balance<T>(Color#Black, $t.l, nr); 
+                    return balance<T>($t.c, $t.l, nr); 
                 }
             }
         }
@@ -647,7 +651,33 @@ namespace ListOps {
             return tt;
         }
         else {
-            return Tree<T>::createNode(Color#Black, $tt.l, $tt.r);
+            let nt = if($tt.c === Color#Red) then Tree<T>::createNode(Color#Black, $tt.l, $tt.r) else $tt;
+            assert checkRBInvariants<T>(nt);
+            return nt;
+        }
+    }
+
+    recursive function delete_helper<T>(t: Tree<T>, idx: Nat): Tree<T> {
+        match(t)@ {
+            BBLeaf<T> => { return Tree<T>::emptyTree; }
+            | Leaf<T> => { return Tree<T>::emptyTree; }
+            | Node<T> => {
+                %% We need to locate our leaf of interest
+                let count = size<T>($t.l);
+                if(idx < count) {
+                     return bubble<T>($t.c, delete_helper[recursive]<T>($t.l, idx), $t.r);
+                }
+                return bubble<T>($t.c, $t.l, delete_helper[recursive]<T>($t.r, idx - count));
+            }
+        }
+    }
+
+    %% For now we just return delete_helpers tree, will need to likely blacken root
+    function delete<T>(t: Tree<T>, idx: Nat): Tree<T> {
+        match(t)@ {
+            BBLeaf<T> => { return Tree<T>::emptyTree; }
+            | Leaf<T> => { return Tree<T>::emptyTree; }
+            | Node<T> => { return delete_helper<T>(t, idx); }
         }
     }
 

--- a/src/core/xcore_list_exec.bsq
+++ b/src/core/xcore_list_exec.bsq
@@ -224,7 +224,7 @@ namespace ListOps {
             let islred = if(t.l)@<Node<T>> then $_.c === Color#Red  else false;
             let isrred = if(t.r)@<Node<T>> then $_.c === Color#Red  else false;
 
-            return \/(islred, isrred);
+            return !\/(islred, isrred);
         }
         
         return checkRBChildColorInvariant[recursive]<T>(t.l) && checkRBChildColorInvariant[recursive]<T>(t.r);
@@ -473,18 +473,23 @@ namespace ListOps {
     }
 
     function bubble<T>(c: Color, tleft: Tree<T>, tright: Tree<T>): Tree<T> {
+        %% Handle case where we try to bubble an empty tree up
+        if(/\(tleft?<BBLeaf<T>>, tright?<BBLeaf<T>>)) {
+            return Tree<T>::emptyTree;
+        }
+
         if(/\(tleft?<Node<T>>, tright?<Node<T>>)) {
             let tl = tleft@<Node<T>>;
             let tr = tright@<Node<T>>;
 
             if(tl.c === Color#BB || tr.c === Color#BB) {
-                let nl = Tree<T>::createNode(redden(tl.c), tl.l, tl.r);
-                let nr = Tree<T>::createNode(redden(tr.c), tr.l, tr.r);
+                let nl = create_with_empty<T>(redden(tl.c), tl.l, tl.r);
+                let nr = create_with_empty<T>(redden(tr.c), tr.l, tr.r);
                 return balance<T>(blacken(tl.c), nl, nr);
             }
         }
         
-        return Tree<T>::createNode(c, tleft, tright);
+        return balance<T>(c, tleft, tright);
     }
 
     function size<T>(t: Tree<T>): Nat {
@@ -571,10 +576,10 @@ namespace ListOps {
 
     recursive function pushBack_helper<T>(t: Tree<T>, v: T): Tree<T> {
         match(t)@ {
-            Leaf<T> => { return balance<T>(Color#Black, $t, Tree<T>::createLeaf(v)); }
+            Leaf<T> => { return balance<T>(Color#Red, $t, Tree<T>::createLeaf(v)); }
             | Node<T> => { 
                 let nr = pushBack_helper[recursive]<T>($t.r, v);
-                return balance<T>(Color#Black, $t.l, nr); 
+                return balance<T>($t.c, $t.l, nr); 
             }
         }
     }
@@ -589,16 +594,18 @@ namespace ListOps {
             return tt;
         }
         else {
-            return Tree<T>::createNode(Color#Black, $tt.l, $tt.r);
+            let nt = if($tt.c === Color#Red) then Tree<T>::createNode(Color#Black, $tt.l, $tt.r) else $tt;
+            assert checkRBInvariants<T>(nt);
+            return nt;
         }
     }
 
     recursive function pushFront_helper<T>(t: Tree<T>, v: T): Tree<T> {
         match(t)@ {
-            Leaf<T> => { return balance<T>(Color#Black, Tree<T>::createLeaf(v), $t); }
+            Leaf<T> => { return balance<T>(Color#Red, Tree<T>::createLeaf(v), $t); }
             | Node<T> => { 
                 let nr = pushFront_helper[recursive]<T>($t.l, v);
-                return balance<T>(Color#Black, nr, $t.r); 
+                return balance<T>($t.c, nr, $t.r); 
             }
         }
     }
@@ -613,7 +620,9 @@ namespace ListOps {
             return tt;
         }
         else {
-            return Tree<T>::createNode(Color#Black, $tt.l, $tt.r);
+            let nt = if($tt.c === Color#Red) then Tree<T>::createNode(Color#Black, $tt.l, $tt.r) else $tt;
+            assert checkRBInvariants<T>(nt);
+            return nt;
         }
     }
 
@@ -657,6 +666,25 @@ namespace ListOps {
         }
     }
 
+    %% Forcefully bubble up leaves to red nodes, otherwise create new node
+    function create_with_empty<T>(c: Color, l: Tree<T>, r: Tree<T>): Tree<T> {
+        if(/\(l?<BBLeaf<T>>, r?<BBLeaf<T>>)) {
+            return Tree<T>::emptyTree;
+        }
+        if(l?<BBLeaf<T>>) {
+            if(c === Color#Red) {
+                return r;
+            }
+        }
+        if(r?<BBLeaf<T>>) {
+            if(c === Color#Red) {
+                return l;
+            }
+        }
+        assert /\(l?!<BBLeaf<T>>, r?!<BBLeaf<T>>);
+        return Tree<T>::createNode(c, l, r);
+    }
+
     recursive function delete_helper<T>(t: Tree<T>, idx: Nat): Tree<T> {
         match(t)@ {
             BBLeaf<T> => { return Tree<T>::emptyTree; }
@@ -672,12 +700,34 @@ namespace ListOps {
         }
     }
 
-    %% For now we just return delete_helpers tree, will need to likely blacken root
     function delete<T>(t: Tree<T>, idx: Nat): Tree<T> {
-        match(t)@ {
+        let nt = delete_helper<T>(t, idx); 
+        match(nt)@ {
             BBLeaf<T> => { return Tree<T>::emptyTree; }
             | Leaf<T> => { return Tree<T>::emptyTree; }
-            | Node<T> => { return delete_helper<T>(t, idx); }
+            | Node<T> => {
+                %% If empty sub tree move root down
+                if($nt.l?<BBLeaf<T>>) {
+                    let r = $nt.r;
+                    if(r)@@!<Node<T>> {
+                        return r;
+                    }
+                    let nrt = balance<T>(r.c, r.l, r.r);
+                    assert checkRBInvariants<T>(nrt);
+                    return nrt;
+                }
+                if($nt.r?<BBLeaf<T>>) {
+                    let l = $nt.l;
+                    if(l)@@!<Node<T>> {
+                        return l;
+                    }
+                    let nlt = balance<T>(l.c, l.l, l.r);
+                    assert checkRBInvariants<T>(nlt);
+                    return nlt;
+                }
+                assert checkRBInvariants<T>(nt);
+                return nt;
+            }
         }
     }
 

--- a/src/core/xcore_list_exec.bsq
+++ b/src/core/xcore_list_exec.bsq
@@ -506,6 +506,9 @@ namespace ListOps {
         }
         else {
             let nn = XCore::s_safeas<Tree<T>, Node<T>>(t);
+            if(nn.l?<BBLeaf<T>>) {
+                return front[recursive]<T>(nn.r);
+            }
             return front[recursive]<T>(nn.l);
         }
     }
@@ -516,6 +519,9 @@ namespace ListOps {
         }
         else {
             let nn = XCore::s_safeas<Tree<T>, Node<T>>(t);
+            if(nn.r?<BBLeaf<T>>) {
+                return back[recursive]<T>(nn.l);
+            }
             return back[recursive]<T>(nn.r);
         }
     }
@@ -703,10 +709,8 @@ namespace ListOps {
     function delete<T>(t: Tree<T>, idx: Nat): Tree<T> {
         let nt = delete_helper<T>(t, idx); 
         match(nt)@ {
-            BBLeaf<T> => { return Tree<T>::emptyTree; }
-            | Leaf<T> => { return Tree<T>::emptyTree; }
-            | Node<T> => {
-                %% If empty sub tree move root down
+            Node<T> => {
+                %% If empty sub tree move root down to non empty slot
                 if($nt.l?<BBLeaf<T>>) {
                     let r = $nt.r;
                     if(r)@@!<Node<T>> {
@@ -728,6 +732,7 @@ namespace ListOps {
                 assert checkRBInvariants<T>(nt);
                 return nt;
             }
+            | _ => { return nt; }
         }
     }
 

--- a/src/core/xcore_list_smt.bsq
+++ b/src/core/xcore_list_smt.bsq
@@ -19,6 +19,8 @@ namespace ListOps {
     function s_list_push_back<T>(l: List<T>, v: T): List<T> = s_list_push_back;
     function s_list_insert<T>(l: List<T>, idx: Nat, v: T): List<T> = s_list_insert;
 
+    function s_list_delete<T>(l: List<T>, idx: Nat): List<T> = s_list_delete;
+
     function s_list_create_empty<T>(): List<T> = s_list_create_empty;
 
     function s_concat2<T>(l1: List<T>, l2: List<T>): List<T> = s_list_concat2;

--- a/src/core/xcore_map_exec.bsq
+++ b/src/core/xcore_map_exec.bsq
@@ -629,9 +629,27 @@ namespace MapOps {
         let nt = delete_helper[recursive]<K, V>(t, k);
         match(nt)@ {
             Node<K, V> => {
-                let ntt = balance<K, V>($nt.c, $nt.l, $nt.r);
-                assert checkRBInvariants<K, V>(ntt);
-                return ntt;
+                %% If empty sub tree move root down
+                if($nt.l?<BBLeaf<K, V>>) {
+                    let r = $nt.r;
+                    if(r)@@!<Node<K, V>> {
+                        return r;
+                    }
+                    let nrt = balance<K, V>(r.c, r.l, r.r);
+                    assert checkRBInvariants<K, V>(nrt);
+                    return nrt;
+                }
+                if($nt.r?<BBLeaf<K, V>>) {
+                    let l = $nt.l;
+                    if(l)@@!<Node<K, V>> {
+                        return l;
+                    }
+                    let nlt = balance<K, V>(l.c, l.l, l.r);
+                    assert checkRBInvariants<K, V>(nlt);
+                    return nlt;
+                }
+                assert checkRBInvariants<K, V>(nt);
+                return nt;
             }
             | _ => { return nt; }
         }

--- a/test/stdlib/list/list_delete.test.js
+++ b/test/stdlib/list/list_delete.test.js
@@ -1,0 +1,16 @@
+"use strict";
+
+import { runMainCode, runMainCodeError } from "../../../bin/test/stdlib/stdlib_nf.js";
+import { describe, it } from "node:test";
+
+describe ("List -- delete", () => {
+    it("should delete index", function () {
+        runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.delete(1n).size(); }', "1n"); 
+    });
+    it("should delete to empty", function() {
+        runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.delete(1n).delete(0n).size(); }', "0n"); 
+    });
+    it("should fail invaid index", function() {
+        runMainCodeError('public function main(): Nat { return List<Int>{1i, 2i}.delete(1n).delete(10n).size(); }', "Error -- i <= this.size() @ list.bsq"); 
+    });
+});

--- a/test/stdlib/list/list_delete.test.js
+++ b/test/stdlib/list/list_delete.test.js
@@ -5,10 +5,21 @@ import { describe, it } from "node:test";
 
 describe ("List -- delete", () => {
     it("should delete index", function () {
+        runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.delete(1n).size(); }', "1n");
+        runMainCode('public function main(): Int { return List<Int>{1i, 3i}.pushBack(2i).delete(1n).back(); }', "2i"); 
+        runMainCode('public function main(): Int { return List<Int>{2i, 2i}.pushFront(3i).delete(2n).front(); }', "3i"); 
+        runMainCode('public function main(): Nat { return List<Int>{2i, 2i}.pushFront(3i).delete(2n).size(); }', "2n"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.pushBack(3i).pushBack(4i).delete(1n).get(2n); }', "4i"); 
+        runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.pushBack(3i).pushBack(4i).pushBack(5i).delete(0n).delete(0n).size(); }', "3n"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.pushBack(3i).pushBack(4i).pushBack(5i).pushBack(6i).delete(0n).delete(0n).get(0n); }', "3i"); 
+        runMainCode('public function main(): Nat { return List<Int>{4i, 5i}.pushFront(3i).pushFront(2i).pushFront(1i).pushBack(6i).pushBack(7i).delete(0n).delete(0n).delete(3n).size(); }', "4n"); 
+        runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.delete(1n).size(); }', "1n"); 
         runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.delete(1n).size(); }', "1n"); 
     });
     it("should delete to empty", function() {
         runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.delete(1n).delete(0n).size(); }', "0n"); 
+        runMainCode('public function main(): Bool { return List<Int>{1i, 4i}.delete(0n).delete(0n).empty(); }', "true");
+        runMainCode('public function main(): Bool { return List<Int>{1i, 3i}.pushBack(0i).pushFront(9i).pushBack(6i).delete(0n).delete(0n).delete(0n).delete(0n).empty(); }', "true");
     });
     it("should fail invaid index", function() {
         runMainCodeError('public function main(): Nat { return List<Int>{1i, 2i}.delete(1n).delete(10n).size(); }', "Error -- i <= this.size() @ list.bsq"); 

--- a/test/stdlib/list/list_delete.test.js
+++ b/test/stdlib/list/list_delete.test.js
@@ -13,15 +13,16 @@ describe ("List -- delete", () => {
         runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.pushBack(3i).pushBack(4i).pushBack(5i).delete(0n).delete(0n).size(); }', "3n"); 
         runMainCode('public function main(): Int { return List<Int>{1i, 2i}.pushBack(3i).pushBack(4i).pushBack(5i).pushBack(6i).delete(0n).delete(0n).get(0n); }', "3i"); 
         runMainCode('public function main(): Nat { return List<Int>{4i, 5i}.pushFront(3i).pushFront(2i).pushFront(1i).pushBack(6i).pushBack(7i).delete(0n).delete(0n).delete(3n).size(); }', "4n"); 
-        runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.delete(1n).size(); }', "1n"); 
-        runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.delete(1n).size(); }', "1n"); 
+        runMainCode('public function main(): Int { return List<Int>{1i}.pushBack(2i).pushFront(3i).delete(0n).front(); }', "1i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.delete(1n).get(0n); }', "1i"); 
     });
     it("should delete to empty", function() {
         runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.delete(1n).delete(0n).size(); }', "0n"); 
         runMainCode('public function main(): Bool { return List<Int>{1i, 4i}.delete(0n).delete(0n).empty(); }', "true");
-        runMainCode('public function main(): Bool { return List<Int>{1i, 3i}.pushBack(0i).pushFront(9i).pushBack(6i).delete(0n).delete(0n).delete(0n).delete(0n).empty(); }', "true");
+        runMainCode('public function main(): Bool { return List<Int>{1i, 3i}.pushBack(0i).pushFront(9i).pushBack(6i).delete(0n).delete(0n).delete(0n).delete(0n).delete(0n).empty(); }', "true");
     });
     it("should fail invaid index", function() {
         runMainCodeError('public function main(): Nat { return List<Int>{1i, 2i}.delete(1n).delete(10n).size(); }', "Error -- i <= this.size() @ list.bsq"); 
+        runMainCodeError('public function main(): Nat { return List<Int>{1i, 3i}.pushBack(2i).delete(4n).size(); }', "Error -- i <= this.size() @ list.bsq"); 
     });
 });


### PR DESCRIPTION
Helps get closer to closing #75

- Implement very similar logic to how I handled map deletion
- Fix nodes always inserting as black in `insert`, `pushBack`, and `pushFront`
- Ensure RB invariants are maintained through insertion and deletion
- Added some logic to handle case where one sub-tree of root node becomes empty but other is still populated. We now simply move the root node to our non empty sub-tree, without doing so RB properties will get violated. I also added this in our map deletion