### PR TITLE
Binary arithmetic, numeric comparisons, overloaded backend cpp emission

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -47,6 +47,8 @@ datatype BinaryArithExpression provides Expression using {
 of
 BinAddExpression { }
 | BinSubExpression { }
+| BinDivExpression { }
+| BinMultExpression { }
 ;
 
 datatype BodyImplementation 

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -41,6 +41,8 @@ entity LiteralSimpleExpression provides Expression {
 }
 
 datatype BinaryArithExpression provides Expression using {
+    %% Need opertype?
+
     field lhs: Expression;
     field rhs: Expression;
 }
@@ -50,6 +52,34 @@ BinAddExpression { }
 | BinDivExpression { }
 | BinMultExpression { }
 ;
+
+datatype BinaryNumericExpression provides Expression using {
+    %% Need opertype?
+    
+    field lhs: Expression;
+    field rhs: Expression;
+}
+of
+NumericEqExpression { }
+| NumericNeqExpression { }
+| NumericLessExpression { }
+| NumericLessEqExpression { }
+| NumericGreaterExpression { }
+| NumericGreaterEqExpression { }
+;
+
+%*
+datatype BinLogicExpression provides Expression using {
+    field lhs: Expression;
+    field rhs: Expression;
+}
+of
+BinLogicAndExpression { }
+| BinLogicOrExpression { }
+| BinLogicImpliesExpression { }
+| BinLogicIFFExpression { }
+;
+*%
 
 datatype BodyImplementation 
 of

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -11,6 +11,7 @@ VoidTypeSignature { }
 ;
 
 concept Expression {
+    field etype: TypeSignature;
 }
 
 concept Operation {

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -30,6 +30,13 @@ const videntifierRE: CRegex = /'$'?[_a-z][_a-zA-Z0-9$]*/c; %%we allow & inside t
 type Identifier = CString of CPPAssembly::identifierRE;
 type VarIdentifier = CString of CPPAssembly::videntifierRE;
 
+%* 
+entity NamespaceConstDecl provides AbstractCoreDecl {
+    field declaredType: TypeSignature;
+    field value: Expression;
+}
+*%
+
 %% May want to change this as it doesnt map super well to bsqir (but maps nice to how smtemit)
 entity NamespaceFunctionDecl {
     field ns: NamespaceKey;
@@ -46,6 +53,6 @@ entity NamespaceFunctionDecl {
 
 %% Will need expanding
 entity Assembly {
-    field nsfuncs: Map<InvokeKey, NamespaceFunctionDecl>;
+    field nsfuncs: Map<NamespaceKey, Map<InvokeKey, NamespaceFunctionDecl>>;
     field allfuncs: List<InvokeKey>;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -12,7 +12,9 @@ const namespaceKeyRE: CRegex = /(${CPPAssembly::namespaceComponentRE}'::')*${CPP
 type NamespaceComponentKey = CString of CPPAssembly::namespaceComponentRE;
 type NamespaceKey = CString of CPPAssembly::namespaceKeyRE; %%Core is implicit here
 
-const basicNominalTypeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}'::')?[_a-zA-Z0-9]+('<'.+'>')?/c;
+%% NOTE: The RE in basic nominal... allows for '::' to be detected. this is because we overload primitives and need access
+%% to matching our __CoreCpp namespace
+const basicNominalTypeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}'::')?[_a-zA-Z0-9'::']+('<'.+'>')?/c;
 const nominalTypeKeyRE: CRegex = /(${CPPAssembly::basicNominalTypeKeyRE})/c; %% Will need to handle special scoped type key?
 
 %% For converting bsq value representation to cpp

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -17,10 +17,6 @@ type NamespaceKey = CString of CPPAssembly::namespaceKeyRE; %%Core is implicit h
 const basicNominalTypeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}'::')?[_a-zA-Z0-9'::']+('<'.+'>')?/c;
 const nominalTypeKeyRE: CRegex = /(${CPPAssembly::basicNominalTypeKeyRE})/c; %% Will need to handle special scoped type key?
 
-%% For converting bsq value representation to cpp
-const bsqIntValue: CRegex = /[0-9]+'i'/c;
-type BsqInt = CString of CPPAssembly::bsqIntValue;
-
 const typeKeyRE: CRegex = /${CPPAssembly::nominalTypeKeyRE}/c;
 type TypeKey = CString of CPPAssembly::typeKeyRE;
 

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -18,9 +18,12 @@ public:
     // We overload literal "_i" to easily match our types
     static constexpr Int from_literal(int64_t v) { return Int(v); }
 
-    // TODO: Overload any operators in Int
+    // Overloaded operations on Int
+    constexpr Int operator+(Int const& i1) { return Int(value + i1.value); }
+    constexpr Int operator-(Int const& i1) { return Int(value - i1.value); }
+    constexpr Int operator/(Int const& i1) { return Int(value / i1.value); }
+    constexpr Int operator*(Int const& i1) { return Int(value * i1.value); }
 };
-constexpr Int operator"" _i(unsigned long long v);
 
 // Unsigned 63 bit value
 class Nat {
@@ -33,9 +36,12 @@ public:
     // We overload literal "_i" to easily match our types
     static constexpr Nat from_literal(int64_t v) { return Nat(v); }
 
-    // TODO: Overload any operators in Nat 
+    // Overloaded operators on Nat
+    constexpr Nat operator+(Nat const& i1) { return Nat(value + i1.value); }
+    constexpr Nat operator-(Nat const& i1) { return Nat(value - i1.value); }
+    constexpr Nat operator/(Nat const& i1) { return Nat(value / i1.value); }
+    constexpr Nat operator*(Nat const& i1) { return Nat(value * i1.value); }
 };
-constexpr Nat operator"" _n(unsigned long long v);
 
 //
 // TODO: Figure out representation for BigNat, BigInt, Float
@@ -85,7 +91,5 @@ struct UnicodeCharBuffer {
 
 } // namespace __CoreCpp
 
-// We MAY want to define these in cppruntime.cpp, leaving here for now
-// Overloading of numeric tags at global scope
-constexpr __CoreCpp::Int operator"" _i(unsigned long long v) { return __CoreCpp::Int::from_literal(static_cast<int64_t>(v)); }
-constexpr __CoreCpp::Nat operator"" _n(unsigned long long v) { return __CoreCpp::Nat::from_literal(static_cast<int64_t>(v)); }
+constexpr __CoreCpp::Int operator"" _i(unsigned long long v) { return __CoreCpp::Int::from_literal(static_cast<int64_t>(v)); }; 
+constexpr __CoreCpp::Nat operator"" _n(unsigned long long v) { return __CoreCpp::Nat::from_literal(static_cast<int64_t>(v)); };

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -30,8 +30,8 @@ constexpr bool is_valid_bignat(__uint128_t val) {
 }
 
 //
-// Note: It appears that due to the nature of our builtin arithmetic operations, we are unable to catch
-// any overflow errors at compile time. This might be fine - if we need to be able to detect at compile
+// Note: It appears that our builtin arithmetic operations do not evaluate at compile time (not 100% but seems to be the case).
+// This is why I decided to throw runtime errors. This might be fine - if we need to be able to detect at compile
 // time we will likely need to add custom overflow checking functions.
 //
 
@@ -42,7 +42,7 @@ public:
     constexpr Int() noexcept : value(0) {};
     constexpr explicit Int(int64_t val) : value(val){ 
         if(!is_valid_int(val)) {
-            throw std::runtime_error("Invalid size for 63 bit int literal!\n");
+            throw std::runtime_error("Invalid size for 63 bit signed integer!\n");
         }
     }; 
 
@@ -50,32 +50,29 @@ public:
     constexpr Int operator+(Int const& rhs) { 
         int64_t res = 0;
         if(__builtin_add_overflow(value, rhs.value, &res)) {
-            throw std::runtime_error("Overflow detected on addition of two 63 bit integers!\n");
+            throw std::runtime_error("Overflow detected on addition of two 63 bit signed integers!\n");
         }
 
         return Int(res);
     }
