### PR TITLE
Basic Cpp Emit Testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
         "test-stdlib": "node ./build/build_all.js && node --test-concurrency=8 --test ./test/stdlib/*/*.test.js",
         "test-docs": "node ./build/build_all.js && node --test-concurrency=8 --test ./test/documentation/*/*.test.js",
         "test-apps": "node ./build/build_all.js && node --test-concurrency=8 --test ./test/apps/*/*.test.js",
-        "test-smtoutput": "node ./build/build_all.js && node ./build/build_smtemit.js && node --test-concurrency=8 --test ./test/smtoutput/*/*.test.js"
+        "test-smtoutput": "node ./build/build_all.js && node ./build/build_smtemit.js && node --test-concurrency=8 --test ./test/smtoutput/*/*.test.js",
+        "test-cppoutput": "node ./build/build_all.js && node ./build/build_cppemit.js && node --test-concurrency=8 --test ./test/cppoutput/*/*.test.js"
     },
     "files": [
         "bin/*"

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -12,7 +12,7 @@ namespace __CoreCpp {
 #define MIN_BSQ_INT (-(int64_t(1) << 62) + 1) 
 #define MAX_BSQ_BIGINT ((__int128_t(1) << 126) - 1)
 #define MIN_BSQ_BIGINT (-(__int128_t(1) << 126) + 1)
-#define MAX_BSQ_NAT ((uint64_t(1) << 63) - 1)
+#define MAX_BSQ_NAT ((uint64_t(1) << 62) - 1)
 #define MAX_BSQ_BIGNAT ((__uint128_t(1) << 127) - 1)
 
 #define is_valid_Int(V) ((V >= MIN_BSQ_INT) && (V <= MAX_BSQ_INT))
@@ -440,24 +440,28 @@ typedef std::variant<Int, Nat, BigInt, BigNat, Float, bool> MainType;
 //
 std::string to_string(MainType v) {
     if(std::holds_alternative<bool>(v)) {
-        return std::to_string(std::get<bool>(v));
+        bool res = std::get<bool>(v);
+        if(!res) {
+            return "false";
+        }
+        return "true";
     }
     else if(std::holds_alternative<Int>(v)) {
-        return std::to_string(std::get<Int>(v).get());
+        return std::to_string(std::get<Int>(v).get()) + "_i";
     }
     else if (std::holds_alternative<Nat>(v)) {
-        return std::to_string(std::get<Nat>(v).get());
+        return std::to_string(std::get<Nat>(v).get()) + "_n";
     }
     else if (std::holds_alternative<Float>(v)) {
-        return std::to_string(std::get<Float>(v).get());
+        return std::to_string(std::get<Float>(v).get()) + "_f";
     }
     else if(std::holds_alternative<BigInt>(v)) {
         __int128_t res = std::get<BigInt>(v).get();
-        return t_to_string<__int128_t>(res);
+        return t_to_string<__int128_t>(res) + "_I";
     }
     else if(std::holds_alternative<BigNat>(v)) {
         __int128_t res = std::get<BigNat>(v).get();
-        return t_to_string<__uint128_t>(res);
+        return t_to_string<__uint128_t>(res) + "_N";
     }
     else {
         return "Unable to print main return type!\n";

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -13,7 +13,7 @@ namespace __CoreCpp {
 #define MAX_BSQ_BIGINT ((__int128_t(1) << 126) - 1)
 #define MIN_BSQ_BIGINT (-(__int128_t(1) << 126) + 1)
 #define MAX_BSQ_NAT ((uint64_t(1) << 62) - 1)
-#define MAX_BSQ_BIGNAT ((__uint128_t(1) << 127) - 1)
+#define MAX_BSQ_BIGNAT ((__uint128_t(1) << 126) - 1)
 
 #define is_valid_Int(V) ((V >= MIN_BSQ_INT) && (V <= MAX_BSQ_INT))
 #define is_valid_BigInt(V) ((V >= MIN_BSQ_BIGINT) && (V <= MAX_BSQ_BIGINT))

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -159,7 +159,7 @@ public:
             std::longjmp(info.error_handler, true);
         }
     };
-    constexpr __int128_t get() noexcept { return value; } // Perhaps string convert here?
+    constexpr __int128_t get() noexcept { return value; }
 
     // Overloaded operators on BigInt
     constexpr BigInt& operator+=(const BigInt& rhs) noexcept {

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -5,10 +5,8 @@ int main() {
     }
 
     // Calling our emitted main is hardcoded for now
-    Main::main();
-
-    // We may want some way to convert what Main::main spits out into 
-    // a string and write to cout
+    __CoreCpp::MainType ret = Main::main();
+    std::cout << __CoreCpp::to_string(ret) << std::endl;
 
     return 0;
 }

--- a/src/cmd/workflows.ts
+++ b/src/cmd/workflows.ts
@@ -104,7 +104,7 @@ function generateASMSMT(usercode: PackageConfig): [Assembly | undefined, ParserE
     return generateASMGeneral(usercode, ["SMT_LIBS"]);
 }
 
-// We MAY want to create separate core files for cpp explicitly to easily make stuff built in, ok for now
+// We MAY want to create separate core files for cpp explicitly to easily make stuff builtin, ok for now
 function generateASMCPP(usercode: PackageConfig): [Assembly | undefined, ParserError[], TypeError[]]{
     return generateASMGeneral(usercode, ["EXEC_LIBS"])
 }

--- a/test/cppoutput/bin_exps/addition.test.js
+++ b/test/cppoutput/bin_exps/addition.test.js
@@ -1,14 +1,17 @@
 "use strict";
 
-import { cppns, runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { runMainCode, runMainCodeError } from "../../../bin/test/cppoutput/cppemit_nf.js"
 import { describe, it } from "node:test";
 
 describe( "CPP Evaluate --- Simple addition", () => {
     it("should cpp emit addition simple", function () {
-        runMainCode("public function main(): Nat { return 2n + 2n; }", `return (2_n + 2_n);`);
-        runMainCode("public function main(): Int { return 4i + 100i; }", `return (4_i + 100_i);`);
-        runMainCode("public function main(): BigNat { return 2N + 1N; }", `return (2_N + 1_N);`);
-        runMainCode("public function main(): BigInt { return 1I + 22I; }", `return (1_I + 22_I);`);
-        runMainCode("public function main(): Float { return 1.0f + 1.0f; }", `return (1.0_f + 1.0_f);`);
+        runMainCode("public function main(): Nat { return 2n + 2n; }", "4_n");
+        runMainCode("public function main(): Int { return 4i + 100i; }", "104_i");
+        runMainCode("public function main(): BigNat { return 2N + 1N; }", "3_N");
+        runMainCode("public function main(): BigInt { return 1I + 22I; }", "23_I");
+        runMainCode("public function main(): Bool { return (1.0f + 1.0f) > 1.0f; }", "true");
+    });
+    it("should addition error (overflow or undefined behaviour)", function () {
+        runMainCodeError("public function main(): Nat { return 4611686018427387903n + 1n; }", "Over/underflow detected!\n");
     });
 });

--- a/test/cppoutput/bin_exps/addition.test.js
+++ b/test/cppoutput/bin_exps/addition.test.js
@@ -6,5 +6,9 @@ import { describe, it } from "node:test";
 describe( "CPP Evaluate --- Simple addition", () => {
     it("should cpp emit addition simple", function () {
         runMainCode("public function main(): Nat { return 2n + 2n; }", `return (2_n + 2_n);`);
+        runMainCode("public function main(): Int { return 4i + 100i; }", `return (4_i + 100_i);`);
+        runMainCode("public function main(): BigNat { return 2N + 1N; }", `return (2_N + 1_N);`);
+        runMainCode("public function main(): BigInt { return 1I + 22I; }", `return (1_I + 22_I);`);
+        runMainCode("public function main(): Float { return 1.0f + 1.0f; }", `return (1.0_f + 1.0_f);`);
     });
 });

--- a/test/cppoutput/bin_exps/addition.test.js
+++ b/test/cppoutput/bin_exps/addition.test.js
@@ -1,0 +1,10 @@
+"use strict";
+
+import { cppns, runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe( "CPP Evaluate --- Simple addition", () => {
+    it("should cpp emit addition simple", function () {
+        runMainCode("public function main(): Nat { return 2n + 2n; }", `return (2_n + 2_n);`);
+    });
+});

--- a/test/cppoutput/bin_exps/addition.test.js
+++ b/test/cppoutput/bin_exps/addition.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { runMainCode, runMainCodeError } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { runMainCode, runMainCodeError, bsq_max_nat, bsq_max_int,  bsq_max_bignat, bsq_max_bigint } from "../../../bin/test/cppoutput/cppemit_nf.js"
 import { describe, it } from "node:test";
 
 describe( "CPP Evaluate --- Simple addition", () => {
@@ -12,6 +12,9 @@ describe( "CPP Evaluate --- Simple addition", () => {
         runMainCode("public function main(): Bool { return (1.0f + 1.0f) > 1.0f; }", "true");
     });
     it("should addition error (overflow or undefined behaviour)", function () {
-        runMainCodeError("public function main(): Nat { return 4611686018427387903n + 1n; }", "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): Nat { return ${bsq_max_nat}n + 1n; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): Int { return ${bsq_max_int}i + 1i; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): BigNat { return ${bsq_max_bignat}N + 1N; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): BigInt { return ${bsq_max_bigint}I + 1I; }`, "Over/underflow detected!\n");
     });
 });

--- a/test/cppoutput/bin_exps/division.test.js
+++ b/test/cppoutput/bin_exps/division.test.js
@@ -1,0 +1,19 @@
+import { runMainCode, runMainCodeError, bsq_max_nat, bsq_max_int,  bsq_max_bignat, bsq_max_bigint } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe( "CPP Evaluate --- Simple Division", () => {
+    it("should cpp emit division simple", function () {
+        runMainCode("public function main(): Nat { return 2n // 2n; }", "1_n");
+        runMainCode("public function main(): Int { return 4i // 1i; }", "4_i");
+        runMainCode("public function main(): BigNat { return 100N // 1N; }", "100_N");
+        runMainCode("public function main(): BigInt { return -1I // -1I; }", "1_I");
+        runMainCode("public function main(): Bool { return (2.0f // 1.0f) > 1.0f; }", "true");
+    });
+    it("should division error (undefined behaviour)", function () {
+        runMainCodeError(`public function main(): Nat { return 2n // 0n; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): Int { return 2i // 0i; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): BigNat { return 3N // 0N; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): BigInt { return 1I // 0I; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): Float { return 1.0f // 0.0f; }`, "Over/underflow detected!\n");
+    });
+});

--- a/test/cppoutput/bin_exps/division.test.js
+++ b/test/cppoutput/bin_exps/division.test.js
@@ -1,4 +1,6 @@
-import { runMainCode, runMainCodeError, bsq_max_nat, bsq_max_int,  bsq_max_bignat, bsq_max_bigint } from "../../../bin/test/cppoutput/cppemit_nf.js"
+"use strict";
+
+import { runMainCode, runMainCodeError } from "../../../bin/test/cppoutput/cppemit_nf.js"
 import { describe, it } from "node:test";
 
 describe( "CPP Evaluate --- Simple Division", () => {

--- a/test/cppoutput/bin_exps/multipication.test.js
+++ b/test/cppoutput/bin_exps/multipication.test.js
@@ -1,3 +1,5 @@
+"use strict";
+
 import { runMainCode, runMainCodeError, bsq_max_nat, bsq_max_int,  bsq_max_bignat, bsq_max_bigint } from "../../../bin/test/cppoutput/cppemit_nf.js"
 import { describe, it } from "node:test";
 

--- a/test/cppoutput/bin_exps/multipication.test.js
+++ b/test/cppoutput/bin_exps/multipication.test.js
@@ -1,0 +1,19 @@
+import { runMainCode, runMainCodeError, bsq_max_nat, bsq_max_int,  bsq_max_bignat, bsq_max_bigint } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe( "CPP Evaluate --- Simple Multiplication", () => {
+    it("should cpp emit multiplication simple", function () {
+        runMainCode("public function main(): Nat { return 2n * 2n; }", "4_n");
+        runMainCode("public function main(): Nat { return 2n * 0n; }", "0_n");
+        runMainCode("public function main(): Int { return 2i * -2i; }", "-4_i");
+        runMainCode("public function main(): BigNat { return 2N * 1N; }", "2_N");
+        runMainCode("public function main(): BigInt { return 2I * -22I; }", "-44_I");
+        runMainCode("public function main(): Bool { return (2.0f * 2.0f) > 3.0f; }", "true");
+    });
+    it("should multiplication error (overflow or undefined behaviour)", function () {
+        runMainCodeError(`public function main(): Nat { return ${bsq_max_nat}n + 1n; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): Int { return ${bsq_max_int}i + 1i; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): BigNat { return ${bsq_max_bignat}N + 1N; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): BigInt { return ${bsq_max_bigint}I + 1I; }`, "Over/underflow detected!\n");
+    });
+});

--- a/test/cppoutput/bin_exps/subtraction.test.js
+++ b/test/cppoutput/bin_exps/subtraction.test.js
@@ -1,3 +1,5 @@
+"use strict";
+
 import { runMainCode, runMainCodeError, bsq_min_int, bsq_min_bigint } from "../../../bin/test/cppoutput/cppemit_nf.js"
 import { describe, it } from "node:test";
 
@@ -9,7 +11,7 @@ describe( "CPP Evaluate --- Simple Subtraction", () => {
         runMainCode("public function main(): BigInt { return 2I - 3I; }", "-1_I");
         runMainCode("public function main(): Bool { return (1.0f - 2.0f) < 0.0f; }", "true");
     });
-    it("should subtraction error (overflow or undefined behaviour)", function () {
+    it("should subtraction error (underflow or undefined behaviour)", function () {
         runMainCodeError(`public function main(): Nat { return 1n - 2n; }`, "Over/underflow detected!\n");
         runMainCodeError(`public function main(): BigNat { return 1N - 2N; }`, "Over/underflow detected!\n");
         runMainCodeError(`public function main(): Int { return ${bsq_min_int}i - 1i; }`, "Over/underflow detected!\n");

--- a/test/cppoutput/bin_exps/subtraction.test.js
+++ b/test/cppoutput/bin_exps/subtraction.test.js
@@ -1,0 +1,18 @@
+import { runMainCode, runMainCodeError, bsq_min_int, bsq_min_bigint } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe( "CPP Evaluate --- Simple Subtraction", () => {
+    it("should cpp emit subtraction simple", function () {
+        runMainCode("public function main(): Nat { return 2n - 2n; }", "0_n");
+        runMainCode("public function main(): Int { return 2i - -2i; }", "4_i");
+        runMainCode("public function main(): BigNat { return 2N - 2N; }", "0_N");
+        runMainCode("public function main(): BigInt { return 2I - 3I; }", "-1_I");
+        runMainCode("public function main(): Bool { return (1.0f - 2.0f) < 0.0f; }", "true");
+    });
+    it("should subtraction error (overflow or undefined behaviour)", function () {
+        runMainCodeError(`public function main(): Nat { return 1n - 2n; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): BigNat { return 1N - 2N; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): Int { return ${bsq_min_int}i - 1i; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): BigInt { return ${bsq_min_bigint}I - 1I; }`, "Over/underflow detected!\n");
+    });
+});

--- a/test/cppoutput/cppemit_nf.ts
+++ b/test/cppoutput/cppemit_nf.ts
@@ -1,0 +1,138 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import assert from "node:assert"
+
+import { generateASMCPP } from '../../src/cmd/workflows.js';
+import { Assembly } from '../../src/frontend/assembly.js';
+import { InstantiationPropagator } from "../../src/frontend/closed_terms.js";
+
+import { fileURLToPath } from 'url';
+import { PackageConfig } from "../../src/frontend/build_decls.js";
+import { execSync } from "child_process";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const bosque_dir: string = path.join(__dirname, "../../../");
+const cpp_transform_bin_path = path.join(bosque_dir, "bin/cppemit/CPPEmitter.mjs");
+
+// We WILL need this to be able to check results when we exec our emitted cpp
+// const cpp_runtime_code_path = path.join(bosque_dir, "bin/cppruntime/emit.cpp");
+
+import { tmpdir } from 'node:os';
+import { BSQIREmitter } from "../../src/frontend/bsqir_emit.js";
+import { validateCStringLiteral } from "@bosque/jsbrex";
+
+// Just so if we change the namespace our tests dont break
+const cppns: string = "__CoreCpp::";
+
+//
+// We will first do our tests by simply comparing the spat out result (after running our cpp emit)
+// and ensure it matches the anticipated cpp output.
+//
+// Then once this is functional we will add another parameter where we can check the anticipated result
+// after executing the generatec cpp code. Likely will want to make this optional.
+// (we may not care about what the result is, just that the emitted cpp matches what we anticipate.)
+//
+
+function buildMainCode(assembly: Assembly, outname: string): string | undefined {
+    const iim = InstantiationPropagator.computeInstantiations(assembly, "Main");
+    const tinfo = BSQIREmitter.emitAssembly(assembly, iim);
+
+    const nndir = path.normalize(outname);
+    const fname = path.join(nndir, "bsqir.bsqon");
+
+    try {
+        fs.writeFileSync(fname, tinfo);
+    }
+    catch(e) {      
+        return undefined;
+    }
+
+    let res = "";
+    try {
+        res = execSync(`node ${cpp_transform_bin_path} --file ${fname}`).toString();
+    }
+    catch(e) {      
+        return undefined;
+    }
+
+    return validateCStringLiteral(res.slice(1, -1));
+}
+
+function buildCppAssembly(srcfile: string): Assembly | undefined {
+    const userpackage = new PackageConfig([], [{ srcpath: "test.bsq", filename: "test.bsq", contents: srcfile }]);
+    const [asm, perrors, terrors] = generateASMCPP(userpackage);
+
+    if(perrors.length === 0 && terrors.length === 0) {
+        return asm;
+    }
+    else {
+        return undefined;
+    }
+}
+
+//
+// Remove extra fluff and grab only body of main 
+//
+function formatOutputCpp(cpp: string) {
+    let formatted = cpp.replace(/(\r\n|\n|\r)/gm, "");
+    
+    const body = formatted.match(/\{([\s\S]*)\}/);
+    if (body && body[1]) {
+        formatted = body[1].trim();
+        
+        const inner = formatted.match(/\{([\s\S]*)\}/);
+        if(inner && inner[1]) {
+            formatted = inner[1].trim();
+        }
+    }
+    
+    return formatted;
+}
+
+//
+// Not sure if we need cpp_output here
+//
+function execMainCode(bsqcode: string, cpp_output: string) {
+    const nndir = fs.mkdtempSync(path.join(tmpdir(), "bosque-cpptest-"));
+
+    let result = "";
+    try {
+        const cppasm = buildCppAssembly("declare namespace Main;\n\n" + bsqcode);
+        if(cppasm === undefined) {
+            result = `[FAILED TO BUILD CPP ASSEMBLY] \n\n ${bsqcode}`;
+        }
+        else {
+            const cpp = buildMainCode(cppasm, nndir);
+            if(cpp === undefined) {
+                result = `[FAILED TO BUILD MAIN CODE] \n\n ${bsqcode}`;
+            }
+            else {
+                // We will want to eventually be able to exec the code here
+                // For now we just assign result to be the emitted cpp code for comparisons
+                result = cpp;
+            }
+        }
+    }
+    catch(e) {
+        result = `[Unexpected error ${e}]`;
+    }
+    finally {
+        fs.rmSync(nndir, { recursive: true});
+    }
+    return formatOutputCpp(result);
+}
+
+function runMainCode(bsqcode: string, cpp_output: string) {
+    const emitted_cpp = execMainCode(bsqcode, cpp_output);
+
+    //
+    // Need to do some cleanup with what it spits out, we are only interested
+    // in what main contains.
+    //
+
+    // See if emitted cpp matches what we expect
+    assert.equal(cpp_output, emitted_cpp);
+}
+
+export { cppns, runMainCode};

--- a/test/cppoutput/cppemit_nf.ts
+++ b/test/cppoutput/cppemit_nf.ts
@@ -14,25 +14,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const bosque_dir: string = path.join(__dirname, "../../../");
 const cpp_transform_bin_path = path.join(bosque_dir, "bin/cppemit/CPPEmitter.mjs");
-
-// We WILL need this to be able to check results when we exec our emitted cpp
-// const cpp_runtime_code_path = path.join(bosque_dir, "bin/cppruntime/emit.cpp");
+const cpp_runtime_dir_path = path.join(bosque_dir, "bin/cppruntime/");
+const cpp_runtime_code_path = path.join(bosque_dir, "bin/cppruntime/emit.cpp");
 
 import { tmpdir } from 'node:os';
 import { BSQIREmitter } from "../../src/frontend/bsqir_emit.js";
 import { validateCStringLiteral } from "@bosque/jsbrex";
-
-// Just so if we change the namespace our tests dont break
-const cppns: string = "__CoreCpp::";
-
-//
-// We will first do our tests by simply comparing the spat out result (after running our cpp emit)
-// and ensure it matches the anticipated cpp output.
-//
-// Then once this is functional we will add another parameter where we can check the anticipated result
-// after executing the generatec cpp code. Likely will want to make this optional.
-// (we may not care about what the result is, just that the emitted cpp matches what we anticipate.)
-//
 
 function buildMainCode(assembly: Assembly, outname: string): string | undefined {
     const iim = InstantiationPropagator.computeInstantiations(assembly, "Main");
@@ -56,7 +43,30 @@ function buildMainCode(assembly: Assembly, outname: string): string | undefined 
         return undefined;
     }
 
-    return validateCStringLiteral(res.slice(1, -1));
+    return validateCStringLiteral(res.slice(1, -2));
+}
+
+function generateCPPFile(cpp: string, outdir: string): boolean {    
+    const dir = path.normalize(outdir);
+
+    let contents: string = "";
+    try {
+        contents = fs.readFileSync(cpp_runtime_code_path).toString() + `\n\n`;
+    }
+    catch(e) {
+        return false
+    }
+    const runtime_header: string = `#include "${cpp_runtime_dir_path}cppruntime.hpp"\n\n`;
+    const new_contents: string = runtime_header.concat( cpp, contents );   
+
+    try {
+        const fname = path.join(dir, "emit.cpp");
+        fs.writeFileSync(fname, new_contents);
+    }
+    catch(e) {
+        return false;
+    }    
+    return true;
 }
 
 function buildCppAssembly(srcfile: string): Assembly | undefined {
@@ -71,46 +81,48 @@ function buildCppAssembly(srcfile: string): Assembly | undefined {
     }
 }
 
-//
-// Remove extra fluff and grab only body of main 
-//
-function formatOutputCpp(cpp: string) {
-    let formatted = cpp.replace(/(\r\n|\n|\r)/gm, "");
-    
-    const body = formatted.match(/\{([\s\S]*)\}/);
-    if (body && body[1]) {
-        formatted = body[1].trim();
-        
-        const inner = formatted.match(/\{([\s\S]*)\}/);
-        if(inner && inner[1]) {
-            formatted = inner[1].trim();
-        }
-    }
-    
-    return formatted;
-}
-
-//
-// Not sure if we need cpp_output here
-//
-function execMainCode(bsqcode: string, cpp_output: string) {
+function execMainCode(bsqcode: string, expect_err: boolean) {
     const nndir = fs.mkdtempSync(path.join(tmpdir(), "bosque-cpptest-"));
 
     let result = "";
     try {
         const cppasm = buildCppAssembly("declare namespace Main;\n\n" + bsqcode);
         if(cppasm === undefined) {
-            result = `[FAILED TO BUILD CPP ASSEMBLY] \n\n ${bsqcode}`;
+            return `[FAILED TO BUILD CPP ASSEMBLY] \n\n ${cppasm}`;
         }
         else {
             const cpp = buildMainCode(cppasm, nndir);
             if(cpp === undefined) {
-                result = `[FAILED TO BUILD MAIN CODE] \n\n ${bsqcode}`;
+                return `[FAILED TO BUILD MAIN CODE] \n\n ${cppasm}`;
             }
             else {
-                // We will want to eventually be able to exec the code here
-                // For now we just assign result to be the emitted cpp code for comparisons
-                result = cpp;
+                if(!generateCPPFile(cpp, nndir)) {
+                    return `[FAILED TO GENERATE CPP FILE] \n\n ${cpp}`;
+                }
+                else {
+                    const emit_cpp_path = path.join(nndir, "emit.cpp");
+                    const executable_path = path.join(nndir, "emit_executable");
+                    const cc = '/usr/bin/g++'; // Note: This will not work on all systems :(
+                    
+                    try {
+                        execSync(`${cc} ${emit_cpp_path} -o ${executable_path}`);
+                    }
+                    catch {
+                        return `[CPP COMPILATION ERROR] \n\n${cpp}`
+                    }
+
+                    try {
+                        result = execSync(executable_path).toString().trim();
+                    }
+                    catch(e) {
+                        if(expect_err) {
+                            result = (e as any).stdout.toString();
+                        }
+                        else {
+                            return `[C++ RUNTIME ERROR] -- \n\n${cpp}`;
+                        }
+                    }
+                } 
             }
         }
     }
@@ -120,19 +132,18 @@ function execMainCode(bsqcode: string, cpp_output: string) {
     finally {
         fs.rmSync(nndir, { recursive: true});
     }
-    return formatOutputCpp(result);
+    return result;
 }
 
-function runMainCode(bsqcode: string, cpp_output: string) {
-    const emitted_cpp = execMainCode(bsqcode, cpp_output);
-
-    //
-    // Need to do some cleanup with what it spits out, we are only interested
-    // in what main contains.
-    //
-
-    // See if emitted cpp matches what we expect
-    assert.equal(cpp_output, emitted_cpp);
+// Lets check what the emitted cpp code (from bsqcode) spits out and make sure it matches our expected output
+function runMainCode(bsqcode: string, expected_output: string) {
+    const cpp_output = execMainCode(bsqcode, false);
+    assert.equal(cpp_output, expected_output);
 }
 
-export { cppns, runMainCode};
+function runMainCodeError(bsqcode: string, error_msg: string) {
+    const cpp_err_msg = execMainCode(bsqcode, true);
+    assert.equal(cpp_err_msg, error_msg);   
+}
+
+export {runMainCode, runMainCodeError};

--- a/test/cppoutput/cppemit_nf.ts
+++ b/test/cppoutput/cppemit_nf.ts
@@ -17,6 +17,9 @@ const cpp_transform_bin_path = path.join(bosque_dir, "bin/cppemit/CPPEmitter.mjs
 const cpp_runtime_dir_path = path.join(bosque_dir, "bin/cppruntime/");
 const cpp_runtime_code_path = path.join(bosque_dir, "bin/cppruntime/emit.cpp");
 
+const cc_flags: string = "-Og -Wall -Wextra -Wno-unused-parameter -Wuninitialized -Werror -std=gnu++20 -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-omit-frame-pointer -fno-stack-protector";
+const cc: string = "/usr/bin/g++"; // Note: This will not work on all systems :(
+
 const bsq_max_int: string = "4611686018427387903";
 const bsq_min_int: string = "-4611686018427387903";
 const bsq_max_nat: string = "4611686018427387903";
@@ -109,10 +112,9 @@ function execMainCode(bsqcode: string, expect_err: boolean) {
                 else {
                     const emit_cpp_path = path.join(nndir, "emit.cpp");
                     const executable_path = path.join(nndir, "emit_executable");
-                    const cc = '/usr/bin/g++'; // Note: This will not work on all systems :(
                     
                     try {
-                        execSync(`${cc} ${emit_cpp_path} -o ${executable_path}`);
+                        execSync(`${cc} ${cc_flags} ${emit_cpp_path} -o ${executable_path}`);
                     }
                     catch {
                         return `[CPP COMPILATION ERROR] \n\n${cpp}`

--- a/test/cppoutput/cppemit_nf.ts
+++ b/test/cppoutput/cppemit_nf.ts
@@ -126,7 +126,7 @@ function execMainCode(bsqcode: string, expect_err: boolean) {
                             result = (e as any).stdout.toString();
                         }
                         else {
-                            return `[C++ RUNTIME ERROR] -- \n\n${cpp}`;
+                            return `[C++ RUNTIME ERROR] \n\n${cpp}`;
                         }
                     }
                 } 
@@ -142,7 +142,9 @@ function execMainCode(bsqcode: string, expect_err: boolean) {
     return result;
 }
 
+//
 // Lets check what the emitted cpp code (from bsqcode) spits out and make sure it matches our expected output
+//
 function runMainCode(bsqcode: string, expected_output: string) {
     const cpp_output = execMainCode(bsqcode, false);
     assert.equal(cpp_output, expected_output);

--- a/test/cppoutput/cppemit_nf.ts
+++ b/test/cppoutput/cppemit_nf.ts
@@ -17,6 +17,13 @@ const cpp_transform_bin_path = path.join(bosque_dir, "bin/cppemit/CPPEmitter.mjs
 const cpp_runtime_dir_path = path.join(bosque_dir, "bin/cppruntime/");
 const cpp_runtime_code_path = path.join(bosque_dir, "bin/cppruntime/emit.cpp");
 
+const bsq_max_int: string = "4611686018427387903";
+const bsq_min_int: string = "-4611686018427387903";
+const bsq_max_nat: string = "4611686018427387903";
+const bsq_max_bignat: string = "85070591730234615865843651857942052863";
+const bsq_max_bigint: string = "85070591730234615865843651857942052863";
+const bsq_min_bigint: string = "-85070591730234615865843651857942052863";
+
 import { tmpdir } from 'node:os';
 import { BSQIREmitter } from "../../src/frontend/bsqir_emit.js";
 import { validateCStringLiteral } from "@bosque/jsbrex";
@@ -146,4 +153,4 @@ function runMainCodeError(bsqcode: string, error_msg: string) {
     assert.equal(cpp_err_msg, error_msg);   
 }
 
-export {runMainCode, runMainCodeError};
+export {runMainCode, runMainCodeError, bsq_max_int, bsq_max_nat, bsq_max_bigint, bsq_max_bignat, bsq_min_int, bsq_min_bigint};


### PR DESCRIPTION
We now test cpp emission for:
 - addition
 - subtraction
 - multiplication
 - division

Each test also will check for possible overflow cases, ensuring they are detected and handled. These likely aren't 100% coverage, but ensures basic functionality is tested.

Also, our emitted cpp code now writes whatever bosque primitive (for now) is returned from our funny namespaced main (the cpp representation of input bosque code, `__CoreCpp::(type) main() {}`) to cout.