### PR TITLE
Very Simple C++ Emit

### DIFF
--- a/build/build_cppemit.js
+++ b/build/build_cppemit.js
@@ -11,13 +11,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const bsqdir = path.dirname(__dirname);
 const cmdpath = path.join(bsqdir, "bin/src/cmd/bosque.js");
 
-const binoutdir = path.join(bsqdir, "bin/cpp");
+const binoutdir = path.join(bsqdir, "bin/cppemit");
 
 const allsrcdirs = [
     path.join(bsqdir, "src/bsqir/asm"),
+    path.join(bsqdir, "src/bsqir/simplifier"),
     path.join(bsqdir, "src/backend/cpp/transformer/"),
-    path.join(bsqdir, "src/backend/cpp/cpprepr/"),
-    path.join(bsqdir, "src/backend/cpp/test/")
+    path.join(bsqdir, "src/backend/cpp/cpprepr/")
 ];
 
 let allsources = [];
@@ -32,7 +32,7 @@ for(let i = 0; i < allsrcdirs.length; ++i) {
     }
 }
 
-exec(`node ${cmdpath} --testgen --namespace CPPEmitter --output ${binoutdir} ${allsources.join(" ")}`, {cwd: bsqdir}, (err, stdout, stderr) => {
+exec(`node ${cmdpath} --namespace CPPEmitter --output ${binoutdir} ${allsources.join(" ")}`, {cwd: bsqdir}, (err, stdout, stderr) => {
     if(err !== null) {
         console.log(err);
         console.log(stderr);

--- a/build/build_cppemit.js
+++ b/build/build_cppemit.js
@@ -14,9 +14,10 @@ const cmdpath = path.join(bsqdir, "bin/src/cmd/bosque.js");
 const binoutdir = path.join(bsqdir, "bin/cpp");
 
 const allsrcdirs = [
+    path.join(bsqdir, "src/bsqir/asm"),
     path.join(bsqdir, "src/backend/cpp/transformer/"),
     path.join(bsqdir, "src/backend/cpp/cpprepr/"),
-    path.join(bsqdir, "src/backend/cpp/test/"),
+    path.join(bsqdir, "src/backend/cpp/test/")
 ];
 
 let allsources = [];

--- a/build/resource_copy.js
+++ b/build/resource_copy.js
@@ -25,7 +25,7 @@ process.stdout.write(`Copying resources...\n`);
 copyResourceDir("core/", "core/");
 copyResourceDir("backend/jsemitter/runtime/", "jsruntime/");
 copyResourceDir("backend/smtcore/runtime/", "smtruntime/");
-copyResourceDir("backend/cpp/runtime/", "cppruntime/")
+copyResourceDir("backend/cpp/runtime/", "cppruntime/");
 
 copyResourceDir("samples/", "samples/");
 

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -1,0 +1,28 @@
+namespace CPPAssembly;
+
+entity Body {
+    field op: Operation;
+}
+
+concept Expression {
+}
+
+concept Operation {
+}
+
+entity LiteralSimpleExpression provides Expression {
+    field vtype: TypeKey;
+    field value: CString;
+}
+
+entity BodyImpl provides Operation {
+    field value: Expression;
+}
+
+datatype BinaryArithExpression provides Expression using {
+    field lhs: Expression;
+    field rhs: Expression;
+}
+of
+BinAddExpression { }
+| BinSubExpression { };

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -1,8 +1,14 @@
 namespace CPPAssembly;
 
-entity Body {
-    field op: Operation;
+%% Bosque TypeSignatures are void, nominal, elist, and lamda (current is fine for tdd)
+datatype TypeSignature using {
+    %% Source info would be good
+    field tkeystr: TypeKey;
 }
+of
+VoidTypeSignature { }
+| NominalTypeSignature { }
+;
 
 concept Expression {
 }
@@ -10,13 +16,22 @@ concept Expression {
 concept Operation {
 }
 
-entity LiteralSimpleExpression provides Expression {
-    field vtype: TypeKey;
-    field value: CString;
+concept Statement {
 }
 
-entity BodyImpl provides Operation {
+entity VariableInitializationStatement provides Statement {
+    field name: Identifier; 
+    field vtype: TypeSignature;
+    field exp: Expression;
+}
+
+entity ReturnSingleStatement provides Statement {
+    field rtype: TypeSignature;
     field value: Expression;
+}
+
+entity LiteralSimpleExpression provides Expression {
+    field value: CString;
 }
 
 datatype BinaryArithExpression provides Expression using {
@@ -25,4 +40,15 @@ datatype BinaryArithExpression provides Expression using {
 }
 of
 BinAddExpression { }
-| BinSubExpression { };
+| BinSubExpression { }
+;
+
+datatype BodyImplementation 
+of
+AbstractBodyImplementation { } %% N/A
+| PredicateUFBodyImplementation { } %% N/A
+| BuiltinBodyImplementation { field builtin: CString; } %% N/A
+| SynthesisBodyImplementation { } %% N/A
+| ExpressionBodyImplementation { field exp: Expression; } %% N/A
+| StandardBodyImplementation { field statements: List<Statement>; } %% Is Available :)
+;

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -25,6 +25,11 @@ entity VariableInitializationStatement provides Statement {
     field exp: Expression;
 }
 
+entity AccessVariableExpression provides Expression {
+    field vname: VarIdentifier;
+    field layouttype: TypeSignature;
+}
+
 entity ReturnSingleStatement provides Statement {
     field rtype: TypeSignature;
     field value: Expression;

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -1,7 +1,7 @@
 declare namespace CPPAssembly;
 
 %% For now this doesnt properly organize code, just serves as a structure to build from
-entity CPPAssembly {
+entity Assembly {
     field includes: CString;
     field body: CString;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -37,17 +37,15 @@ entity NamespaceFunctionDecl {
     field invokeKey: InvokeKey;
 
     %% Will be List<InvokeParameterDecl> or something
-    field params: None;
+    field params: None; %% TODO: Parameters not implemented
 
-    %% Will be ResultType
-    field resultType: None;
+    field resultType: TypeSignature;
 
     field body: BodyImplementation;
 }
 
 %% Will need expanding
 entity Assembly {
-    %% Is this best way to store nsfuncs? (maps nice to bsqasm)
     field nsfuncs: Map<InvokeKey, NamespaceFunctionDecl>;
     field allfuncs: List<InvokeKey>;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -1,7 +1,18 @@
 declare namespace CPPAssembly;
 
-%% For now this doesnt properly organize code, just serves as a structure to build from
+%% Most map well from Bosque
+const namespaceComponentRE: CRegex = /[A-Z][_a-zA-Z0-9]+/c;
+const namespaceKeyRE: CRegex = /(${CPPAssembly::namespaceComponentRE}'::')*${CPPAssembly::namespaceComponentRE}/c;
+type NamespaceComponentKey = CString of CPPAssembly::namespaceComponentRE;
+type NamespaceKey = CString of CPPAssembly::namespaceKeyRE; %%Core is implicit here
+
+const basicNominalTypeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}'::')?[A-Z][_a-zA-Z0-9]+('<'.+'>')?/c;
+const nominalTypeKeyRE: CRegex = /(${CPPAssembly::basicNominalTypeKeyRE})/c; %% Will need to handle special scoped type key?
+
+const invokeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}|${BSQAssembly::nominalTypeKeyRE})'::'[_a-z][_a-zA-Z0-9$]+/c;
+type InvokeKey = CString of CPPAssembly::invokeKeyRE;
+
+%% Will need expanding
 entity Assembly {
-    field includes: CString;
-    field body: CString;
+    field allfuncs: List<InvokeKey>;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -12,8 +12,12 @@ const namespaceKeyRE: CRegex = /(${CPPAssembly::namespaceComponentRE}'::')*${CPP
 type NamespaceComponentKey = CString of CPPAssembly::namespaceComponentRE;
 type NamespaceKey = CString of CPPAssembly::namespaceKeyRE; %%Core is implicit here
 
-const basicNominalTypeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}'::')?[A-Z][_a-zA-Z0-9]+('<'.+'>')?/c;
+const basicNominalTypeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}'::')?[_a-zA-Z0-9]+('<'.+'>')?/c;
 const nominalTypeKeyRE: CRegex = /(${CPPAssembly::basicNominalTypeKeyRE})/c; %% Will need to handle special scoped type key?
+
+%% For converting bsq value representation to cpp
+const bsqIntValue: CRegex = /[0-9]+'i'/c;
+type BsqInt = CString of CPPAssembly::bsqIntValue;
 
 const typeKeyRE: CRegex = /${CPPAssembly::nominalTypeKeyRE}/c;
 type TypeKey = CString of CPPAssembly::typeKeyRE;

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -1,6 +1,12 @@
 declare namespace CPPAssembly;
 
-%% Most map well from Bosque
+%% Most map well from Bosque/SMT emit
+
+entity SourceInfo {
+    field line: Nat;
+    field column: Nat;
+}
+
 const namespaceComponentRE: CRegex = /[A-Z][_a-zA-Z0-9]+/c;
 const namespaceKeyRE: CRegex = /(${CPPAssembly::namespaceComponentRE}'::')*${CPPAssembly::namespaceComponentRE}/c;
 type NamespaceComponentKey = CString of CPPAssembly::namespaceComponentRE;
@@ -9,10 +15,27 @@ type NamespaceKey = CString of CPPAssembly::namespaceKeyRE; %%Core is implicit h
 const basicNominalTypeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}'::')?[A-Z][_a-zA-Z0-9]+('<'.+'>')?/c;
 const nominalTypeKeyRE: CRegex = /(${CPPAssembly::basicNominalTypeKeyRE})/c; %% Will need to handle special scoped type key?
 
+const typeKeyRE: CRegex = /${CPPAssembly::nominalTypeKeyRE}/c;
+type TypeKey = CString of CPPAssembly::typeKeyRE;
+
 const invokeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}|${BSQAssembly::nominalTypeKeyRE})'::'[_a-z][_a-zA-Z0-9$]+/c;
 type InvokeKey = CString of CPPAssembly::invokeKeyRE;
 
+entity NamespaceFunctionDecl {
+    field ns: NamespaceKey;
+    field name: CString;
+    field invokeKey: InvokeKey;
+
+    %% Will be List<InvokeParameterDecl>
+    field params: None;
+
+    %% Will be ResultType
+    field resultType: None;
+
+    field body: Body;
+}
+
 %% Will need expanding
 entity Assembly {
-    field allfuncs: List<InvokeKey>;
+    field nsfuncs: List<NamespaceFunctionDecl>;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -18,24 +18,32 @@ const nominalTypeKeyRE: CRegex = /(${CPPAssembly::basicNominalTypeKeyRE})/c; %% 
 const typeKeyRE: CRegex = /${CPPAssembly::nominalTypeKeyRE}/c;
 type TypeKey = CString of CPPAssembly::typeKeyRE;
 
-const invokeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}|${BSQAssembly::nominalTypeKeyRE})'::'[_a-z][_a-zA-Z0-9$]+/c;
+const invokeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}|${CPPAssembly::nominalTypeKeyRE})'::'[_a-z][_a-zA-Z0-9$]+/c;
 type InvokeKey = CString of CPPAssembly::invokeKeyRE;
 