-    constexpr Int operator-() { // Negation 
-        return Int(value);
-    }
     constexpr Int operator-(Int const& rhs) { 
         int64_t res = 0;
         if(__builtin_sub_overflow(value, rhs.value, &res)) {
-            throw std::runtime_error("Overflow detected on subtraction of two 63 bit integers!\n");
+            throw std::runtime_error("Overflow detected on subtraction of two 63 bit signed integers!\n");
         }
         return Int(res);
     }
     constexpr Int operator/(Int const& rhs) {
         int64_t res = 0;
         if(rhs.value == 0 || (value == MIN_BSQ_INT && rhs.value == -1)) {
-            throw std::runtime_error("Overflow detected on division of two 63 bit integers!\n");
+            throw std::runtime_error("Overflow detected on division of two 63 bit signed integers!\n");
         }
         return Int(value / rhs.value);
     }
     constexpr Int operator*(Int const& rhs) {
         int64_t res = 0;
         if(__builtin_mul_overflow(value, rhs.value, &res)) {
-            throw std::runtime_error("Overflow detected on multiplication of two 63 bit integers!\n");
+            throw std::runtime_error("Overflow detected on multiplication of two 63 bit signed integers!\n");
         }
         return Int(res);
     }
@@ -122,14 +119,14 @@ public:
     // Used when constructing from bosque code
     constexpr explicit BigInt(const char* val) : value(to_int128(val)) {
         if(!is_valid_bigint(value)) {
-            throw std::runtime_error("Invalid size for 127 bit int literal!\n");
+            throw std::runtime_error("Invalid size for 127 bit signed integer!\n");
         }
     };
 
     // Used with our arithmetic operators
     constexpr explicit BigInt(__int128_t val) : value(val) {
         if(!is_valid_bigint(val)) {
-            throw std::runtime_error("Invalid size for 127 bit int literal!\n");
+            throw std::runtime_error("Invalid size for 127 bit signed integer!\n");
         }
     }; 
 