+const identifierRE: CRegex = /[_a-z][_a-zA-Z0-9$]*/c; %%we allow & inside these identifiers so we can make special names
+const videntifierRE: CRegex = /'$'?[_a-z][_a-zA-Z0-9$]*/c; %%we allow & inside these identifiers so we can make special names
+type Identifier = CString of CPPAssembly::identifierRE;
+type VarIdentifier = CString of CPPAssembly::videntifierRE;
+
+%% May want to change this as it doesnt map super well to bsqir (but maps nice to how smtemit)
 entity NamespaceFunctionDecl {
     field ns: NamespaceKey;
     field name: CString;
     field invokeKey: InvokeKey;
 
-    %% Will be List<InvokeParameterDecl>
+    %% Will be List<InvokeParameterDecl> or something
     field params: None;
 
     %% Will be ResultType
     field resultType: None;
 
-    field body: Body;
+    field body: BodyImplementation;
 }
 
 %% Will need expanding
 entity Assembly {
-    field nsfuncs: List<NamespaceFunctionDecl>;
+    %% Is this best way to store nsfuncs? (maps nice to bsqasm)
+    field nsfuncs: Map<InvokeKey, NamespaceFunctionDecl>;
+    field allfuncs: List<InvokeKey>;
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -2,7 +2,8 @@ namespace CPPEmitter;
 
 %%
 %% TODO: We will need to properly overload our conversion from bosque types to cpp types to ensure
-%% everything stays safe (such as Nat in bosque only being 63 bits not 64)
+%% everything stays safe (such as Nat in bosque only being 63 bits not 64) and all operations on 
+%% these values need to be provided via overloading and using compiler builtins (like __builtin_add_overflow__)
 %%
 
 %% CPP Pre-defined backend
@@ -57,15 +58,18 @@ function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression
     return emitVarIdentifier(exp.vname);
 }
 
+function emitReturnSingleStatement(ret: CPPAssembly::ReturnSingleStatement): CString {
+    %% let rtype = emitTypeSignature(ret.rtype);
+    let exp = emitExpression(ret.value);
+
+    return CString::concat('return ', exp, ';%n;');
+}
+
 recursive function emitBinAddExpression(add: CPPAssembly::BinAddExpression): CString {
     let lhs = emitExpression[recursive](add.lhs);
     let rhs = emitExpression[recursive](add.rhs);
 
-    %% In my cppruntime header I need to for each primitive write out a struct
-    %% with correct operator overloading to correctly map Int -> int64_t and stuff
-    %% Here we also need to something like Struct Int_TypeInfo IN THE HEADER ITSELF.
-    %% We also want to do overflow safe like __safe_add__ . We overload plus with these values
-
+    %% TODO: Overload '+'
     return CString::concat('(', lhs, ' + ', rhs, ')');
 }
 
@@ -101,7 +105,7 @@ function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitiali
 function emitStatement(stmt: CPPAssembly::Statement): CString {
     match(stmt)@ {
         CPPAssembly::VariableInitializationStatement => { return emitVariableInitializationStatement($stmt); }
-        | CPPAssembly::ReturnSingleStatement => { return ''; } %% TODO
+        | CPPAssembly::ReturnSingleStatement => { return emitReturnSingleStatement($stmt); }
         | _ => { abort; }
     }
 }
@@ -122,16 +126,26 @@ function emitBodyImplementation(body: CPPAssembly::BodyImplementation): CString 
     }
 }
 
-
+%% Will need to specific namespace of function
 function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl): CString {
-    %% Function name
-    %% Params
-    %% Return?
-    return emitBodyImplementation(func.body);
+    let name = func.name;
+    let params = ''; %% TODO: Parameters not implemented
+
+    %%
+    %% g++ forces 'main' return type to be int. Once we overload types, this interaction may
+    %% become somewhat funny, so need to be careful. This will also be akward with main in bosque
+    %% since its happy to return types other than int. Perhaps make a psuedo main function
+    %% that we always just call from real 'int main() ... ' that contains whatever bosque code main does
+    %% and the real 'int main() ... ' just returns 0
+    %%
+    let rtype = if(name === 'main') then 'int' else emitTypeSignature(func.resultType); 
+
+    let decl: CString = CString::concat(rtype, ' ', name, '(', params, ')');
+
+    return CString::concat(decl, ' {%n;', emitBodyImplementation(func.body), '}%n;');
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
-    %% For now we just grab every function
     let efuncs_list = asm.allfuncs.map<CString>(fn(t) => { 
         if(asm.nsfuncs.has(t)) {
             return emitNamespaceFunctionDecl(asm.nsfuncs.get(t));
@@ -142,6 +156,5 @@ function emitAssembly(asm: CPPAssembly::Assembly): CString {
 
     %% For CCharBuf and Unicode... will need to emit builtin functions explicitly
 
-    %% We dont even emit the headers, so something must be causing aborting
     return CString::join('%n;', efuncs);
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -30,6 +30,15 @@ namespace UnicodeCharBuffer {
     %% Emit c++ for buffer creation here
 }
 
+function emitFunction(ik: CPPAssembly::InvokeKey): CString {
+    return ik.value;
+}
+
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
-    return CString::concat(asm.includes, asm.body);
+    %% For now we just grab every function
+    let efuncs_list = asm.allfuncs.map<CString>(fn(t) => {
+        return emitFunction(t);
+    });
+
+    return CString::joinAll('%n;%n;', efuncs_list);
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -30,6 +30,6 @@ namespace UnicodeCharBuffer {
     %% Emit c++ for buffer creation here
 }
 
-function emitAssembly(asm: CPPAssembly): CString {
+function emitAssembly(asm: CPPAssembly::Assembly): CString {
     return CString::concat(asm.includes, asm.body);
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1,16 +1,60 @@
 namespace CPPEmitter;
 
 %%
-%% I suspect either somewhere in this file or in the transform we hit an abort and never actually emit any cpp
-%% Not sure exactly where thought...
+%% TODO: We will need to properly overload our conversion from bosque types to cpp types to ensure
+%% everything stays safe (such as Nat in bosque only being 63 bits not 64)
 %%
 
-function emitIncludes(): CString {
-    return '#include "cppruntime.hpp"';
+%% CPP Pre-defined backend
+namespace PathStack {
+    function emitPathStackCreate(): CString {
+        return 'PathStack ps = PathStack::create();';
+    }
+
+    function emitPathStackLeft(): CString {
+        return 'ps.left();';
+    }
+
+    function emitPathStackRight(): CString {
+        return 'ps.right();';
+    }
+
+    function emitPathStackUp(): CString {
+        return 'ps.up();';
+    }
+}
+
+namespace CCharBuffer {
+    %% Emit c++ for buffer creation here
+}
+
+namespace UnicodeCharBuffer {
+    %% Emit c++ for buffer creation here
+}
+
+function emitTypeSignature(ts: CPPAssembly::TypeSignature): CString {
+    return ts.tkeystr.value;
+}
+
+function emitIdentifier(ident: CPPAssembly::Identifier): CString {
+    return ident.value;
+}
+
+function emitVarIdentifier(vident: CPPAssembly::VarIdentifier): CString {
+    return vident.value;
 }
 
 function emitFunction(ik: CPPAssembly::InvokeKey): CString {
     return ik.value;
+}
+
+function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression): CString {
+    return exp.value;
+}
+
+function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression): CString {
+    %% May need some work with type
+    return emitVarIdentifier(exp.vname);
 }
 
 recursive function emitBinAddExpression(add: CPPAssembly::BinAddExpression): CString {
@@ -26,7 +70,7 @@ recursive function emitBinAddExpression(add: CPPAssembly::BinAddExpression): CSt
 }
 
 recursive function emitBinSubExpression(add: CPPAssembly::BinSubExpression): CString {
-    abort;
+    abort; %% TODO
 }
 
 function emitBinaryArithExpression(e: CPPAssembly::BinaryArithExpression): CString {
@@ -40,16 +84,18 @@ function emitBinaryArithExpression(e: CPPAssembly::BinaryArithExpression): CStri
 function emitExpression(e: CPPAssembly::Expression): CString {
     match(e)@ {
         CPPAssembly::BinaryArithExpression => { return emitBinaryArithExpression[recursive]($e); }
+        | CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($e); }
+        | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e); }
         | _ => { abort; }
     }
 }
 
 function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitializationStatement): CString {
-    let name: CString = 'hi'; %% need to convert stmt.name
-    let stype: CString = 'int'; %% Needs some real magic
-    let exp: CString = emitExpression(stmt.exp);
+    let name = emitIdentifier(stmt.name);
+    let stype = emitTypeSignature(stmt.vtype);
+    let exp = emitExpression(stmt.exp);
 
-    return CString::concat(stype, ' ', stype, ' = ', exp);
+    return CString::concat(stype, ' ', name, ' = ', exp, ';');
 }
 
 function emitStatement(stmt: CPPAssembly::Statement): CString {
@@ -84,48 +130,18 @@ function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl): CS
     return emitBodyImplementation(func.body);
 }
 
-%% CPP Pre-defined backend
-namespace PathStack {
-    function emitPathStackCreate(): CString {
-        return 'PathStack ps = PathStack::create();';
-    }
-
-    function emitPathStackLeft(): CString {
-        return 'ps.left();';
-    }
-
-    function emitPathStackRight(): CString {
-        return 'ps.right();';
-    }
-
-    function emitPathStackUp(): CString {
-        return 'ps.up();';
-    }
-}
-
-namespace CCharBuffer {
-    %% Emit c++ for buffer creation here
-}
-
-namespace UnicodeCharBuffer {
-    %% Emit c++ for buffer creation here
-}
-
-
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
     %% For now we just grab every function
-    let includes = emitIncludes();
-
     let efuncs_list = asm.allfuncs.map<CString>(fn(t) => { 
         if(asm.nsfuncs.has(t)) {
             return emitNamespaceFunctionDecl(asm.nsfuncs.get(t));
         }
         return 'NOT IMPLEMENTED!';
-     });
-    let efuncs = CString::joinAll('%n;%n;', efuncs_list);
+    });
+    let efuncs = CString::joinAll('%n;', efuncs_list);
 
     %% For CCharBuf and Unicode... will need to emit builtin functions explicitly
 
     %% We dont even emit the headers, so something must be causing aborting
-    return CString::join('%n;', includes, efuncs);
+    return CString::join('%n;', efuncs);
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1,5 +1,10 @@
 namespace CPPEmitter;
 
+%%
+%% I suspect either somewhere in this file or in the transform we hit an abort and never actually emit any cpp
+%% Not sure exactly where thought...
+%%
+
 function emitIncludes(): CString {
     return '#include "cppruntime.hpp"';
 }
@@ -12,6 +17,11 @@ recursive function emitBinAddExpression(add: CPPAssembly::BinAddExpression): CSt
     let lhs = emitExpression[recursive](add.lhs);
     let rhs = emitExpression[recursive](add.rhs);
 
+    %% In my cppruntime header I need to for each primitive write out a struct
+    %% with correct operator overloading to correctly map Int -> int64_t and stuff
+    %% Here we also need to something like Struct Int_TypeInfo IN THE HEADER ITSELF.
+    %% We also want to do overflow safe like __safe_add__ . We overload plus with these values
+
     return CString::concat('(', lhs, ' + ', rhs, ')');
 }
 
@@ -19,15 +29,11 @@ recursive function emitBinSubExpression(add: CPPAssembly::BinSubExpression): CSt
     abort;
 }
 
-%%
-%% Not very confident on these commented functions, needs some thought
-%%
-
-%* 
 function emitBinaryArithExpression(e: CPPAssembly::BinaryArithExpression): CString {
     match(e)@ {
         CPPAssembly::BinAddExpression => { return emitBinAddExpression[recursive]($e); }
-        | CPPAssembly::BinSubExpression => { return emitBinSubExpression[recursive]($e); }
+        %% | CPPAssembly::BinSubExpression => { return emitBinSubExpression[recursive]($e); }
+        | _ => { abort; }
     }
 }
 
@@ -38,25 +44,44 @@ function emitExpression(e: CPPAssembly::Expression): CString {
     }
 }
 
-function emitSimpleLiteralExpression(sle: CPPAssembly::LiteralSimpleExpression) {
+function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitializationStatement): CString {
+    let name: CString = 'hi'; %% need to convert stmt.name
+    let stype: CString = 'int'; %% Needs some real magic
+    let exp: CString = emitExpression(stmt.exp);
 
+    return CString::concat(stype, ' ', stype, ' = ', exp);
 }
 