@@ -137,7 +134,7 @@ public:
     constexpr BigInt operator+(BigInt const& rhs) { 
         __int128_t res = 0;
         if(__builtin_add_overflow(value, rhs.value, &res)) {
-            throw std::runtime_error("Overflow detected on addition of two 127 bit integers!\n");
+            throw std::runtime_error("Overflow detected on addition of two 127 bit signed integers!\n");
         }
 
         return BigInt(res);
@@ -145,7 +142,7 @@ public:
     constexpr BigInt operator-(BigInt const& rhs) {
         __int128_t res = 0;
         if(__builtin_sub_overflow(value, rhs.value, &res)) {
-            throw std::runtime_error("Overflow detected on subtraction of two 127 bit integers!\n");
+            throw std::runtime_error("Overflow detected on subtraction of two 127 bit signed integers!\n");
         }
 
         return BigInt(res);
@@ -153,14 +150,14 @@ public:
     constexpr BigInt operator/(BigInt const& rhs) {
         __int128_t res = 0;
         if(rhs.value == 0 || (value == MIN_BSQ_BIGINT && rhs.value == -1)) {
-            throw std::runtime_error("Overflow detected on division of two 127 bit integers!\n");
+            throw std::runtime_error("Overflow detected on division of two 127 bit signed integers!\n");
         }
         return BigInt(value / rhs.value);
     }
     constexpr BigInt operator*(BigInt const& rhs) {
         __int128_t res = 0;
         if(__builtin_mul_overflow(value, rhs.value, &res)) {
-            throw std::runtime_error("Overflow detected on multiplication of two 127 bit integers!\n");
+            throw std::runtime_error("Overflow detected on multiplication of two 127 bit signed integers!\n");
         }
 
         return BigInt(res);
@@ -180,7 +177,7 @@ public:
     constexpr Nat() noexcept : value(0) {};
     constexpr explicit Nat(uint64_t val) : value(val) {
         if(!is_valid_nat(val)) {
-            throw std::runtime_error("Invalid size for 63 bit nat literal!\n");
+            throw std::runtime_error("Invalid size for 63 bit unsigned integer!\n");
         }
     }; 
 
@@ -307,7 +304,6 @@ public:
         } 
     }
 
-    // "_f" prefix is overloaded to call from_literal 
     static constexpr Float from_literal(double v) { return Float(v); }
 
     // Overloaded operators on float

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -3,7 +3,24 @@
 #include <stdint.h>
 #include <iostream>
 
+#define BIT_MASK (0x7FFFFFFFFFFFFFF)
+
 namespace __CoreCpp {
+
+class Int63 {
+    int64_t value;
+    constexpr explicit Int63(int64_t val) : value(val & BIT_MASK) {}; 
+public:
+    constexpr Int63() noexcept : value(0) {};
+    constexpr int64_t get() const noexcept { return value; }
+
+    // We overload literal "_i" to easily match our types
+    static constexpr Int63 from_literal(int64_t v) { return Int63(v); }
+
+    // TODO: Overload any operators in Int63
+};
+
+constexpr Int63 operator"" _i(unsigned long long v);
 
 // Useful for keeping track of path in tree iteration
 struct PathStack {
@@ -48,3 +65,6 @@ struct UnicodeCharBuffer {
 };
 
 } // namespace __CoreCpp
+
+// Overloading of numeric tags at global scope
+constexpr __CoreCpp::Int63 operator"" _i(unsigned long long v) { return __CoreCpp::Int63::from_literal(static_cast<int64_t>(v)); }

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -7,20 +7,39 @@
 
 namespace __CoreCpp {
 
-class Int63 {
+// Signed 63 bit value
+class Int {
     int64_t value;
-    constexpr explicit Int63(int64_t val) : value(val & BIT_MASK) {}; 
+    constexpr explicit Int(int64_t val) : value(val & BIT_MASK) {}; 
 public:
-    constexpr Int63() noexcept : value(0) {};
+    constexpr Int() noexcept : value(0) {};
     constexpr int64_t get() const noexcept { return value; }
 
     // We overload literal "_i" to easily match our types
-    static constexpr Int63 from_literal(int64_t v) { return Int63(v); }
+    static constexpr Int from_literal(int64_t v) { return Int(v); }
 
-    // TODO: Overload any operators in Int63
+    // TODO: Overload any operators in Int
 };
+constexpr Int operator"" _i(unsigned long long v);
 
-constexpr Int63 operator"" _i(unsigned long long v);
+// Unsigned 63 bit value
+class Nat {
+    uint64_t value;
+    constexpr explicit Nat(uint64_t val) : value(val & BIT_MASK) {}; 
+public:
+    constexpr Nat() noexcept : value(0) {};
+    constexpr int64_t get() const noexcept { return value; }
+
+    // We overload literal "_i" to easily match our types
+    static constexpr Nat from_literal(int64_t v) { return Nat(v); }
+
+    // TODO: Overload any operators in Nat 
+};
+constexpr Nat operator"" _n(unsigned long long v);
+
+//
+// TODO: Figure out representation for BigNat, BigInt, Float
+//
 
 // Useful for keeping track of path in tree iteration
 struct PathStack {
@@ -66,5 +85,7 @@ struct UnicodeCharBuffer {
 
 } // namespace __CoreCpp
 
+// We MAY want to define these in cppruntime.cpp, leaving here for now
 // Overloading of numeric tags at global scope
-constexpr __CoreCpp::Int63 operator"" _i(unsigned long long v) { return __CoreCpp::Int63::from_literal(static_cast<int64_t>(v)); }
+constexpr __CoreCpp::Int operator"" _i(unsigned long long v) { return __CoreCpp::Int::from_literal(static_cast<int64_t>(v)); }
+constexpr __CoreCpp::Nat operator"" _n(unsigned long long v) { return __CoreCpp::Nat::from_literal(static_cast<int64_t>(v)); }

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -23,6 +23,12 @@ public:
     constexpr Int operator-(Int const& i1) { return Int(value - i1.value); }
     constexpr Int operator/(Int const& i1) { return Int(value / i1.value); }
     constexpr Int operator*(Int const& i1) { return Int(value * i1.value); }
+    constexpr bool operator==(Int const& i1) const { return value == i1.value; }
+    constexpr bool operator!=(Int const& i1) const { return value != i1.value; }
+    constexpr bool operator<(Int const& i1) const { return value < i1.value; }
+    constexpr bool operator<=(Int const& i1) const { return value <= i1.value; }
+    constexpr bool operator>(Int const& i1) const { return value > i1.value; }
+    constexpr bool operator>=(Int const& i1) const { return value >= i1.value; }
 };
 
 // Unsigned 63 bit value
@@ -41,6 +47,12 @@ public:
     constexpr Nat operator-(Nat const& i1) { return Nat(value - i1.value); }
     constexpr Nat operator/(Nat const& i1) { return Nat(value / i1.value); }
     constexpr Nat operator*(Nat const& i1) { return Nat(value * i1.value); }
+    constexpr bool operator==(Nat const& i1) const { return value == i1.value; }
+    constexpr bool operator!=(Nat const& i1) const { return value != i1.value; }
+    constexpr bool operator<(Nat const& i1) const { return value < i1.value; }
+    constexpr bool operator<=(Nat const& i1) const { return value <= i1.value; }
+    constexpr bool operator>(Nat const& i1) const { return value > i1.value; }
+    constexpr bool operator>=(Nat const& i1) const { return value >= i1.value; }
 };
 
 //

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <iostream>
 
 namespace __CoreCpp {
 

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -2,20 +2,39 @@
 
 #include <stdint.h>
 #include <iostream>
-
-#define BIT_MASK (0x7FFFFFFFFFFFFFF)
+#include <cmath>
 
 namespace __CoreCpp {
+
+constexpr bool is_valid_int(int64_t val) {
+    return ((val >= -(1LL << 62)) && (val <= (1LL << 62) - 1));
+}
+
+constexpr bool is_valid_bigint(__int128_t val) {
+    return ((val >= -(__int128_t(1) << 126)) && (val <= (__int128_t(1) << 126) - 1));
+}
+
+constexpr bool is_valid_nat(uint64_t val) {
+    return (val <= (1ULL << 63) - 1);
+}
+
+constexpr bool is_valid_bignat(__uint128_t val) {
+    return (val <= (__uint128_t(1) << 127) - 1);
+}
 
 // Signed 63 bit value
 class Int {
     int64_t value;
-    constexpr explicit Int(int64_t val) : value(val & BIT_MASK) {}; 
+    constexpr explicit Int(int64_t val) : value(val){ 
+        if(!is_valid_int(val)) {
+            throw std::runtime_error("Invalid size for 63 bit int literal!\n");
+        }
+    }; 
 public:
     constexpr Int() noexcept : value(0) {};
     constexpr int64_t get() const noexcept { return value; }
 
-    // We overload literal "_i" to easily match our types
+    // "_i" postfix is overloaded to call from_literal
     static constexpr Int from_literal(int64_t v) { return Int(v); }
 
     // Overloaded operations on Int
@@ -31,15 +50,47 @@ public:
     constexpr bool operator>=(Int const& i1) const { return value >= i1.value; }
 };
 
+// Signed 127 bit value
+class BigInt {
+    __int128_t value;
+    constexpr explicit BigInt(int64_t val) : value(val){ 
+        if(!is_valid_bigint(val)) {
+            throw std::runtime_error("Invalid size for 127 bit int literal!\n");
+        }
+    }; 
+public:
+    constexpr BigInt() noexcept : value(0) {};
+    constexpr __int128_t get() const noexcept { return value; }
+
+    // "_I" postfix is overloaded to call from_literal
+    static constexpr BigInt from_literal(__int128_t v) { return BigInt(v); }
+
+    // Overloaded operators on BigInt 
+    constexpr BigInt operator+(BigInt const& i1) { return BigInt(value + i1.value); }
+    constexpr BigInt operator-(BigInt const& i1) { return BigInt(value - i1.value); }
+    constexpr BigInt operator/(BigInt const& i1) { return BigInt(value / i1.value); }
+    constexpr BigInt operator*(BigInt const& i1) { return BigInt(value * i1.value); }
+    constexpr bool operator==(BigInt const& i1) const { return value == i1.value; }
+    constexpr bool operator!=(BigInt const& i1) const { return value != i1.value; }
+    constexpr bool operator<(BigInt const& i1) const { return value < i1.value; }
+    constexpr bool operator<=(BigInt const& i1) const { return value <= i1.value; }
+    constexpr bool operator>(BigInt const& i1) const { return value > i1.value; }
+    constexpr bool operator>=(BigInt const& i1) const { return value >= i1.value; }
+};
+
 // Unsigned 63 bit value
 class Nat {
     uint64_t value;
-    constexpr explicit Nat(uint64_t val) : value(val & BIT_MASK) {}; 
+    constexpr explicit Nat(uint64_t val) : value(val) {
+        if(!is_valid_nat(val)) {
+            throw std::runtime_error("Invalid size for 63 bit nat literal!\n");
+        }
+    }; 
 public:
     constexpr Nat() noexcept : value(0) {};
     constexpr int64_t get() const noexcept { return value; }
 
-    // We overload literal "_i" to easily match our types
+    // "_n" postfix is overloaded to call from_literal
     static constexpr Nat from_literal(int64_t v) { return Nat(v); }
 
     // Overloaded operators on Nat
@@ -55,9 +106,62 @@ public:
     constexpr bool operator>=(Nat const& i1) const { return value >= i1.value; }
 };
 
-//
-// TODO: Figure out representation for BigNat, BigInt, Float
-//
+// Unsigned 127 bit value
+class BigNat {
+    __uint128_t value;
+    constexpr explicit BigNat(__uint128_t val) : value(val) {
+        if(!is_valid_bignat(val)) {
+            throw std::runtime_error("Invalid size for 127 bit nat literal!\n");
+        }
+    }; 
+public:
+    constexpr BigNat() noexcept : value(0) {};
+    constexpr __uint128_t get() const noexcept { return value; }
+
+    // "_N" postfix is overloaded to call from_literal
+    static constexpr BigNat from_literal(__uint128_t v) { return BigNat(v); }
+
+    // Overloaded operators on BigNat
+    constexpr BigNat operator+(BigNat const& i1) { return BigNat(value + i1.value); }
+    constexpr BigNat operator-(BigNat const& i1) { return BigNat(value - i1.value); }
+    constexpr BigNat operator/(BigNat const& i1) { return BigNat(value / i1.value); }
+    constexpr BigNat operator*(BigNat const& i1) { return BigNat(value * i1.value); }
+    constexpr bool operator==(BigNat const& i1) const { return value == i1.value; }
+    constexpr bool operator!=(BigNat const& i1) const { return value != i1.value; }
+    constexpr bool operator<(BigNat const& i1) const { return value < i1.value; }
+    constexpr bool operator<=(BigNat const& i1) const { return value <= i1.value; }
+    constexpr bool operator>(BigNat const& i1) const { return value > i1.value; }
+    constexpr bool operator>=(BigNat const& i1) const { return value >= i1.value; }
+};
+
+// Are runtime checks necessary here?
+// 64 bit base 2 floats
+class Float {
+    double value;
+    constexpr explicit Float(double val) : value(val) { 
+        if(!std::isfinite(val)) { 
+            throw std::runtime_error("Bosque Float does now allow NAN/Infinity!\n");
+        } 
+    }
+public:
+    constexpr Float() noexcept : value(0) {};
+    constexpr double get() const noexcept { return value; }
+
+    // "_f" prefix is overloaded to call from_literal 
+    static constexpr Float from_literal(double v) { return Float(v); }
+
+    // Overloaded operators on float
+    constexpr Float operator+(Float const& i1) { return Float(value + i1.value); }
+    constexpr Float operator-(Float const& i1) { return Float(value - i1.value); }
+    constexpr Float operator/(Float const& i1) { return Float(value / i1.value); }
+    constexpr Float operator*(Float const& i1) { return Float(value * i1.value); }
+    constexpr bool operator==(Float const& i1) const { return value == i1.value; }
+    constexpr bool operator!=(Float const& i1) const { return value != i1.value; }
+    constexpr bool operator<(Float const& i1) const { return value < i1.value; }
+    constexpr bool operator<=(Float const& i1) const { return value <= i1.value; }
+    constexpr bool operator>(Float const& i1) const { return value > i1.value; }
+    constexpr bool operator>=(Float const& i1) const { return value >= i1.value; }
+};
 
 // Useful for keeping track of path in tree iteration
 struct PathStack {
@@ -103,5 +207,8 @@ struct UnicodeCharBuffer {
 
 } // namespace __CoreCpp
 
-constexpr __CoreCpp::Int operator"" _i(unsigned long long v) { return __CoreCpp::Int::from_literal(static_cast<int64_t>(v)); }; 
+constexpr __CoreCpp::Int operator"" _i(unsigned long long v) { return __CoreCpp::Int::from_literal(static_cast<int64_t>(v)); };
+constexpr __CoreCpp::BigInt operator"" _I(unsigned long long v) { return __CoreCpp::BigInt::from_literal(static_cast<__int128_t>(v)); }; 
 constexpr __CoreCpp::Nat operator"" _n(unsigned long long v) { return __CoreCpp::Nat::from_literal(static_cast<int64_t>(v)); };
+constexpr __CoreCpp::BigNat operator"" _N(unsigned long long v) { return __CoreCpp::BigNat::from_literal(static_cast<__uint128_t>(v)); };
+constexpr __CoreCpp::Float operator"" _f(long double v) { return __CoreCpp::Float::from_literal(static_cast<double>(v)); };

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -300,7 +300,7 @@ public:
     constexpr Float() noexcept : value(0) {};
      constexpr explicit Float(double val) : value(val) { 
         if(!std::isfinite(val)) { 
-            throw std::runtime_error("Bosque Float does now allow NAN/Infinity!\n");
+            throw std::runtime_error("Bosque Float does not allow NAN/Infinity!\n");
         } 
     }
 

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -1,0 +1,4 @@
+int main() {
+
+    return 0;
+}

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -1,7 +1,7 @@
 int main() {
     // Calling our emitted main is hardcoded for now
     auto bsq_main = Main::main();
-    std::cout << bsq_main.get() << std::endl;
+    std::cout << bsq_main.get() << std::endl; // (this cout wont scale)
 
     return 0;
 }

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -1,7 +1,9 @@
 int main() {
     // Calling our emitted main is hardcoded for now
-    auto bsq_main = Main::main();
-    std::cout << bsq_main.get() << std::endl; // We will need a better way to print for all types
+    Main::main();
+
+    // We may want some way to convert what Main::main spits out into 
+    // a string and write to cout
 
     return 0;
 }

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -1,7 +1,7 @@
 int main() {
     // Calling our emitted main is hardcoded for now
     auto bsq_main = Main::main();
-    std::cout << bsq_main.get() << std::endl; // (this cout wont scale)
+    std::cout << bsq_main.get() << std::endl; // We will need a better way to print for all types
 
     return 0;
 }

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -1,4 +1,9 @@
 int main() {
+    if(setjmp(__CoreCpp::info.error_handler)) {
+        std::cout << "Over/underflow detected!" << std::endl;
+        return EXIT_FAILURE;
+    }
+
     // Calling our emitted main is hardcoded for now
     Main::main();
 

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -1,7 +1,7 @@
 int main() {
     // Calling our emitted main is hardcoded for now
     auto bsq_main = Main::main();
-    std::cout << bsq_main << std::endl;
+    std::cout << bsq_main.get() << std::endl;
 
     return 0;
 }

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -1,4 +1,7 @@
 int main() {
+    // Calling our emitted main is hardcoded for now
+    auto bsq_main = Main::main();
+    std::cout << bsq_main << std::endl;
 
     return 0;
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -57,7 +57,10 @@ function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression):
     %% We may want to make this matching a tad nicer, although not too bad as is 
     switch(exp.etype.tkeystr.value) {
         '__CoreCpp::Int' => { return CString::concat(exp.value, '_i'); }
+        | '__CoreCpp::BigInt' => { return CString::concat(exp.value, '_I'); } 
         | '__CoreCpp::Nat' => { return CString::concat(exp.value, '_n'); }
+        | '__CoreCpp::BigNat' => { return CString::concat(exp.value, '_N'); }
+        | '__CoreCpp::Float' => { return CString::concat(exp.value, '_f'); }
         | 'bool' => { return exp.value; }
         | _ => { abort; }
     }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -54,7 +54,12 @@ function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): CString {
 }
 
 function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression): CString {
-    return exp.value;
+    %% May want to store type in our literals to make matching nicer...
+    if(exp.value === '__CoreCpp::Int63') {
+        return CString::concat(exp.value, '_i');
+    }
+         return CString::concat(exp.value, '_i');
+
 }
 
 function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression): CString {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -62,11 +62,12 @@ function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression
     return emitVarIdentifier(exp.vname);
 }
 
-function emitReturnSingleStatement(ret: CPPAssembly::ReturnSingleStatement): CString {
+function emitReturnSingleStatement(ret: CPPAssembly::ReturnSingleStatement, indent: CString): CString {
     %% let rtype = emitTypeSignature(ret.rtype);
     let exp = emitExpression(ret.value);
 
-    return CString::concat('return ', exp, ';%n;');
+    let full_indent: CString = CString::concat(indent, '    ');
+    return CString::concat(full_indent, 'return ', exp, ';%n;');
 }
 
 recursive function emitBinAddExpression(add: CPPAssembly::BinAddExpression): CString {
@@ -98,40 +99,41 @@ function emitExpression(e: CPPAssembly::Expression): CString {
     }
 }
 
-function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitializationStatement): CString {
+function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitializationStatement, indent: CString): CString {
     let name = emitIdentifier(stmt.name);
     let stype = emitTypeSignature(stmt.vtype);
     let exp = emitExpression(stmt.exp);
 
-    return CString::concat(stype, ' ', name, ' = ', exp, ';');
+    let full_indent: CString = CString::concat(indent, '    ', stype); %% List constructor size max 6
+    return CString::concat(full_indent, ' ', name, ' = ', exp, ';');
 }
 
-function emitStatement(stmt: CPPAssembly::Statement): CString {
+function emitStatement(stmt: CPPAssembly::Statement, indent: CString): CString {
     match(stmt)@ {
-        CPPAssembly::VariableInitializationStatement => { return emitVariableInitializationStatement($stmt); }
-        | CPPAssembly::ReturnSingleStatement => { return emitReturnSingleStatement($stmt); }
+        CPPAssembly::VariableInitializationStatement => { return emitVariableInitializationStatement($stmt, indent); }
+        | CPPAssembly::ReturnSingleStatement => { return emitReturnSingleStatement($stmt, indent); }
         | _ => { abort; }
     }
 }
 
-function emitStandardBodyImplementation(body: CPPAssembly::StandardBodyImplementation): CString {
-    return CString::joinAll('%n;', body.statements.map<CString>(fn(stmt) => emitStatement(stmt)));
+function emitStandardBodyImplementation(body: CPPAssembly::StandardBodyImplementation, indent: CString): CString {
+    return CString::joinAll('%n;', body.statements.map<CString>(fn(stmt) => emitStatement(stmt, indent)));
 }
 
-function emitBodyImplementation(body: CPPAssembly::BodyImplementation): CString {
+function emitBodyImplementation(body: CPPAssembly::BodyImplementation, indent: CString): CString {
     match(body)@ {
         %% CPPAssembly::AbstractBodyImplementation => { abort; }
         %% | CPPAssembly::PredicateUFBodyImplementation => { abort; }
         %% | CPPAssembly::BuiltinBodyImplementation => { abort; }
         %% | CPPAssembly::SynthesisBodyImplementation => { abort; }
         %% | CPPAssembly::ExpressionBodyImplementation => { abort; }
-        CPPAssembly::StandardBodyImplementation => { return emitStandardBodyImplementation($body); }
+        CPPAssembly::StandardBodyImplementation => { return emitStandardBodyImplementation($body, indent); }
         | _ => { abort; }
     }
 }
 
 %% Will need to specific namespace of function
-function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl): CString {
+function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, indent: CString): CString {
     let name = func.name;
     let nskey = emitNamespaceKey(func.ns);
     let params = ''; %% TODO: Parameters not implemented
@@ -140,19 +142,20 @@ function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl): CS
     let pre: CString = CString::concat(rtype, ' ', name );
     let params_impl: CString = CString::concat('(', params, ')');
 
-    return CString::concat(pre, params_impl, ' {%n;', emitBodyImplementation(func.body), '}%n;');
+    return CString::concat(pre, params_impl, ' {%n;', emitBodyImplementation(func.body, indent), indent, '}%n;');
 }
 
 %% Emits all funcions inside a given namespace
 function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceKey, funcs: CString): CString {
-    return CString::concat('namespace ', nsdecl.value, ' {%n;', funcs, '%n;}%n;');
+    return CString::concat('namespace ', nsdecl.value, ' {%n;', funcs, '}%n;%n;');
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
     %% First emit all namespace blocks with their functions
     let nsblocks = asm.nsfuncs.reduce<CString>('', fn(acc, nskey, funcs) => {
         let emission = funcs.reduce<CString>('', fn(funcacc, ikey, func) => {
-            return CString::concat(funcacc, emitNamespaceFunctionDecl(func));
+            let indent: CString = '    ';
+            return CString::concat(indent, funcacc, emitNamespaceFunctionDecl(func, indent));
         });
         
         return emitNamespaceDecl(nskey, emission);

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -49,6 +49,10 @@ function emitFunction(ik: CPPAssembly::InvokeKey): CString {
     return ik.value;
 }
 
+function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): CString {
+    return nsk.value;
+}
+
 function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression): CString {
     return exp.value;
 }
@@ -129,32 +133,34 @@ function emitBodyImplementation(body: CPPAssembly::BodyImplementation): CString 
 %% Will need to specific namespace of function
 function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl): CString {
     let name = func.name;
+    let nskey = emitNamespaceKey(func.ns);
     let params = ''; %% TODO: Parameters not implemented
+    let rtype = emitTypeSignature(func.resultType); 
 
-    %%
-    %% g++ forces 'main' return type to be int. Once we overload types, this interaction may
-    %% become somewhat funny, so need to be careful. This will also be akward with main in bosque
-    %% since its happy to return types other than int. Perhaps make a psuedo main function
-    %% that we always just call from real 'int main() ... ' that contains whatever bosque code main does
-    %% and the real 'int main() ... ' just returns 0
-    %%
-    let rtype = if(name === 'main') then 'int' else emitTypeSignature(func.resultType); 
+    let pre: CString = CString::concat(rtype, ' ', name );
+    let params_impl: CString = CString::concat('(', params, ')');
 
-    let decl: CString = CString::concat(rtype, ' ', name, '(', params, ')');
+    return CString::concat(pre, params_impl, ' {%n;', emitBodyImplementation(func.body), '}%n;');
+}
 
-    return CString::concat(decl, ' {%n;', emitBodyImplementation(func.body), '}%n;');
+%% Emits all funcions inside a given namespace
+function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceKey, funcs: CString): CString {
+    return CString::concat('namespace ', nsdecl.value, ' {%n;', funcs, '%n;}%n;');
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
-    let efuncs_list = asm.allfuncs.map<CString>(fn(t) => { 
-        if(asm.nsfuncs.has(t)) {
-            return emitNamespaceFunctionDecl(asm.nsfuncs.get(t));
-        }
-        return 'NOT IMPLEMENTED!';
+    %% First emit all namespace blocks with their functions
+    let nsblocks = asm.nsfuncs.reduce<CString>('', fn(acc, nskey, funcs) => {
+        let emission = funcs.reduce<CString>('', fn(funcacc, ikey, func) => {
+            return CString::concat(funcacc, emitNamespaceFunctionDecl(func));
+        });
+        
+        return emitNamespaceDecl(nskey, emission);
     });
-    let efuncs = CString::joinAll('%n;', efuncs_list);
+
+    %% TODO: Other non namespace functions
 
     %% For CCharBuf and Unicode... will need to emit builtin functions explicitly
 
-    return CString::join('%n;', efuncs);
+    return CString::join('%n;', nsblocks);
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -56,11 +56,11 @@ function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): CString {
 function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression): CString {
     %% We may want to make this matching a tad nicer, although not too bad as is 
     switch(exp.etype.tkeystr.value) {
-        '__CoreCpp::Int' => { return CString::concat('__CoreCpp::Int(', exp.value, ')'); }
-        | '__CoreCpp::BigInt' => { return CString::concat('__CoreCpp::BigInt("', exp.value, '")'); } 
-        | '__CoreCpp::Nat' => { return CString::concat('__CoreCpp::Nat(', exp.value, ')'); }
-        | '__CoreCpp::BigNat' => { return CString::concat('__CoreCpp::BigNat("', exp.value, '")'); }
-        | '__CoreCpp::Float' => { return CString::concat('__CoreCpp::Float(', exp.value, ')'); }
+        '__CoreCpp::Int' => { return CString::concat(exp.value, '_i'); }
+        | '__CoreCpp::BigInt' => { return CString::concat(exp.value, '_I'); } 
+        | '__CoreCpp::Nat' => { return CString::concat(exp.value, '_n'); }
+        | '__CoreCpp::BigNat' => { return CString::concat(exp.value, '_N'); }
+        | '__CoreCpp::Float' => { return CString::concat(exp.value, '_f'); }
         | 'bool' => { return exp.value; }
         | _ => { abort; }
     }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -58,6 +58,7 @@ function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression):
     switch(exp.etype.tkeystr.value) {
         '__CoreCpp::Int' => { return CString::concat(exp.value, '_i'); }
         | '__CoreCpp::Nat' => { return CString::concat(exp.value, '_n'); }
+        | 'bool' => { return exp.value; }
         | _ => { abort; }
     }
 }
@@ -103,7 +104,7 @@ recursive function emitBinMultExpression(mult: CPPAssembly::BinMultExpression): 
     return CString::concat('(', lhs, ' * ', rhs, ')');
 }
 
-function emitBinaryArithExpression(e: CPPAssembly::BinaryArithExpression): CString {
+recursive function emitBinaryArithExpression(e: CPPAssembly::BinaryArithExpression): CString {
     match(e)@ {
         CPPAssembly::BinAddExpression => { return emitBinAddExpression[recursive]($e); }
         | CPPAssembly::BinSubExpression => { return emitBinSubExpression[recursive]($e); }
@@ -112,9 +113,63 @@ function emitBinaryArithExpression(e: CPPAssembly::BinaryArithExpression): CStri
     }
 }
 
+recursive function emitNumericEqExpression(e: CPPAssembly::NumericEqExpression): CString {
+    let lhs = emitExpression[recursive](e.lhs);
+    let rhs = emitExpression[recursive](e.rhs);
+
+    return CString::concat('(', lhs, ' == ', rhs, ')');   
+}
+
+recursive function emitNumericNeqExpression(e: CPPAssembly::NumericNeqExpression): CString {
+    let lhs = emitExpression[recursive](e.lhs);
+    let rhs = emitExpression[recursive](e.rhs);
+
+    return CString::concat('(', lhs, ' != ', rhs, ')');   
+}
+
+recursive function emitNumericLessExpression(e: CPPAssembly::NumericLessExpression): CString {
+    let lhs = emitExpression[recursive](e.lhs);
+    let rhs = emitExpression[recursive](e.rhs);
+
+    return CString::concat('(', lhs, ' < ', rhs, ')');   
+}
+
+recursive function emitNumericLessEqExpression(e: CPPAssembly::NumericLessEqExpression): CString {
+    let lhs = emitExpression[recursive](e.lhs);
+    let rhs = emitExpression[recursive](e.rhs);
+
+    return CString::concat('(', lhs, ' <= ', rhs, ')');   
+}
+
+recursive function emitNumericGreaterExpression(e: CPPAssembly::NumericGreaterExpression): CString {
+    let lhs = emitExpression[recursive](e.lhs);
+    let rhs = emitExpression[recursive](e.rhs);
+
+    return CString::concat('(', lhs, ' > ', rhs, ')');   
+}
+
+recursive function emitNumericGreaterEqExpression(e: CPPAssembly::NumericGreaterEqExpression): CString {
+    let lhs = emitExpression[recursive](e.lhs);
+    let rhs = emitExpression[recursive](e.rhs);
+
+    return CString::concat('(', lhs, ' >= ', rhs, ')');   
+}
+
+recursive function emitBinaryNumericExpression(e: CPPAssembly::BinaryNumericExpression): CString {
+    match(e)@ {
+        CPPAssembly::NumericEqExpression => { return emitNumericEqExpression[recursive]($e); }
+        | CPPAssembly::NumericNeqExpression => { return emitNumericNeqExpression[recursive]($e); }
+        | CPPAssembly::NumericLessExpression => { return emitNumericLessExpression[recursive]($e); }
+        | CPPAssembly::NumericLessEqExpression => { return emitNumericLessEqExpression[recursive]($e); }
+        | CPPAssembly::NumericGreaterExpression => { return emitNumericGreaterExpression[recursive]($e); }
+        | CPPAssembly::NumericGreaterEqExpression => { return emitNumericGreaterEqExpression[recursive]($e); }
+    }
+}
+
 function emitExpression(e: CPPAssembly::Expression): CString {
     match(e)@ {
         CPPAssembly::BinaryArithExpression => { return emitBinaryArithExpression[recursive]($e); }
+        | CPPAssembly::BinaryNumericExpression => { return emitBinaryNumericExpression[recursive]($e); }
         | CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($e); }
         | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e); }
         | _ => { abort; }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -79,19 +79,36 @@ recursive function emitBinAddExpression(add: CPPAssembly::BinAddExpression): CSt
     let lhs = emitExpression[recursive](add.lhs);
     let rhs = emitExpression[recursive](add.rhs);
 
-    %% TODO: Overload '+'
     return CString::concat('(', lhs, ' + ', rhs, ')');
 }
 
-recursive function emitBinSubExpression(add: CPPAssembly::BinSubExpression): CString {
-    abort; %% TODO
+recursive function emitBinSubExpression(sub: CPPAssembly::BinSubExpression): CString {
+    let lhs = emitExpression[recursive](sub.lhs);
+    let rhs = emitExpression[recursive](sub.rhs);
+
+    return CString::concat('(', lhs, ' - ', rhs, ')');
+}
+
+recursive function emitBinDivExpression(div: CPPAssembly::BinDivExpression): CString {
+    let lhs = emitExpression[recursive](div.lhs);
+    let rhs = emitExpression[recursive](div.rhs);
+
+    return CString::concat('(', lhs, ' / ', rhs, ')');
+}
+
+recursive function emitBinMultExpression(mult: CPPAssembly::BinMultExpression): CString {
+    let lhs = emitExpression[recursive](mult.lhs);
+    let rhs = emitExpression[recursive](mult.rhs);
+
+    return CString::concat('(', lhs, ' * ', rhs, ')');
 }
 
 function emitBinaryArithExpression(e: CPPAssembly::BinaryArithExpression): CString {
     match(e)@ {
         CPPAssembly::BinAddExpression => { return emitBinAddExpression[recursive]($e); }
-        %% | CPPAssembly::BinSubExpression => { return emitBinSubExpression[recursive]($e); }
-        | _ => { abort; }
+        | CPPAssembly::BinSubExpression => { return emitBinSubExpression[recursive]($e); }
+        | CPPAssembly::BinDivExpression => { return emitBinDivExpression[recursive]($e); }
+        | CPPAssembly::BinMultExpression => { return emitBinMultExpression[recursive]($e); }
     }
 }
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -56,11 +56,11 @@ function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): CString {
 function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression): CString {
     %% We may want to make this matching a tad nicer, although not too bad as is 
     switch(exp.etype.tkeystr.value) {
-        '__CoreCpp::Int' => { return CString::concat(exp.value, '_i'); }
-        | '__CoreCpp::BigInt' => { return CString::concat(exp.value, '_I'); } 
-        | '__CoreCpp::Nat' => { return CString::concat(exp.value, '_n'); }
-        | '__CoreCpp::BigNat' => { return CString::concat(exp.value, '_N'); }
-        | '__CoreCpp::Float' => { return CString::concat(exp.value, '_f'); }
+        '__CoreCpp::Int' => { return CString::concat('__CoreCpp::Int(', exp.value, ')'); }
+        | '__CoreCpp::BigInt' => { return CString::concat('__CoreCpp::BigInt("', exp.value, '")'); } 
+        | '__CoreCpp::Nat' => { return CString::concat('__CoreCpp::Nat(', exp.value, ')'); }
+        | '__CoreCpp::BigNat' => { return CString::concat('__CoreCpp::BigNat("', exp.value, '")'); }
+        | '__CoreCpp::Float' => { return CString::concat('__CoreCpp::Float(', exp.value, ')'); }
         | 'bool' => { return exp.value; }
         | _ => { abort; }
     }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -54,12 +54,12 @@ function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): CString {
 }
 
 function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression): CString {
-    %% May want to store type in our literals to make matching nicer...
-    if(exp.value === '__CoreCpp::Int63') {
-        return CString::concat(exp.value, '_i');
+    %% We may want to make this matching a tad nicer, although not too bad as is 
+    switch(exp.etype.tkeystr.value) {
+        '__CoreCpp::Int' => { return CString::concat(exp.value, '_i'); }
+        | '__CoreCpp::Nat' => { return CString::concat(exp.value, '_n'); }
+        | _ => { abort; }
     }
-         return CString::concat(exp.value, '_i');
-
 }
 
 function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression): CString {

--- a/src/backend/cpp/transformer/cppprocessor.bsq
+++ b/src/backend/cpp/transformer/cppprocessor.bsq
@@ -3,8 +3,6 @@ declare namespace CPPEmitter {
     using CPPAssembly;
 }
 
-%% TODO: actually glue or properly transformed cpp together
-
 %% Our API for emitting cpp
 public function main(asm: BSQAssembly::Assembly): CString {
     let tasm = CPPEmitter::CPPTransformer::convertBsqAsmToCpp(asm);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -124,16 +124,25 @@ entity CPPTransformer {
         return CPPAssembly::NamespaceFunctionDecl{nskey, decl.name.value, ikey, none, res, body};
     }   
 
-    function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {
-            let transformer = CPPTransformer{ bsqasm };
+    %*
+    method transformNamespaceConstDecl(decl: BSQAssembly::NamespaceConstDecl): CPPAssembly::NamespaceConstDecl {
+        abort;
+    }
+    *%
 
+    function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {
+        let transformer = CPPTransformer{ bsqasm };
+
+        %% Maps each namespace key to a map for each function in the namespace 
         let transformer_nsfuncs = bsqasm.allfuncs
             .filter(pred(ikey) => bsqasm.nsfuncs.has(ikey))
-            .reduce<Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>>(Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>{},
+            .reduce<Map<CPPAssembly::NamespaceKey, Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>>>(
+                Map<CPPAssembly::NamespaceKey, Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>>{},
                 fn(acc, ikey) => {
                     let bsqdecl = bsqasm.nsfuncs.get(ikey);
                     let cppdecl = transformer.transformNamespaceFunctionDeclToCpp(bsqdecl);
-                    return acc.insert(cppdecl.invokeKey, cppdecl);
+                    let map = Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>{cppdecl.invokeKey => cppdecl};
+                    return acc.insert(cppdecl.ns, map);
                 });
 
         let transformer_allfuncs = bsqasm.allfuncs.map<CPPAssembly::InvokeKey>(fn(ikey) => CPPTransformNameManager::convertInvokeKey(ikey));

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -16,7 +16,10 @@ namespace CPPTransformNameManager {
         %% We will want to eventually not use nominal type signature always, i think itll be obvious when to not use
         switch(tk.value) {
             'Int' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::Int') }; }
+            | 'BigInt' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::BigInt') }; }
             | 'Nat' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::Nat') }; }
+            | 'BigNat' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::BigNat') }; }
+            | 'Float' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::Float') }; }
             | 'Bool' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('bool') }; }
             | _ => { abort; }
         }
@@ -77,8 +80,17 @@ entity CPPTransformer {
         if(val.endsWithString('i')) {
             return CPPAssembly::LiteralSimpleExpression{ exprtype, val.removeSuffixString('i') };
         }
+        elif(val.endsWithString('I')) {
+            return CPPAssembly::LiteralSimpleExpression{ exprtype, val.removeSuffixString('I') };
+        }
         elif(val.endsWithString('n')) {
             return CPPAssembly::LiteralSimpleExpression{ exprtype, val.removeSuffixString('n') };
+        }
+        elif(val.endsWithString('N')) {
+            return CPPAssembly::LiteralSimpleExpression{ exprtype, val.removeSuffixString('N') };
+        }
+        elif(val.endsWithString('f')) {
+            return CPPAssembly::LiteralSimpleExpression{ exprtype, val.removeSuffixString('f') };
         }
         else {
             %% Fall through

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -15,7 +15,7 @@ namespace CPPTransformNameManager {
 
         if(tk.value === 'Int') {
             %% We will need call our overloaded int type
-            return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('int64_t') };
+            return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::Int63') };
         }
 
         return CPPAssembly::NominalTypeSignature{ tk }; %% We wont want this to be nominal always (look at smttransfrom)

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -33,8 +33,39 @@ namespace CPPTransformNameManager {
 entity CPPTransformer {
     field bsqasm: BSQAssembly::Assembly;
 
-    method transformBinAddExpressionToCpp(binadd: BSQAssembly::BinAddExpression): CPPAssembly::BinAddExpression {
-        abort;
+    recursive method processBinaryArgs(lhs: BSQAssembly::Expression, rhs: BSQAssembly::Expression): CPPAssembly::Expression, CPPAssembly::Expression {
+        let cpplhs = this.transformExpressionToCpp[recursive](lhs);
+        let cpprhs = this.transformExpressionToCpp[recursive](rhs);
+
+        return cpplhs, cpprhs;
+    }
+
+    recursive method transformBinAddExpressionToCpp(expr: BSQAssembly::BinAddExpression): CPPAssembly::BinAddExpression {
+        let lexpr, rexpr = this.processBinaryArgs[recursive](expr.lhs, expr.rhs);
+
+        %% lhs and rhs for addition operator must have same type, so it does not matter what expr we use for etype
+        return CPPAssembly::BinAddExpression{ lexpr.etype, lexpr, rexpr };
+    }
+
+    recursive method transformBinSubExpressionToCpp(expr: BSQAssembly::BinSubExpression): CPPAssembly::BinSubExpression {
+        let lexpr, rexpr = this.processBinaryArgs[recursive](expr.lhs, expr.rhs);
+
+        %% lhs and rhs for addition operator must have same type, so it does not matter what expr we use for etype
+        return CPPAssembly::BinSubExpression{ lexpr.etype, lexpr, rexpr };
+    }
+
+    recursive method transformBinDivExpressionToCpp(expr: BSQAssembly::BinDivExpression): CPPAssembly::BinDivExpression {
+        let lexpr, rexpr = this.processBinaryArgs[recursive](expr.lhs, expr.rhs);
+
+        %% lhs and rhs for addition operator must have same type, so it does not matter what expr we use for etype
+        return CPPAssembly::BinDivExpression{ lexpr.etype, lexpr, rexpr };
+    }
+
+    recursive method transformBinMultExpressionToCpp(expr: BSQAssembly::BinMultExpression): CPPAssembly::BinMultExpression {
+        let lexpr, rexpr = this.processBinaryArgs[recursive](expr.lhs, expr.rhs);
+
+        %% lhs and rhs for addition operator must have same type, so it does not matter what expr we use for etype
+        return CPPAssembly::BinMultExpression{ lexpr.etype, lexpr, rexpr };
     }
 
     method transformLiteralSimpleExpression(expr: BSQAssembly::LiteralSimpleExpression): CPPAssembly::LiteralSimpleExpression {
@@ -62,17 +93,18 @@ entity CPPTransformer {
         return CPPAssembly::AccessVariableExpression { vtype, vname, layouttype };
     }
 
-    method transformBinaryArithExpressionToCpp(binarith: BSQAssembly::BinaryArithExpression): CPPAssembly::BinaryArithExpression {
+    recursive method transformBinaryArithExpressionToCpp(binarith: BSQAssembly::BinaryArithExpression): CPPAssembly::BinaryArithExpression {
         match(binarith)@ {
-            BSQAssembly::BinAddExpression => { return this.transformBinAddExpressionToCpp($binarith); }
-            | BSQAssembly::BinSubExpression => { abort; } %% Eventually...
-            | _ => { abort; }
+            BSQAssembly::BinAddExpression => { return this.transformBinAddExpressionToCpp[recursive]($binarith); }
+            | BSQAssembly::BinSubExpression => { return this.transformBinSubExpressionToCpp[recursive]($binarith); }           
+            | BSQAssembly::BinDivExpression => { return this.transformBinDivExpressionToCpp[recursive]($binarith); }
+            | BSQAssembly::BinMultExpression => { return this.transformBinMultExpressionToCpp[recursive]($binarith); }
         }
     }
 
-    method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
+    recursive method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
         match(expr)@ {
-            BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpressionToCpp($expr); }
+            BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpressionToCpp[recursive]($expr); }
             | BSQAssembly::LiteralSimpleExpression => { return this.transformLiteralSimpleExpression($expr); }
             | BSQAssembly::AccessVariableExpression => { return this.transformAccessVariableExpression($expr); }
             | _ => { abort; }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -17,6 +17,7 @@ namespace CPPTransformNameManager {
         switch(tk.value) {
             'Int' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::Int') }; }
             | 'Nat' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::Nat') }; }
+            | 'Bool' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('bool') }; }
             | _ => { abort; }
         }
     }
@@ -93,6 +94,7 @@ entity CPPTransformer {
         return CPPAssembly::AccessVariableExpression { vtype, vname, layouttype };
     }
 
+    %% I think we can simplify this and remove the transform functions, just match our bsqasm type then return transform type
     recursive method transformBinaryArithExpressionToCpp(binarith: BSQAssembly::BinaryArithExpression): CPPAssembly::BinaryArithExpression {
         match(binarith)@ {
             BSQAssembly::BinAddExpression => { return this.transformBinAddExpressionToCpp[recursive]($binarith); }
@@ -102,9 +104,24 @@ entity CPPTransformer {
         }
     }
 
+    recursive method transformBinaryNumericCompareExpression(expr: BSQAssembly::BinaryNumericExpression): CPPAssembly::BinaryNumericExpression {
+        let cpplhs, cpprhs = this.processBinaryArgs[recursive](expr.lhs, expr.rhs);
+
+        let etype = CPPTransformNameManager::convertTypeSignature(expr.etype);
+        match(expr)@ {
+            BSQAssembly::NumericEqExpression => { return CPPAssembly::NumericEqExpression { etype, cpplhs, cpprhs }; }
+            | BSQAssembly::NumericNeqExpression => { return CPPAssembly::NumericNeqExpression{ etype, cpplhs, cpprhs }; }
+            | BSQAssembly::NumericLessExpression => { return CPPAssembly::NumericLessExpression{ etype, cpplhs, cpprhs}; }
+            | BSQAssembly::NumericLessEqExpression => { return CPPAssembly::NumericLessEqExpression{ etype, cpplhs, cpprhs }; }
+            | BSQAssembly::NumericGreaterExpression => { return CPPAssembly::NumericGreaterExpression{ etype, cpplhs, cpprhs }; }
+            | BSQAssembly::NumericGreaterEqExpression => { return CPPAssembly::NumericGreaterEqExpression{ etype, cpplhs, cpprhs }; }
+        }
+    }
+
     recursive method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
         match(expr)@ {
             BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpressionToCpp[recursive]($expr); }
+            | BSQAssembly::BinaryNumericExpression => { return this.transformBinaryNumericCompareExpression[recursive]($expr); }
             | BSQAssembly::LiteralSimpleExpression => { return this.transformLiteralSimpleExpression($expr); }
             | BSQAssembly::AccessVariableExpression => { return this.transformAccessVariableExpression($expr); }
             | _ => { abort; }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -10,15 +10,15 @@ namespace CPPTransformNameManager {
         return CPPAssembly::InvokeKey::from(ikey.value);
     }
 
-    function convertTypeSignature(tkey: BSQAssembly::TypeSignature): CPPAssembly::TypeSignature {
-        let tk = CPPAssembly::TypeKey::from(tkey.tkeystr.value);
+    function convertTypeSignature(tsig: BSQAssembly::TypeSignature): CPPAssembly::TypeSignature {
+        let tk = CPPAssembly::TypeKey::from(tsig.tkeystr.value);
 
-        if(tk.value === 'Int') {
-            %% We will need call our overloaded int type
-            return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::Int63') };
+        %% We will want to eventually not use nominal type signature always, i think itll be obvious when to not use
+        switch(tk.value) {
+            'Int' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::Int') }; }
+            | 'Nat' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::Nat') }; }
+            | _ => { abort; }
         }
-
-        return CPPAssembly::NominalTypeSignature{ tk }; %% We wont want this to be nominal always (look at smttransfrom)
     }
 
     function convertIdentifier(ident: BSQAssembly::Identifier): CPPAssembly::Identifier {
@@ -37,22 +37,29 @@ entity CPPTransformer {
         abort;
     }
 
-    method transformLiteralSimpleExpression(exp: BSQAssembly::LiteralSimpleExpression): CPPAssembly::LiteralSimpleExpression {
-        let val = exp.value;
-        
-        %% May be cleaner to handle in cppemit
-        if(CPPAssembly::BsqInt::from(val).value !== '') {
-            return CPPAssembly::LiteralSimpleExpression{ val.removeSuffixString('i') };
-        }
+    method transformLiteralSimpleExpression(expr: BSQAssembly::LiteralSimpleExpression): CPPAssembly::LiteralSimpleExpression {
+        let val = expr.value;
+        let exprtype = CPPTransformNameManager::convertTypeSignature(expr.etype);
 
-        return CPPAssembly::LiteralSimpleExpression{ val };
+        %% May be cleaner to handle in cppemit
+        if(val.endsWithString('i')) {
+            return CPPAssembly::LiteralSimpleExpression{ exprtype, val.removeSuffixString('i') };
+        }
+        elif(val.endsWithString('n')) {
+            return CPPAssembly::LiteralSimpleExpression{ exprtype, val.removeSuffixString('n') };
+        }
+        else {
+            %% Fall through
+            return CPPAssembly::LiteralSimpleExpression{ exprtype, val };
+        }
     }
 
-    method transformAccessVariableExpression(exp: BSQAssembly::AccessVariableExpression): CPPAssembly::AccessVariableExpression {
-        let vname = CPPTransformNameManager::convertVarIdentifier(exp.vname);
-        let layouttype = CPPTransformNameManager::convertTypeSignature(exp.layouttype);
+    method transformAccessVariableExpression(expr: BSQAssembly::AccessVariableExpression): CPPAssembly::AccessVariableExpression {
+        let vname = CPPTransformNameManager::convertVarIdentifier(expr.vname);
+        let vtype = CPPTransformNameManager::convertTypeSignature(expr.etype);
+        let layouttype = CPPTransformNameManager::convertTypeSignature(expr.layouttype);
 
-        return CPPAssembly::AccessVariableExpression { vname, layouttype };
+        return CPPAssembly::AccessVariableExpression { vtype, vname, layouttype };
     }
 
     method transformBinaryArithExpressionToCpp(binarith: BSQAssembly::BinaryArithExpression): CPPAssembly::BinaryArithExpression {

--- a/src/cmd/analyzecpp.ts
+++ b/src/cmd/analyzecpp.ts
@@ -49,12 +49,13 @@ function generateCPPFile(cpp: string, outdir: string) {
     Status.output("    Reading Contents of Base emit.cpp File...\n");
     let contents: string = "";
     try {
-        contents = fs.readFileSync(cpp_runtime_code_path).toString();
+        contents = fs.readFileSync(cpp_runtime_code_path).toString() + `\n\n`;
     }
     catch(e) {
         Status.error("Failed to read base emit.cpp file!\n");
     }
-    const new_contents = contents.concat(cpp);
+    const runtime_header: string = `#include "${cpp_runtime_dir_path}cppruntime.hpp"\n\n`;
+    const new_contents: string = runtime_header.concat( contents, cpp);   
 
     Status.output("    Writing to emit.cpp...\n");
     try {
@@ -80,7 +81,7 @@ function runCPPEmit(outname: string): string {
         Status.error("Failed to write bsqir info file!\n");
     }
 
-    return `#include "${cpp_runtime_dir_path}cppruntime.hpp"\n\n` + validateCStringLiteral(res.slice(1, -2));
+    return validateCStringLiteral(res.slice(1, -2));
 }
 
 function buildBSQONAssembly(assembly: Assembly, rootasm: string, outname: string) {

--- a/src/cmd/analyzecpp.ts
+++ b/src/cmd/analyzecpp.ts
@@ -55,7 +55,7 @@ function generateCPPFile(cpp: string, outdir: string) {
         Status.error("Failed to read base emit.cpp file!\n");
     }
     const runtime_header: string = `#include "${cpp_runtime_dir_path}cppruntime.hpp"\n\n`;
-    const new_contents: string = runtime_header.concat( contents, cpp);   
+    const new_contents: string = runtime_header.concat( cpp, contents );   
 
     Status.output("    Writing to emit.cpp...\n");
     try {


### PR DESCRIPTION
This adds support for emitting cpp for following operations on Int, Nat, BigInt, BigNat, and Float
 - addition
 - subtraction
 - multiplication
 - division
 - equality
 - non-equality
 - less than and less than or equal to
 - greater than and greater than or equal to

All of these operations are overloaded in the file `cppruntime.hpp` and all arithmetic is done using `__builtin_*_overflow(...)` . I tried to get any overflow operations to be detected at compile time, but it appears that these builtin overflow arithmetic operations can only detect overflow at runtime, hence throwing `std::runtime_error` whenever overflow is detected _(although I may be wrong here)_. 

I also had to pivot from my user defined literal idea ( instead of emitting `__CoreCpp::Int(1)` we would emit `1_i` where `_i` is overloaded to call `Int`s constructor) since I could not get it to work for negation properly due to subtraction already being overloaded.

BigInt and BigNat have to use `const char*`s in their constructors where we convert to corresponding `__int128_t` or `__uint128_t` value due to these 128 bit values being too large to be represented in code as literals.