-function emitOperation(op: CPPAssembly::Operation) {
-    match(op)@ {
-        CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($op); }
+function emitStatement(stmt: CPPAssembly::Statement): CString {
+    match(stmt)@ {
+        CPPAssembly::VariableInitializationStatement => { return emitVariableInitializationStatement($stmt); }
+        | CPPAssembly::ReturnSingleStatement => { return ''; } %% TODO
         | _ => { abort; }
     }
 }
 
-function emitBody(body: CPPAssembly::Body): CString{
-    return emitOperation(body.op);
+function emitStandardBodyImplementation(body: CPPAssembly::StandardBodyImplementation): CString {
+    return CString::joinAll('%n;', body.statements.map<CString>(fn(stmt) => emitStatement(stmt)));
 }
-*%
+
+function emitBodyImplementation(body: CPPAssembly::BodyImplementation): CString {
+    match(body)@ {
+        %% CPPAssembly::AbstractBodyImplementation => { abort; }
+        %% | CPPAssembly::PredicateUFBodyImplementation => { abort; }
+        %% | CPPAssembly::BuiltinBodyImplementation => { abort; }
+        %% | CPPAssembly::SynthesisBodyImplementation => { abort; }
+        %% | CPPAssembly::ExpressionBodyImplementation => { abort; }
+        CPPAssembly::StandardBodyImplementation => { return emitStandardBodyImplementation($body); }
+        | _ => { abort; }
+    }
+}
+
 
 function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl): CString {
-    %% Needs to properly setup function name, args, etc
-    return emitBody(f.body);
+    %% Function name
+    %% Params
+    %% Return?
+    return emitBodyImplementation(func.body);
 }
 
 %% CPP Pre-defined backend
@@ -91,14 +116,16 @@ function emitAssembly(asm: CPPAssembly::Assembly): CString {
     %% For now we just grab every function
     let includes = emitIncludes();
 
-    let efuncs_list = asm.nsfuncs.map<CString>(fn(t) => { 
+    let efuncs_list = asm.allfuncs.map<CString>(fn(t) => { 
         if(asm.nsfuncs.has(t)) {
-            return emitNamespaceFunctionDecl(t);
+            return emitNamespaceFunctionDecl(asm.nsfuncs.get(t));
         }
+        return 'NOT IMPLEMENTED!';
      });
     let efuncs = CString::joinAll('%n;%n;', efuncs_list);
 
     %% For CCharBuf and Unicode... will need to emit builtin functions explicitly
 
+    %% We dont even emit the headers, so something must be causing aborting
     return CString::join('%n;', includes, efuncs);
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -36,9 +36,7 @@ function emitFunction(ik: CPPAssembly::InvokeKey): CString {
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
     %% For now we just grab every function
-    let efuncs_list = asm.allfuncs.map<CString>(fn(t) => {
-        return emitFunction(t);
-    });
+    let efuncs_list = asm.allfuncs.map<CString>(fn(t) => { return emitFunction(t); });
 
     return CString::joinAll('%n;%n;', efuncs_list);
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -4,6 +4,62 @@ function emitIncludes(): CString {
     return '#include "cppruntime.hpp"';
 }
 
+function emitFunction(ik: CPPAssembly::InvokeKey): CString {
+    return ik.value;
+}
+
+recursive function emitBinAddExpression(add: CPPAssembly::BinAddExpression): CString {
+    let lhs = emitExpression[recursive](add.lhs);
+    let rhs = emitExpression[recursive](add.rhs);
+
+    return CString::concat('(', lhs, ' + ', rhs, ')');
+}
+
+recursive function emitBinSubExpression(add: CPPAssembly::BinSubExpression): CString {
+    abort;
+}
+
+%%
+%% Not very confident on these commented functions, needs some thought
+%%
+
+%* 
+function emitBinaryArithExpression(e: CPPAssembly::BinaryArithExpression): CString {
+    match(e)@ {
+        CPPAssembly::BinAddExpression => { return emitBinAddExpression[recursive]($e); }
+        | CPPAssembly::BinSubExpression => { return emitBinSubExpression[recursive]($e); }
+    }
+}
+
+function emitExpression(e: CPPAssembly::Expression): CString {
+    match(e)@ {
+        CPPAssembly::BinaryArithExpression => { return emitBinaryArithExpression[recursive]($e); }
+        | _ => { abort; }
+    }
+}
+
+function emitSimpleLiteralExpression(sle: CPPAssembly::LiteralSimpleExpression) {
+
+}
+
+function emitOperation(op: CPPAssembly::Operation) {
+    match(op)@ {
+        CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($op); }
+        | _ => { abort; }
+    }
+}
+
+function emitBody(body: CPPAssembly::Body): CString{
+    return emitOperation(body.op);
+}
+*%
+
+function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl): CString {
+    %% Needs to properly setup function name, args, etc
+    return emitBody(f.body);
+}
+
+%% CPP Pre-defined backend
 namespace PathStack {
     function emitPathStackCreate(): CString {
         return 'PathStack ps = PathStack::create();';
@@ -30,13 +86,19 @@ namespace UnicodeCharBuffer {
     %% Emit c++ for buffer creation here
 }
 
-function emitFunction(ik: CPPAssembly::InvokeKey): CString {
-    return ik.value;
-}
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
     %% For now we just grab every function
-    let efuncs_list = asm.allfuncs.map<CString>(fn(t) => { return emitFunction(t); });
+    let includes = emitIncludes();
 
-    return CString::joinAll('%n;%n;', efuncs_list);
+    let efuncs_list = asm.nsfuncs.map<CString>(fn(t) => { 
+        if(asm.nsfuncs.has(t)) {
+            return emitNamespaceFunctionDecl(t);
+        }
+     });
+    let efuncs = CString::joinAll('%n;%n;', efuncs_list);
+
+    %% For CCharBuf and Unicode... will need to emit builtin functions explicitly
+
+    return CString::join('%n;', includes, efuncs);
 }

--- a/src/backend/cpp/transformer/cppprocessor.bsq
+++ b/src/backend/cpp/transformer/cppprocessor.bsq
@@ -7,6 +7,10 @@ declare namespace CPPEmitter {
 
 %% Our API for emitting cpp
 public function main(asm: BSQAssembly::Assembly): CString {
+    let tmp = BSQAssembly::VarMapping::createEmpty();
+
     let tasm = CPPEmitter::CPPTransformer::convertBsqAsmToCpp(asm);
-    return CPPEmitter::emitAssembly(tasm);
+    let cppstr = CPPEmitter::emitAssembly(tasm);
+
+    return cppstr;
 }

--- a/src/backend/cpp/transformer/cppprocessor.bsq
+++ b/src/backend/cpp/transformer/cppprocessor.bsq
@@ -6,6 +6,7 @@ declare namespace CPPEmitter {
 %% TODO: actually glue or properly transformed cpp together
 
 %% Our API for emitting cpp
-public function main(asm: CPPAssembly): CString {
-    return CPPEmitter::emitAssembly(asm);
+public function main(asm: BSQAssembly::Assembly): CString {
+    let tasm = CPPEmitter::CPPTransformer::convertBsqAsmToCpp(asm);
+    return CPPEmitter::emitAssembly(tasm);
 }

--- a/src/backend/cpp/transformer/cppprocessor.bsq
+++ b/src/backend/cpp/transformer/cppprocessor.bsq
@@ -7,8 +7,6 @@ declare namespace CPPEmitter {
 
 %% Our API for emitting cpp
 public function main(asm: BSQAssembly::Assembly): CString {
-    let tmp = BSQAssembly::VarMapping::createEmpty();
-
     let tasm = CPPEmitter::CPPTransformer::convertBsqAsmToCpp(asm);
     let cppstr = CPPEmitter::emitAssembly(tasm);
 

--- a/src/backend/cpp/transformer/cppprocessor.bsq
+++ b/src/backend/cpp/transformer/cppprocessor.bsq
@@ -1,4 +1,5 @@
 declare namespace CPPEmitter {
+    using BSQAssembly;
     using CPPAssembly;
 }
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -12,19 +12,47 @@ namespace CPPTransformNameManager {
 
     function convertTypeSignature(tkey: BSQAssembly::TypeKey): CPPAssembly::TypeSignature {
         let tk = CPPAssembly::TypeKey::from(tkey.value);
-        return CPPAssembly::NominalTypeSignature{ tk }; %% We wont want this to ne nominal always
+
+        if(tk.value === 'Int') {
+            %% We will need call our overloaded int type
+            return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('int64_t') };
+        }
+
+        return CPPAssembly::NominalTypeSignature{ tk }; %% We wont want this to be nominal always (look at smttransfrom)
     }
 
-    function convertIdentifier(nkey: BSQAssembly::Identifier): CPPAssembly::Identifier {
-        return CPPAssembly::Identifier::from(nkey.value);
+    function convertIdentifier(ident: BSQAssembly::Identifier): CPPAssembly::Identifier {
+        return CPPAssembly::Identifier::from(ident.value);
+    }
+
+    function convertVarIdentifier(vident: BSQAssembly::VarIdentifier): CPPAssembly::VarIdentifier {
+        return CPPAssembly::VarIdentifier::from(vident.value);
     }
 }
 
 entity CPPTransformer {
     field bsqasm: BSQAssembly::Assembly;
 
+
     method transformBinAddExpressionToCpp(binadd: BSQAssembly::BinAddExpression): CPPAssembly::BinAddExpression {
         abort;
+    }
+
+    %% Given how simple (lol) this expression is, may not need a separate method for this transform
+    method transformLiteralSimpleExpression(exp: BSQAssembly::LiteralSimpleExpression): CPPAssembly::LiteralSimpleExpression {
+        let val = exp.value;
+        if(CPPAssembly::BsqInt::from(val).value !== '') {
+            return CPPAssembly::LiteralSimpleExpression{ val.removeSuffixString('i') };
+        }
+
+        return CPPAssembly::LiteralSimpleExpression{ val };
+    }
+
+    method transformAccessVariableExpression(exp: BSQAssembly::AccessVariableExpression): CPPAssembly::AccessVariableExpression {
+        let vname = CPPTransformNameManager::convertVarIdentifier(exp.vname);
+        let layouttype = CPPTransformNameManager::convertTypeSignature(exp.layouttype.tkeystr);
+
+        return CPPAssembly::AccessVariableExpression { vname, layouttype };
     }
 
     method transformBinaryArithExpressionToCpp(binarith: BSQAssembly::BinaryArithExpression): CPPAssembly::BinaryArithExpression {
@@ -38,6 +66,8 @@ entity CPPTransformer {
     method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
         match(expr)@ {
             BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpressionToCpp($expr); }
+            | BSQAssembly::LiteralSimpleExpression => { return this.transformLiteralSimpleExpression($expr); }
+            | BSQAssembly::AccessVariableExpression => { return this.transformAccessVariableExpression($expr); }
             | _ => { abort; }
         }
     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -10,8 +10,8 @@ namespace CPPTransformNameManager {
         return CPPAssembly::InvokeKey::from(ikey.value);
     }
 
-    function convertTypeSignature(tkey: BSQAssembly::TypeKey): CPPAssembly::TypeSignature {
-        let tk = CPPAssembly::TypeKey::from(tkey.value);
+    function convertTypeSignature(tkey: BSQAssembly::TypeSignature): CPPAssembly::TypeSignature {
+        let tk = CPPAssembly::TypeKey::from(tkey.tkeystr.value);
 
         if(tk.value === 'Int') {
             %% We will need call our overloaded int type
@@ -33,14 +33,14 @@ namespace CPPTransformNameManager {
 entity CPPTransformer {
     field bsqasm: BSQAssembly::Assembly;
 
-
     method transformBinAddExpressionToCpp(binadd: BSQAssembly::BinAddExpression): CPPAssembly::BinAddExpression {
         abort;
     }
 
-    %% Given how simple (lol) this expression is, may not need a separate method for this transform
     method transformLiteralSimpleExpression(exp: BSQAssembly::LiteralSimpleExpression): CPPAssembly::LiteralSimpleExpression {
         let val = exp.value;
+        
+        %% May be cleaner to handle in cppemit
         if(CPPAssembly::BsqInt::from(val).value !== '') {
             return CPPAssembly::LiteralSimpleExpression{ val.removeSuffixString('i') };
         }
@@ -50,7 +50,7 @@ entity CPPTransformer {
 
     method transformAccessVariableExpression(exp: BSQAssembly::AccessVariableExpression): CPPAssembly::AccessVariableExpression {
         let vname = CPPTransformNameManager::convertVarIdentifier(exp.vname);
-        let layouttype = CPPTransformNameManager::convertTypeSignature(exp.layouttype.tkeystr);
+        let layouttype = CPPTransformNameManager::convertTypeSignature(exp.layouttype);
 
         return CPPAssembly::AccessVariableExpression { vname, layouttype };
     }
@@ -73,7 +73,7 @@ entity CPPTransformer {
     }
 
     method transformReturnSingleStatementToCpp(ret: BSQAssembly::ReturnSingleStatement): CPPAssembly::ReturnSingleStatement {
-        let rtype = CPPTransformNameManager::convertTypeSignature(ret.rtype.tkeystr);
+        let rtype = CPPTransformNameManager::convertTypeSignature(ret.rtype);
         let rexp = this.transformExpressionToCpp(ret.value);
 
         return CPPAssembly::ReturnSingleStatement{rtype, rexp};
@@ -81,7 +81,7 @@ entity CPPTransformer {
 
     method transformVariableInitializationStatementToCpp(stmt: BSQAssembly::VariableInitializationStatement): CPPAssembly::VariableInitializationStatement {
         let name = CPPTransformNameManager::convertIdentifier(stmt.name);
-        let stype = CPPTransformNameManager::convertTypeSignature(stmt.vtype.tkeystr);
+        let stype = CPPTransformNameManager::convertTypeSignature(stmt.vtype);
         let cppexpr = this.transformExpressionToCpp(stmt.exp);
 
         return CPPAssembly::VariableInitializationStatement{name, stype, cppexpr};
@@ -117,11 +117,11 @@ entity CPPTransformer {
         let nskey = CPPTransformNameManager::convertNamespaceKey(decl.declaredInNS);
         let ikey = CPPTransformNameManager::convertInvokeKey(decl.ikey);
         %% Parameters
-        %% Return type
+        let res = CPPTransformNameManager::convertTypeSignature(decl.resultType);
 
         let body = this.transformBodyToCpp(decl.body);
 
-        return CPPAssembly::NamespaceFunctionDecl{nskey, decl.name.value, ikey, none, none, body};
+        return CPPAssembly::NamespaceFunctionDecl{nskey, decl.name.value, ikey, none, res, body};
     }   
 
     function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -5,19 +5,73 @@ namespace CPPTransformNameManager {
     function convertInvokeKey(ikey: BSQAssembly::InvokeKey): CPPAssembly::InvokeKey {
         return CPPAssembly::InvokeKey::from(ikey.value);
     }
+
+    function convertTypeKey(tkey: BSQAssembly::TypeKey): CPPAssembly::TypeKey {
+        return CPPAssembly::TypeKey::from(tkey.value);
+    }
 }
 
 entity CPPTransformer {
     field bsqasm: BSQAssembly::Assembly;
 
-    function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {
-        let transformer = CPPTransformer{bsqasm};
+    %% Will need more concrete method for converting to LiteralSimpleExpression from bsq. Should call transformExprCpp...
+    recursive method transformBinAddExpression(exp: BSQAssembly::BinAddExpression): CPPAssembly::TypeKey {
+        let cpptype: CPPAssembly::TypeKey = this.transformStdTypeToCpp(exp.etype);
+        let nlhs: CPPAssembly::LiteralSimpleExpression = CPPAssembly::LiteralSimpleExpression{ cpptype, exp.value };
+        let nrhs: CPPAssembly::LiteralSimpleExpression = CPPAssembly::LiteralSimpleExpression{ cpptype, exp.value };
 
-        %% let allfuncs = bsqasm.allfuncs.map<CPPAssembly::InvokeKey>(fn(ikey) => CPPTransformNameManager::convertInvokeKey(ikey));
-        let allfuncs = List<CPPAssembly::InvokeKey>{};
+        return CPPAssembly::BinAddExpression{nlhs, nrhs};
+    }
+
+    %% Likely needs more, just simple structure now
+    method transformStdTypeToCpp(vtype: BSQAssembly::TypeSignature): CPPAssembly::TypeKey {
+        return CPPTransformNameManager::convertTypeKey(vtype);
+    }
+
+    recursive method transformBinaryArithExpression(exp: BSQAssembly::BinaryArithExpression): CPPAssembly::TypeKey {
+        match(exp)@ {
+            BSQAssembly::BinAddExpression => { 
+                return this.transformBinAddExpression[recursive]($exp); 
+            }
+            | _ => { abort; }
+        }
+    }
+
+    recursive function transformExpressionToCPP(exp: BSQAssembly::Expression): CPPAssembly::TypeKey {
+        match(exp)@ {
+            BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpression($exp); }
+            | _ => { abort; }
+        }
+    }
+
+    method transformBodyToCPP(impl: BSQAssembly::BodyImplementation): CPPAssembly::Body {
+        match(impl)@ {
+            BSQAssembly::ExpressionBodyImplementation => {
+                let cppexp = this.transformExpressionToCPP($impl.exp);
+
+                return CPPAssembly::Body{ %* Stuff *% };
+            }
+        }
+    }
+
+    method transformNamespaceFunctionDeclToCPP(decl: BSQAssembly::NamespaceFunctionDecl): CPPAssembly::NamespaceFunctionDecl {
+        let body = this.transformBodyToCPP(decl.body);
+    }   
+
+    function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {
+        let transformer = CPPTransformer{ bsqasm };
+
+        let transformer_nsfuncs = bsqasm.allfuncs
+            .filter(pred(ikey) => bsqasm.nsfuncs.has(ikey))
+            .reduce<Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>>(Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>{},
+                fn(acc, ikey) => {
+                    let bsqdecl = bsqasm.nsfuncs.get(ikey);
+                    let cppdecl = transformer.transformNamespaceFunctionDeclToCPP(bsqdecl);
+                    return acc.insert(cppdecl.invokeKey, cppdecl);
+                });
 
         return CPPAssembly::Assembly {
-            allfuncs
+            nsfuncs = transformer_nsfuncs
         };
     }
 }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -2,76 +2,115 @@ namespace CPPEmitter;
 
 %% Transform Bosque names into cpp representation
 namespace CPPTransformNameManager {
+    function convertNamespaceKey(nskey: BSQAssembly::NamespaceKey): CPPAssembly::NamespaceKey {
+        return CPPAssembly::NamespaceKey::from(nskey.value);
+    }
+
     function convertInvokeKey(ikey: BSQAssembly::InvokeKey): CPPAssembly::InvokeKey {
         return CPPAssembly::InvokeKey::from(ikey.value);
     }
 
-    function convertTypeKey(tkey: BSQAssembly::TypeKey): CPPAssembly::TypeKey {
-        return CPPAssembly::TypeKey::from(tkey.value);
+    function convertTypeSignature(tkey: BSQAssembly::TypeKey): CPPAssembly::TypeSignature {
+        let tk = CPPAssembly::TypeKey::from(tkey.value);
+        return CPPAssembly::NominalTypeSignature{ tk }; %% We wont want this to ne nominal always
+    }
+
+    function convertIdentifier(nkey: BSQAssembly::Identifier): CPPAssembly::Identifier {
+        return CPPAssembly::Identifier::from(nkey.value);
     }
 }
 
 entity CPPTransformer {
     field bsqasm: BSQAssembly::Assembly;
 
-    %% Will need more concrete method for converting to LiteralSimpleExpression from bsq. Should call transformExprCpp...
-    recursive method transformBinAddExpression(exp: BSQAssembly::BinAddExpression): CPPAssembly::TypeKey {
-        let cpptype: CPPAssembly::TypeKey = this.transformStdTypeToCpp(exp.etype);
-        let nlhs: CPPAssembly::LiteralSimpleExpression = CPPAssembly::LiteralSimpleExpression{ cpptype, exp.value };
-        let nrhs: CPPAssembly::LiteralSimpleExpression = CPPAssembly::LiteralSimpleExpression{ cpptype, exp.value };
-
-        return CPPAssembly::BinAddExpression{nlhs, nrhs};
+    method transformBinAddExpressionToCpp(binadd: BSQAssembly::BinAddExpression): CPPAssembly::BinAddExpression {
+        abort;
     }
 
-    %% Likely needs more, just simple structure now
-    method transformStdTypeToCpp(vtype: BSQAssembly::TypeSignature): CPPAssembly::TypeKey {
-        return CPPTransformNameManager::convertTypeKey(vtype);
+    method transformBinaryArithExpressionToCpp(binarith: BSQAssembly::BinaryArithExpression): CPPAssembly::BinaryArithExpression {
+        match(binarith)@ {
+            BSQAssembly::BinAddExpression => { return this.transformBinAddExpressionToCpp($binarith); }
+            | BSQAssembly::BinSubExpression => { abort; } %% Eventually...
+            | _ => { abort; }
+        }
     }
 
-    recursive method transformBinaryArithExpression(exp: BSQAssembly::BinaryArithExpression): CPPAssembly::TypeKey {
-        match(exp)@ {
-            BSQAssembly::BinAddExpression => { 
-                return this.transformBinAddExpression[recursive]($exp); 
+    method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
+        match(expr)@ {
+            BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpressionToCpp($expr); }
+            | _ => { abort; }
+        }
+    }
+
+    method transformReturnSingleStatementToCpp(ret: BSQAssembly::ReturnSingleStatement): CPPAssembly::ReturnSingleStatement {
+        let rtype = CPPTransformNameManager::convertTypeSignature(ret.rtype.tkeystr);
+        let rexp = this.transformExpressionToCpp(ret.value);
+
+        return CPPAssembly::ReturnSingleStatement{rtype, rexp};
+    }
+
+    method transformVariableInitializationStatementToCpp(stmt: BSQAssembly::VariableInitializationStatement): CPPAssembly::VariableInitializationStatement {
+        let name = CPPTransformNameManager::convertIdentifier(stmt.name);
+        let stype = CPPTransformNameManager::convertTypeSignature(stmt.vtype.tkeystr);
+        let cppexpr = this.transformExpressionToCpp(stmt.exp);
+
+        return CPPAssembly::VariableInitializationStatement{name, stype, cppexpr};
+    }
+
+    method transformStatementToCpp(stmt: BSQAssembly::Statement): CPPAssembly::Statement {
+        match(stmt)@ {
+            BSQAssembly::VariableInitializationStatement => { return this.transformVariableInitializationStatementToCpp($stmt); }
+            | BSQAssembly::ReturnSingleStatement => { return this.transformReturnSingleStatementToCpp($stmt); }
+            | _ => { abort; }
+        }
+    }
+
+    method transformStatementListToCpp(stmts: List<BSQAssembly::Statement>): List<CPPAssembly::Statement> {
+        let tailop = stmts.back();
+
+        %% Need to match tailop to get return, not implemented for now
+
+        return stmts.map<CPPAssembly::Statement>(fn(stmt) => this.transformStatementToCpp(stmt));
+    }
+
+    method transformBodyToCpp(body: BSQAssembly::BodyImplementation): CPPAssembly::BodyImplementation {
+        match(body)@ {
+            BSQAssembly::StandardBodyImplementation => { 
+                let cppstmts = this.transformStatementListToCpp($body.statements);
+                return CPPAssembly::StandardBodyImplementation{ cppstmts };
             }
             | _ => { abort; }
         }
     }
 
-    recursive function transformExpressionToCPP(exp: BSQAssembly::Expression): CPPAssembly::TypeKey {
-        match(exp)@ {
-            BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpression($exp); }
-            | _ => { abort; }
-        }
-    }
+    method transformNamespaceFunctionDeclToCpp(decl: BSQAssembly::NamespaceFunctionDecl): CPPAssembly::NamespaceFunctionDecl {
+        let nskey = CPPTransformNameManager::convertNamespaceKey(decl.declaredInNS);
+        let ikey = CPPTransformNameManager::convertInvokeKey(decl.ikey);
+        %% Parameters
+        %% Return type
 
-    method transformBodyToCPP(impl: BSQAssembly::BodyImplementation): CPPAssembly::Body {
-        match(impl)@ {
-            BSQAssembly::ExpressionBodyImplementation => {
-                let cppexp = this.transformExpressionToCPP($impl.exp);
+        let body = this.transformBodyToCpp(decl.body);
 
-                return CPPAssembly::Body{ %* Stuff *% };
-            }
-        }
-    }
-
-    method transformNamespaceFunctionDeclToCPP(decl: BSQAssembly::NamespaceFunctionDecl): CPPAssembly::NamespaceFunctionDecl {
-        let body = this.transformBodyToCPP(decl.body);
+        return CPPAssembly::NamespaceFunctionDecl{nskey, decl.name.value, ikey, none, none, body};
     }   
 
     function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {
-        let transformer = CPPTransformer{ bsqasm };
+            let transformer = CPPTransformer{ bsqasm };
 
         let transformer_nsfuncs = bsqasm.allfuncs
             .filter(pred(ikey) => bsqasm.nsfuncs.has(ikey))
             .reduce<Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>>(Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>{},
                 fn(acc, ikey) => {
                     let bsqdecl = bsqasm.nsfuncs.get(ikey);
-                    let cppdecl = transformer.transformNamespaceFunctionDeclToCPP(bsqdecl);
+                    let cppdecl = transformer.transformNamespaceFunctionDeclToCpp(bsqdecl);
                     return acc.insert(cppdecl.invokeKey, cppdecl);
                 });
 
+        let transformer_allfuncs = bsqasm.allfuncs.map<CPPAssembly::InvokeKey>(fn(ikey) => CPPTransformNameManager::convertInvokeKey(ikey));
+
         return CPPAssembly::Assembly {
-            nsfuncs = transformer_nsfuncs
+            nsfuncs = transformer_nsfuncs,
+            allfuncs = transformer_allfuncs
         };
     }
 }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -1,0 +1,17 @@
+namespace CPPEmitter;
+
+entity CPPTransformer {
+    field bsqasm: BSQAssembly::Assembly;
+
+    function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {
+        let transformer = CPPTransformer{bsqasm};
+
+        %% Reference SMT Assembly approach
+
+        %% Simply testing to see if I can get a cpp file to be spat out with my includes
+        return CPPAssembly::Assembly {
+            emitIncludes(),
+            ''
+        };
+    }
+}

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -1,17 +1,22 @@
 namespace CPPEmitter;
 
+%% Transform Bosque names into cpp representation
+namespace CPPTransformNameManager {
+    function convertInvokeKey(ikey: BSQAssembly::InvokeKey): CPPAssembly::InvokeKey {
+        return CPPAssembly::InvokeKey::from(ikey.value);
+    }
+}
+
 entity CPPTransformer {
     field bsqasm: BSQAssembly::Assembly;
 
     function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {
         let transformer = CPPTransformer{bsqasm};
 
-        %% Reference SMT Assembly approach
+        let allfuncs = bsqasm.allfuncs.map<CPPAssembly::InvokeKey>(fn(ikey) => CPPTransformNameManager::convertInvokeKey(ikey));
 
-        %% Simply testing to see if I can get a cpp file to be spat out with my includes
         return CPPAssembly::Assembly {
-            emitIncludes(),
-            ''
+            allfuncs
         };
     }
 }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -13,7 +13,8 @@ entity CPPTransformer {
     function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {
         let transformer = CPPTransformer{bsqasm};
 
-        let allfuncs = bsqasm.allfuncs.map<CPPAssembly::InvokeKey>(fn(ikey) => CPPTransformNameManager::convertInvokeKey(ikey));
+        %% let allfuncs = bsqasm.allfuncs.map<CPPAssembly::InvokeKey>(fn(ikey) => CPPTransformNameManager::convertInvokeKey(ikey));
+        let allfuncs = List<CPPAssembly::InvokeKey>{};
 
         return CPPAssembly::Assembly {
             allfuncs

--- a/src/cmd/analyzecpp.ts
+++ b/src/cmd/analyzecpp.ts
@@ -42,7 +42,6 @@ function getSimpleFilename(fn: string): string {
     return path.basename(fn);
 }
 
-// Likely more work to do, for now just spits out cpp directly
 function generateCPPFile(cpp: string, outdir: string) {
     Status.output("Processing existing contents of emit.cpp...\n");
     const dir = path.normalize(outdir);

--- a/src/cmd/analyzecpp.ts
+++ b/src/cmd/analyzecpp.ts
@@ -1,27 +1,161 @@
 import * as fs from "fs";
+import { BSQIREmitter } from "../frontend/bsqir_emit.js";
+import { Assembly } from "../frontend/assembly.js";
+import { InstantiationPropagator } from "../frontend/closed_terms.js";
+import { Status } from "./status_output.js";
+import { generateASMCPP, workflowLoadUserSrc } from "./workflows.js";
 import * as path from "path";
+
 import { fileURLToPath } from 'url';
-import { Assembly } from "../frontend/assembly.js";
+import { PackageConfig } from "../frontend/build_decls.js";
+import { execSync } from "child_process";
+import { validateCStringLiteral } from "@bosque/jsbrex";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const bosque_dir: string = path.join(__dirname, "../../../");
-const outdir: string = path.join(bosque_dir, "bin/cpp");
-/*
-import { Assembly } from "../frontend/assembly.js";
+const cpp_transform_bin_path = path.join(bosque_dir, "bin/cppemit/CPPEmitter.mjs");
+const cpp_runtime_code_path = path.join(bosque_dir, "bin/cppruntime/emit.cpp");
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-const bosque_dir: string = path.join(__dirname, "../../../");
-*/
-
-// Doesnt really do much but spit out a file at outname directory for now
-// Would be good to call this generateCPPFile somewhere internally to this file
-// then export the wrapper method 
-function generateCPPFile(asm: Assembly) {
-
-
-    fs.writeFileSync(outdir, "");
+let fullargs = [...process.argv].slice(2);
+if(fullargs.length === 0) {
+    Status.error("No input files specified!\n");
+    process.exit(1);
 }
 
-export { generateCPPFile };
+let mainns = "Main";
+let mainnsidx = fullargs.findIndex((v) => v === "--namespace");
+if(mainnsidx !== -1) {
+    mainns = fullargs[mainnsidx + 1];
+    fullargs = fullargs.slice(0, mainnsidx).concat(fullargs.slice(mainnsidx + 2));
+}
+
+let outdir = path.join(path.dirname(path.resolve(fullargs[0])), "cppout");
+let outdiridx = fullargs.findIndex((v) => v === "--output");
+if(outdiridx !== -1) {
+    outdir = fullargs[outdiridx + 1];
+    fullargs = fullargs.slice(0, outdiridx).concat(fullargs.slice(outdiridx + 2));
+}
+
+function getSimpleFilename(fn: string): string {
+    return path.basename(fn);
+}
+
+// Likely more work to do, for now just spits out cpp directly
+function generateCPPFile(cpp: string, outdir: string) {
+    Status.output("Processing existing contents of emit.cpp...\n");
+    const dir = path.normalize(outdir);
+
+    Status.output("    Reading Contents of Base emit.cpp File...\n");
+    let contents: string = "";
+    try {
+        contents = fs.readFileSync(cpp_runtime_code_path).toString();
+    }
+    catch(e) {
+        Status.error("Failed to read base emit.cpp file!\n");
+    }
+    const new_contents = contents.concat(cpp);
+
+    Status.output("    Writing to emit.cpp...\n");
+    try {
+        const fname = path.join(dir, "emit.cpp");
+        fs.writeFileSync(fname, new_contents);
+    }
+    catch(e) {
+        Status.error("Failed to write to emit.cpp!\n");
+    }
+    Status.output(`    CPP emission successfun -- emitted to ${dir}\n\n`);
+}
+
+//
+// NOTE: Something quite funky is going on when I attempt to run bsqir.bsqon and output bsqon.
+// It spits out the error "ParseError -- Expected scoped type" which I have not been able to 
+// find a solution for yet...
+//
+function runCPPEmit(outname: string): string {
+    Status.output("Processing IR into CPP Code...\n");
+   
+    const nndir = path.normalize(outname);
+    let res = "";
+    try {
+        const fname = path.join(nndir, "bsqir.bsqon");
+        res = execSync(`node ${cpp_transform_bin_path} --file ${fname}`).toString();
+    }
+    catch(e) {      
+        Status.error("Failed to write bsqir info file!\n");
+    }
+
+    return validateCStringLiteral(res.slice(1, -1));
+}
+
+function buildBSQONAssembly(assembly: Assembly, rootasm: string, outname: string) {
+    Status.output("Generating Type Info assembly...\n");
+    const iim = InstantiationPropagator.computeInstantiations(assembly, rootasm);
+    const tinfo = BSQIREmitter.emitAssembly(assembly, iim);
+
+    Status.output("    Writing BSQIR to disk...\n");
+    const nndir = path.normalize(outname);
+    try {
+        const fname = path.join(nndir, "bsqir.bsqon");
+        fs.writeFileSync(fname, tinfo);
+    }
+    catch(e) {      
+        Status.error("Failed to write bsqir info file!\n");
+    }
+
+    Status.output(`    IR generation successful -- emitted to ${nndir}\n\n`);
+}
+
+function checkAssembly(srcfiles: string[]): Assembly | undefined {
+    Status.enable();
+
+    const lstart = Date.now();
+    Status.output("Loading user sources...\n");
+    const usersrcinfo = workflowLoadUserSrc(srcfiles);
+    if(usersrcinfo === undefined) {
+        Status.error("Failed to load user sources!\n");
+        return;
+    }
+    const dend = Date.now();
+    Status.output(`    User sources loaded [${(dend - lstart) / 1000}s]\n\n`);
+
+    const userpackage = new PackageConfig([], usersrcinfo)
+    const [asm, perrors, terrors] = generateASMCPP(userpackage);
+
+    if(perrors.length === 0 && terrors.length === 0) {
+        return asm;
+    }
+    else {
+        Status.error("Failed to generate assembly!\n");
+
+        //TODO -- need to do filename in error and sort nicely
+        perrors.sort((a, b) => (a.srcfile !== b.srcfile) ? a.srcfile.localeCompare(b.srcfile) : a.sinfo.line - b.sinfo.line);
+        for(let i = 0; i < perrors.length; ++i) {
+            Status.error(`Parser Error @ ${getSimpleFilename(perrors[i].srcfile)}#${perrors[i].sinfo.line}: ${perrors[i].message}\n`);
+        }
+
+        terrors.sort((a, b) => (a.file !== b.file) ? a.file.localeCompare(b.file) : a.line - b.line);
+        if(terrors.length !== 0) {
+            for(let i = 0; i < terrors.length; ++i) {
+                Status.error(`Type Error @ ${getSimpleFilename(terrors[i].file)}#${terrors[i].line}: ${terrors[i].msg}\n`);
+            }
+        }
+
+        return undefined;
+    }
+}
+
+const asm = checkAssembly(fullargs);
+if(asm === undefined) {
+    process.exit(1);
+}
+
+Status.output(`-- CPP output directory: ${outdir}\n\n`);
+
+fs.rmSync(outdir, { recursive: true, force: true });
+fs.mkdirSync(outdir);
+
+buildBSQONAssembly(asm, mainns, outdir);
+
+const cpp = runCPPEmit(outdir);
+generateCPPFile(cpp, outdir);

--- a/src/cmd/analyzecpp.ts
+++ b/src/cmd/analyzecpp.ts
@@ -14,6 +14,7 @@ import { validateCStringLiteral } from "@bosque/jsbrex";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const bosque_dir: string = path.join(__dirname, "../../../");
+const cpp_runtime_dir_path = path.join(bosque_dir, "bin/cppruntime/");
 const cpp_transform_bin_path = path.join(bosque_dir, "bin/cppemit/CPPEmitter.mjs");
 const cpp_runtime_code_path = path.join(bosque_dir, "bin/cppruntime/emit.cpp");
 
@@ -64,30 +65,14 @@ function generateCPPFile(cpp: string, outdir: string) {
     catch(e) {
         Status.error("Failed to write to emit.cpp!\n");
     }
-    Status.output(`    CPP emission successfun -- emitted to ${dir}\n\n`);
+    Status.output(`    CPP emission successful -- emitted to ${dir}\n\n`);
 }
 
-//
-// NOTE (again): I will almost 100% need to emit the correct builtin mapping for 
-// our char buffers creation. Likely in JSEmitter.
-//
-
-//
-// NOTE (again again): May want to include the runtime headers from this file, not emitter
-//
-
-//
-// NOTE: Something quite funky is going on when I attempt to run bsqir.bsqon and output bsqon.
-// It spits out the error "ParseError -- Expected scoped type" which I have not been able to 
-// find a solution for yet...
-//
-// Turns out the issue was related to using lists in our cpp emission! for now just deal with basic arithmetic
-//
 function runCPPEmit(outname: string): string {
     Status.output("Processing IR into CPP Code...\n");
    
     const nndir = path.normalize(outname);
-    let res = "";
+    let res = ``;
     try {
         const fname = path.join(nndir, "bsqir.bsqon");
         res = execSync(`node ${cpp_transform_bin_path} --file ${fname}`).toString();
@@ -96,7 +81,7 @@ function runCPPEmit(outname: string): string {
         Status.error("Failed to write bsqir info file!\n");
     }
 
-    return validateCStringLiteral(res.slice(1, -1));
+    return `#include "${cpp_runtime_dir_path}cppruntime.hpp"\n\n` + validateCStringLiteral(res.slice(1, -2));
 }
 
 function buildBSQONAssembly(assembly: Assembly, rootasm: string, outname: string) {

--- a/src/cmd/analyzecpp.ts
+++ b/src/cmd/analyzecpp.ts
@@ -1,9 +1,14 @@
 import * as fs from "fs";
-
-/*
-import { Assembly } from "../frontend/assembly.js";
 import * as path from "path";
 import { fileURLToPath } from 'url';
+import { Assembly } from "../frontend/assembly.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const bosque_dir: string = path.join(__dirname, "../../../");
+const outdir: string = path.join(bosque_dir, "bin/cpp");
+/*
+import { Assembly } from "../frontend/assembly.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -13,10 +18,10 @@ const bosque_dir: string = path.join(__dirname, "../../../");
 // Doesnt really do much but spit out a file at outname directory for now
 // Would be good to call this generateCPPFile somewhere internally to this file
 // then export the wrapper method 
-function generateCPPFile(cppcomponents: string, outname: string) {
-    let code: string = cppcomponents;
+function generateCPPFile(asm: Assembly) {
 
-    fs.writeFileSync(outname, code);
+
+    fs.writeFileSync(outdir, "");
 }
 
 export { generateCPPFile };

--- a/src/cmd/analyzecpp.ts
+++ b/src/cmd/analyzecpp.ts
@@ -1,0 +1,22 @@
+import * as fs from "fs";
+
+/*
+import { Assembly } from "../frontend/assembly.js";
+import * as path from "path";
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const bosque_dir: string = path.join(__dirname, "../../../");
+*/
+
+// Doesnt really do much but spit out a file at outname directory for now
+// Would be good to call this generateCPPFile somewhere internally to this file
+// then export the wrapper method 
+function generateCPPFile(cppcomponents: string, outname: string) {
+    let code: string = cppcomponents;
+
+    fs.writeFileSync(outname, code);
+}
+
+export { generateCPPFile };

--- a/src/cmd/analyzecpp.ts
+++ b/src/cmd/analyzecpp.ts
@@ -68,9 +68,20 @@ function generateCPPFile(cpp: string, outdir: string) {
 }
 
 //
+// NOTE (again): I will almost 100% need to emit the correct builtin mapping for 
+// our char buffers creation. Likely in JSEmitter.
+//
+
+//
+// NOTE (again again): May want to include the runtime headers from this file, not emitter
+//
+
+//
 // NOTE: Something quite funky is going on when I attempt to run bsqir.bsqon and output bsqon.
 // It spits out the error "ParseError -- Expected scoped type" which I have not been able to 
 // find a solution for yet...
+//
+// Turns out the issue was related to using lists in our cpp emission! for now just deal with basic arithmetic
 //
 function runCPPEmit(outname: string): string {
     Status.output("Processing IR into CPP Code...\n");

--- a/src/cmd/workflows.ts
+++ b/src/cmd/workflows.ts
@@ -104,6 +104,11 @@ function generateASMSMT(usercode: PackageConfig): [Assembly | undefined, ParserE
     return generateASMGeneral(usercode, ["SMT_LIBS"]);
 }
 
+// We MAY want to create separate core files for cpp explicitly to easily make stuff built in, ok for now
+function generateASMCPP(usercode: PackageConfig): [Assembly | undefined, ParserError[], TypeError[]]{
+    return generateASMGeneral(usercode, ["EXEC_LIBS"])
+}
+
 export { 
-    workflowLoadUserSrc, workflowLoadCoreSrc, workflowLoadAllSrc, generateASM, generateASMSMT
+    workflowLoadUserSrc, workflowLoadCoreSrc, workflowLoadAllSrc, generateASM, generateASMSMT, generateASMCPP
 };


### PR DESCRIPTION
We are now able to emit very simple functions and variable initialization. I have not overloaded primitive types yet, so some of this code will need to be changed in the future, but I figured it would be good to get a naive approach working first.

As of now we are able to transform a bosque file like so:
```
declare namespace Main;

public function main(): Int {
    let xyz: Int = 1i;
    return xyz;
}
```

Into:
```
#include "/home/stub/repos/BosqueCore/bin/cppruntime/cppruntime.hpp"

int main() {
int64_t xyz = 1;
return xyz;
}
```