### PR TITLE
Cpp Emit Logic Ops, Unary Ops, Logic Action Expressions, & Testing

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -40,6 +40,14 @@ entity LiteralSimpleExpression provides Expression {
     field value: CString;
 }
 
+entity LogicActionAndExpression provides Expression {
+    field args: List<Expression>;
+}
+
+entity LogicActionOrExpression provides Expression {
+    field args: List<Expression>;
+}
+
 datatype UnaryExpression provides Expression using {
     field expr: Expression;
 }
@@ -73,7 +81,6 @@ NumericEqExpression { }
 | NumericGreaterEqExpression { }
 ;
 
-%*
 datatype BinLogicExpression provides Expression using {
     field lhs: Expression;
     field rhs: Expression;
@@ -84,7 +91,6 @@ BinLogicAndExpression { }
 | BinLogicImpliesExpression { }
 | BinLogicIFFExpression { }
 ;
-*%
 
 datatype BodyImplementation 
 of

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -40,9 +40,16 @@ entity LiteralSimpleExpression provides Expression {
     field value: CString;
 }
 
-datatype BinaryArithExpression provides Expression using {
-    %% Need opertype?
+datatype UnaryExpression provides Expression using {
+    field expr: Expression;
+}
+of
+PrefixNotOpExpression { }
+| PrefixNegateOpExpression { }
+| PrefixPlusOpExpression { }
+;
 
+datatype BinaryArithExpression provides Expression using {
     field lhs: Expression;
     field rhs: Expression;
 }
@@ -54,8 +61,6 @@ BinAddExpression { }
 ;
 
 datatype BinaryNumericExpression provides Expression using {
-    %% Need opertype?
-    
     field lhs: Expression;
     field rhs: Expression;
 }

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -111,10 +111,13 @@ public:
         do_safe_arithmetic(Int, int64_t, mul);
     }
     constexpr Int operator-() noexcept { // dont want to modify value here
-        if(value == MIN_BSQ_INT) {
+        if(this->value == MIN_BSQ_INT) {
             std::longjmp(info.error_handler, true);
         }
         return Int(-value);
+    }
+    constexpr Int operator+() noexcept {
+        return *this;
     }
     friend constexpr Int operator+(Int lhs, const Int& rhs) noexcept { 
         lhs += rhs;
@@ -180,6 +183,9 @@ public:
         }
         return BigInt(-value);
     }
+    constexpr BigInt operator+() noexcept {
+        return *this;
+    }
     friend constexpr BigInt operator+(BigInt lhs, const BigInt& rhs) noexcept { 
         lhs += rhs;
         return lhs;
@@ -228,6 +234,9 @@ public:
     }
     constexpr Nat& operator*=(const Nat& rhs) noexcept {
         do_safe_arithmetic(Nat, uint64_t, mul);
+    }
+    constexpr Nat& operator+() noexcept {
+        return *this;
     }
     friend constexpr Nat operator+(Nat lhs, const Nat& rhs) noexcept { 
         lhs += rhs;
@@ -287,6 +296,9 @@ public:
     constexpr BigNat& operator*=(const BigNat& rhs) noexcept {
         do_safe_arithmetic(BigNat, __uint128_t, mul);
     }
+    constexpr BigNat& operator+() noexcept {
+        return *this;
+    }
     friend constexpr BigNat operator+(BigNat lhs, const BigNat& rhs) noexcept { 
         lhs += rhs;
         return lhs;
@@ -337,6 +349,9 @@ public:
     }
     constexpr Float& operator*=(const Float& rhs) noexcept {
         do_safe_float_arithmetic(*);
+    }
+    constexpr Float& operator+() noexcept {
+        return *this;
     }
     constexpr Float operator-() noexcept { // dont want to modify value here
         return Float(-this->value);

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -110,14 +110,14 @@ public:
     constexpr Int& operator*=(const Int& rhs) noexcept {
         do_safe_arithmetic(Int, int64_t, mul);
     }
+    constexpr Int& operator+() noexcept {
+        return *this;
+    }
     constexpr Int operator-() noexcept { // dont want to modify value here
         if(this->value == MIN_BSQ_INT) {
             std::longjmp(info.error_handler, true);
         }
         return Int(-value);
-    }
-    constexpr Int operator+() noexcept {
-        return *this;
     }
     friend constexpr Int operator+(Int lhs, const Int& rhs) noexcept { 
         lhs += rhs;
@@ -177,14 +177,14 @@ public:
     constexpr BigInt& operator*=(const BigInt& rhs) noexcept {
         do_safe_arithmetic(BigInt, __int128_t, mul);
     }
+    constexpr BigInt& operator+() noexcept {
+        return *this;
+    }
     constexpr BigInt operator-() noexcept { // dont want to modify value here
         if(this->value == MIN_BSQ_BIGINT) {
             std::longjmp(info.error_handler, true);
         }
         return BigInt(-value);
-    }
-    constexpr BigInt operator+() noexcept {
-        return *this;
     }
     friend constexpr BigInt operator+(BigInt lhs, const BigInt& rhs) noexcept { 
         lhs += rhs;

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -126,7 +126,6 @@ recursive function emitPrefixNegateOpExpression(negop: CPPAssembly::PrefixNegate
     return CString::concat('-', expr);
 }
 
-%% I think this is how prefix plus works? doesnt convert value to positive, just visual specifier?
 recursive function emitPrefixPlusOpExpression(plusop: CPPAssembly::PrefixPlusOpExpression): CString {
     return emitExpression[recursive](plusop.expr);
 }
@@ -181,7 +180,6 @@ recursive function emitNumericGreaterEqExpression(e: CPPAssembly::NumericGreater
     return CString::concat('(', lhs, ' >= ', rhs, ')');   
 }
 
-%% May be able to remove function calls here...?
 recursive function emitBinaryNumericExpression(e: CPPAssembly::BinaryNumericExpression): CString {
     match(e)@ {
         CPPAssembly::NumericEqExpression => { return emitNumericEqExpression[recursive]($e); }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -181,6 +181,7 @@ recursive function emitNumericGreaterEqExpression(e: CPPAssembly::NumericGreater
     return CString::concat('(', lhs, ' >= ', rhs, ')');   
 }
 
+%% May be able to remove function calls here...?
 recursive function emitBinaryNumericExpression(e: CPPAssembly::BinaryNumericExpression): CString {
     match(e)@ {
         CPPAssembly::NumericEqExpression => { return emitNumericEqExpression[recursive]($e); }
@@ -192,11 +193,67 @@ recursive function emitBinaryNumericExpression(e: CPPAssembly::BinaryNumericExpr
     }
 }
 
+recursive function emitBinLogicAndExpression(e: CPPAssembly::BinLogicAndExpression): CString {
+    let lhs = emitExpression[recursive](e.lhs);
+    let rhs = emitExpression[recursive](e.rhs);   
+
+    return CString::concat('(', lhs, ' && ', rhs, ')');
+}
+
+recursive function emitBinLogicOrExpression(e: CPPAssembly::BinLogicOrExpression): CString {
+    let lhs = emitExpression[recursive](e.lhs);
+    let rhs = emitExpression[recursive](e.rhs);   
+
+    return CString::concat('(', lhs, ' || ', rhs, ')');
+}
+
+recursive function emitBinLogicImpliesExpression(e: CPPAssembly::BinLogicImpliesExpression): CString {
+    let lhs = emitExpression[recursive](e.lhs);
+    let rhs = emitExpression[recursive](e.rhs);  
+
+    let implies: CString = CString::concat('!', lhs, ' || ', rhs);
+    return CString::concat('(', implies ,')');
+}
+
+recursive function emitBinLogicIFFExpression(e: CPPAssembly::BinLogicIFFExpression): CString {
+    let lhs = emitExpression[recursive](e.lhs);
+    let rhs = emitExpression[recursive](e.rhs); 
+    let nlhs: CString = CString::concat('!', lhs);
+    let nrhs: CString = CString::concat('!', rhs);
+
+    let first: CString = CString::concat('(', lhs, ' && ', rhs, ')');
+    let second: CString = CString::concat('(', nlhs, ' && ', nrhs, ')');
+
+    return CString::concat('(', first, ' || ', second, ')');
+}
+
+recursive function emitBinLogicExpression(e: CPPAssembly::BinLogicExpression): CString {
+    match(e)@ {
+        CPPAssembly::BinLogicAndExpression => { return emitBinLogicAndExpression[recursive]($e); }
+        | CPPAssembly::BinLogicOrExpression => { return emitBinLogicOrExpression[recursive]($e); }
+        | CPPAssembly::BinLogicImpliesExpression => { return emitBinLogicImpliesExpression[recursive]($e); }
+        | CPPAssembly::BinLogicIFFExpression => { return emitBinLogicIFFExpression[recursive]($e); }
+    }
+}
+
+recursive function emitLogicActionAndExpression(e: CPPAssembly::LogicActionAndExpression): CString {
+    let args = e.args.map<CString>(fn(expr) => emitExpression[recursive](expr));
+    return CString::concat('(', CString::joinAll(' && ', args), ')');
+}
+
+recursive function emitLogicActionOrExpression(e: CPPAssembly::LogicActionOrExpression): CString {
+    let args = e.args.map<CString>(fn(expr) => emitExpression[recursive](expr));
+    return CString::concat('(', CString::joinAll(' || ', args), ')');
+}
+
 function emitExpression(e: CPPAssembly::Expression): CString {
     match(e)@ {
         CPPAssembly::BinaryArithExpression => { return emitBinaryArithExpression[recursive]($e); }
         | CPPAssembly::BinaryNumericExpression => { return emitBinaryNumericExpression[recursive]($e); }
         | CPPAssembly::UnaryExpression => { return emitUnaryExpression[recursive]($e); }
+        | CPPAssembly::BinLogicExpression => { return emitBinLogicExpression[recursive]($e); }
+        | CPPAssembly::LogicActionAndExpression => { return emitLogicActionAndExpression[recursive]($e); }
+        | CPPAssembly::LogicActionOrExpression => { return emitLogicActionOrExpression[recursive]($e); }
         | CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($e); }
         | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e); }
         | _ => { abort; }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -118,18 +118,17 @@ recursive function emitBinaryArithExpression(e: CPPAssembly::BinaryArithExpressi
 
 recursive function emitPrefixNotOpExpression(notop: CPPAssembly::PrefixNotOpExpression): CString {
     let expr = emitExpression[recursive](notop.expr);
-    return CString::concat('(', '!', expr, ')');
+    return CString::concat('!', expr);
 }
 
 recursive function emitPrefixNegateOpExpression(negop: CPPAssembly::PrefixNegateOpExpression): CString {
     let expr = emitExpression[recursive](negop.expr);
-    return CString::concat('(', '-', expr, ')');
+    return CString::concat('-', expr);
 }
 
 %% I think this is how prefix plus works? doesnt convert value to positive, just visual specifier?
 recursive function emitPrefixPlusOpExpression(plusop: CPPAssembly::PrefixPlusOpExpression): CString {
-    let expr = emitExpression[recursive](plusop.expr);
-    return CString::concat('(', expr, ')');
+    return emitExpression[recursive](plusop.expr);
 }
 
 recursive function emitUnaryExpression(e: CPPAssembly::UnaryExpression): CString {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -116,6 +116,30 @@ recursive function emitBinaryArithExpression(e: CPPAssembly::BinaryArithExpressi
     }
 }
 
+recursive function emitPrefixNotOpExpression(notop: CPPAssembly::PrefixNotOpExpression): CString {
+    let expr = emitExpression[recursive](notop.expr);
+    return CString::concat('(', '!', expr, ')');
+}
+
+recursive function emitPrefixNegateOpExpression(negop: CPPAssembly::PrefixNegateOpExpression): CString {
+    let expr = emitExpression[recursive](negop.expr);
+    return CString::concat('(', '-', expr, ')');
+}
+
+%% I think this is how prefix plus works? doesnt convert value to positive, just visual specifier?
+recursive function emitPrefixPlusOpExpression(plusop: CPPAssembly::PrefixPlusOpExpression): CString {
+    let expr = emitExpression[recursive](plusop.expr);
+    return CString::concat('(', expr, ')');
+}
+
+recursive function emitUnaryExpression(e: CPPAssembly::UnaryExpression): CString {
+    match(e)@ {
+        CPPAssembly::PrefixNotOpExpression => { return emitPrefixNotOpExpression[recursive]($e); }
+        | CPPAssembly::PrefixNegateOpExpression => { return emitPrefixNegateOpExpression[recursive]($e); }
+        | CPPAssembly::PrefixPlusOpExpression => { return emitPrefixPlusOpExpression[recursive]($e); }
+    }
+}
+
 recursive function emitNumericEqExpression(e: CPPAssembly::NumericEqExpression): CString {
     let lhs = emitExpression[recursive](e.lhs);
     let rhs = emitExpression[recursive](e.rhs);
@@ -173,6 +197,7 @@ function emitExpression(e: CPPAssembly::Expression): CString {
     match(e)@ {
         CPPAssembly::BinaryArithExpression => { return emitBinaryArithExpression[recursive]($e); }
         | CPPAssembly::BinaryNumericExpression => { return emitBinaryNumericExpression[recursive]($e); }
+        | CPPAssembly::UnaryExpression => { return emitUnaryExpression[recursive]($e); }
         | CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($e); }
         | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e); }
         | _ => { abort; }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -46,29 +46,21 @@ entity CPPTransformer {
 
     recursive method transformBinAddExpressionToCpp(expr: BSQAssembly::BinAddExpression): CPPAssembly::BinAddExpression {
         let lexpr, rexpr = this.processBinaryArgs[recursive](expr.lhs, expr.rhs);
-
-        %% lhs and rhs for addition operator must have same type, so it does not matter what expr we use for etype
         return CPPAssembly::BinAddExpression{ lexpr.etype, lexpr, rexpr };
     }
 
     recursive method transformBinSubExpressionToCpp(expr: BSQAssembly::BinSubExpression): CPPAssembly::BinSubExpression {
         let lexpr, rexpr = this.processBinaryArgs[recursive](expr.lhs, expr.rhs);
-
-        %% lhs and rhs for addition operator must have same type, so it does not matter what expr we use for etype
         return CPPAssembly::BinSubExpression{ lexpr.etype, lexpr, rexpr };
     }
 
     recursive method transformBinDivExpressionToCpp(expr: BSQAssembly::BinDivExpression): CPPAssembly::BinDivExpression {
         let lexpr, rexpr = this.processBinaryArgs[recursive](expr.lhs, expr.rhs);
-
-        %% lhs and rhs for addition operator must have same type, so it does not matter what expr we use for etype
         return CPPAssembly::BinDivExpression{ lexpr.etype, lexpr, rexpr };
     }
 
     recursive method transformBinMultExpressionToCpp(expr: BSQAssembly::BinMultExpression): CPPAssembly::BinMultExpression {
         let lexpr, rexpr = this.processBinaryArgs[recursive](expr.lhs, expr.rhs);
-
-        %% lhs and rhs for addition operator must have same type, so it does not matter what expr we use for etype
         return CPPAssembly::BinMultExpression{ lexpr.etype, lexpr, rexpr };
     }
 
@@ -93,8 +85,7 @@ entity CPPTransformer {
             return CPPAssembly::LiteralSimpleExpression{ exprtype, val.removeSuffixString('f') };
         }
         else {
-            %% Fall through
-            return CPPAssembly::LiteralSimpleExpression{ exprtype, val };
+            return CPPAssembly::LiteralSimpleExpression{ exprtype, val }; %% Fall through
         }
     }
 
@@ -106,8 +97,18 @@ entity CPPTransformer {
         return CPPAssembly::AccessVariableExpression { vtype, vname, layouttype };
     }
 
+    recursive method transformUnaryExpression(uexpr: BSQAssembly::UnaryExpression): CPPAssembly::UnaryExpression {
+        let expr = this.transformExpressionToCpp[recursive](uexpr.exp);
+
+        match(uexpr)@ {
+            BSQAssembly::PrefixNotOpExpression => { return CPPAssembly::PrefixNotOpExpression{ expr.etype, expr }; }
+            | BSQAssembly::PrefixNegateOpExpression => { return CPPAssembly::PrefixNegateOpExpression{ expr.etype, expr }; }
+            | BSQAssembly::PrefixPlusOpExpression => { return CPPAssembly::PrefixPlusOpExpression{ expr.etype, expr }; }
+        }
+    }
+
     %% I think we can simplify this and remove the transform functions, just match our bsqasm type then return transform type
-    recursive method transformBinaryArithExpressionToCpp(binarith: BSQAssembly::BinaryArithExpression): CPPAssembly::BinaryArithExpression {
+    recursive method transformBinaryArithExpression(binarith: BSQAssembly::BinaryArithExpression): CPPAssembly::BinaryArithExpression {
         match(binarith)@ {
             BSQAssembly::BinAddExpression => { return this.transformBinAddExpressionToCpp[recursive]($binarith); }
             | BSQAssembly::BinSubExpression => { return this.transformBinSubExpressionToCpp[recursive]($binarith); }           
@@ -132,25 +133,26 @@ entity CPPTransformer {
 
     recursive method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
         match(expr)@ {
-            BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpressionToCpp[recursive]($expr); }
+            BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpression[recursive]($expr); }
             | BSQAssembly::BinaryNumericExpression => { return this.transformBinaryNumericCompareExpression[recursive]($expr); }
+            | BSQAssembly::UnaryExpression => { return this.transformUnaryExpression[recursive]($expr); }
             | BSQAssembly::LiteralSimpleExpression => { return this.transformLiteralSimpleExpression($expr); }
             | BSQAssembly::AccessVariableExpression => { return this.transformAccessVariableExpression($expr); }
             | _ => { abort; }
         }
     }
 
-    method transformReturnSingleStatementToCpp(ret: BSQAssembly::ReturnSingleStatement): CPPAssembly::ReturnSingleStatement {
+    recursive method transformReturnSingleStatementToCpp(ret: BSQAssembly::ReturnSingleStatement): CPPAssembly::ReturnSingleStatement {
         let rtype = CPPTransformNameManager::convertTypeSignature(ret.rtype);
-        let rexp = this.transformExpressionToCpp(ret.value);
+        let rexp = this.transformExpressionToCpp[recursive](ret.value);
 
         return CPPAssembly::ReturnSingleStatement{rtype, rexp};
     }
 
-    method transformVariableInitializationStatementToCpp(stmt: BSQAssembly::VariableInitializationStatement): CPPAssembly::VariableInitializationStatement {
+    recursive method transformVariableInitializationStatementToCpp(stmt: BSQAssembly::VariableInitializationStatement): CPPAssembly::VariableInitializationStatement {
         let name = CPPTransformNameManager::convertIdentifier(stmt.name);
         let stype = CPPTransformNameManager::convertTypeSignature(stmt.vtype);
-        let cppexpr = this.transformExpressionToCpp(stmt.exp);
+        let cppexpr = this.transformExpressionToCpp[recursive](stmt.exp);
 
         return CPPAssembly::VariableInitializationStatement{name, stype, cppexpr};
     }
@@ -158,7 +160,7 @@ entity CPPTransformer {
     method transformStatementToCpp(stmt: BSQAssembly::Statement): CPPAssembly::Statement {
         match(stmt)@ {
             BSQAssembly::VariableInitializationStatement => { return this.transformVariableInitializationStatementToCpp($stmt); }
-            | BSQAssembly::ReturnSingleStatement => { return this.transformReturnSingleStatementToCpp($stmt); }
+            | BSQAssembly::ReturnSingleStatement => { return this.transformReturnSingleStatementToCpp[recursive]($stmt); }
             | _ => { abort; }
         }
     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -89,6 +89,7 @@ entity CPPTransformer {
         }
     }
 
+    %% uh
     method transformAccessVariableExpression(expr: BSQAssembly::AccessVariableExpression): CPPAssembly::AccessVariableExpression {
         let vname = CPPTransformNameManager::convertVarIdentifier(expr.vname);
         let vtype = CPPTransformNameManager::convertTypeSignature(expr.etype);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -84,12 +84,11 @@ entity CPPTransformer {
         elif(val.endsWithString('f')) {
             return CPPAssembly::LiteralSimpleExpression{ exprtype, val.removeSuffixString('f') };
         }
-        else {
-            return CPPAssembly::LiteralSimpleExpression{ exprtype, val }; %% Fall through
+        else { %% Fall through, may need explicit handling in future
+            return CPPAssembly::LiteralSimpleExpression{ exprtype, val };
         }
     }
 
-    %% uh
     method transformAccessVariableExpression(expr: BSQAssembly::AccessVariableExpression): CPPAssembly::AccessVariableExpression {
         let vname = CPPTransformNameManager::convertVarIdentifier(expr.vname);
         let vtype = CPPTransformNameManager::convertTypeSignature(expr.etype);
@@ -136,8 +135,8 @@ entity CPPTransformer {
         match(expr)@ {
             BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpression[recursive]($expr); }
             | BSQAssembly::BinaryNumericExpression => { return this.transformBinaryNumericCompareExpression[recursive]($expr); }
-            | BSQAssembly::UnaryExpression => { return this.transformUnaryExpression[recursive]($expr); }
             | BSQAssembly::LiteralSimpleExpression => { return this.transformLiteralSimpleExpression($expr); }
+            | BSQAssembly::UnaryExpression => { return this.transformUnaryExpression[recursive]($expr); }
             | BSQAssembly::AccessVariableExpression => { return this.transformAccessVariableExpression($expr); }
             | _ => { abort; }
         }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -120,15 +120,41 @@ entity CPPTransformer {
     recursive method transformBinaryNumericCompareExpression(expr: BSQAssembly::BinaryNumericExpression): CPPAssembly::BinaryNumericExpression {
         let cpplhs, cpprhs = this.processBinaryArgs[recursive](expr.lhs, expr.rhs);
 
-        let etype = CPPTransformNameManager::convertTypeSignature(expr.etype);
+        let cpptype = CPPTransformNameManager::convertTypeSignature(expr.etype);
         match(expr)@ {
-            BSQAssembly::NumericEqExpression => { return CPPAssembly::NumericEqExpression { etype, cpplhs, cpprhs }; }
-            | BSQAssembly::NumericNeqExpression => { return CPPAssembly::NumericNeqExpression{ etype, cpplhs, cpprhs }; }
-            | BSQAssembly::NumericLessExpression => { return CPPAssembly::NumericLessExpression{ etype, cpplhs, cpprhs}; }
-            | BSQAssembly::NumericLessEqExpression => { return CPPAssembly::NumericLessEqExpression{ etype, cpplhs, cpprhs }; }
-            | BSQAssembly::NumericGreaterExpression => { return CPPAssembly::NumericGreaterExpression{ etype, cpplhs, cpprhs }; }
-            | BSQAssembly::NumericGreaterEqExpression => { return CPPAssembly::NumericGreaterEqExpression{ etype, cpplhs, cpprhs }; }
+            BSQAssembly::NumericEqExpression => { return CPPAssembly::NumericEqExpression { cpptype, cpplhs, cpprhs }; }
+            | BSQAssembly::NumericNeqExpression => { return CPPAssembly::NumericNeqExpression{ cpptype, cpplhs, cpprhs }; }
+            | BSQAssembly::NumericLessExpression => { return CPPAssembly::NumericLessExpression{ cpptype, cpplhs, cpprhs}; }
+            | BSQAssembly::NumericLessEqExpression => { return CPPAssembly::NumericLessEqExpression{ cpptype, cpplhs, cpprhs }; }
+            | BSQAssembly::NumericGreaterExpression => { return CPPAssembly::NumericGreaterExpression{ cpptype, cpplhs, cpprhs }; }
+            | BSQAssembly::NumericGreaterEqExpression => { return CPPAssembly::NumericGreaterEqExpression{ cpptype, cpplhs, cpprhs }; }
         }
+    }
+
+    recursive method transformBinLogicExpression(expr: BSQAssembly::BinLogicExpression): CPPAssembly::BinLogicExpression {
+        let cpplhs, cpprhs = this.processBinaryArgs[recursive](expr.lhs, expr.rhs);
+        let cpptype = CPPTransformNameManager::convertTypeSignature(expr.etype);
+
+        match(expr)@ {
+            BSQAssembly::BinLogicAndExpression => { return CPPAssembly::BinLogicAndExpression{ cpptype, cpplhs, cpprhs }; }
+            | BSQAssembly::BinLogicOrExpression => { return CPPAssembly::BinLogicOrExpression{ cpptype, cpplhs, cpprhs }; }
+            | BSQAssembly::BinLogicImpliesExpression => { return CPPAssembly::BinLogicImpliesExpression{ cpptype, cpplhs, cpprhs }; }
+            | BSQAssembly::BinLogicIFFExpression => { return CPPAssembly::BinLogicIFFExpression{ cpptype, cpplhs, cpprhs }; }
+        }
+    }
+
+    recursive method transformLogicActionAndExpression(expr: BSQAssembly::LogicActionAndExpression): CPPAssembly::LogicActionAndExpression {
+        let args = expr.args.map<CPPAssembly::Expression>(fn(e) => this.transformExpressionToCpp(e));
+        let cpptype = CPPTransformNameManager::convertTypeSignature(expr.etype);
+
+        return CPPAssembly::LogicActionAndExpression{cpptype, args};
+    }
+
+    recursive method transformLogicActionOrExpression(expr: BSQAssembly::LogicActionOrExpression): CPPAssembly::LogicActionOrExpression {
+        let args = expr.args.map<CPPAssembly::Expression>(fn(e) => this.transformExpressionToCpp(e));
+        let cpptype = CPPTransformNameManager::convertTypeSignature(expr.etype);
+
+        return CPPAssembly::LogicActionOrExpression{cpptype, args};
     }
 
     recursive method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
@@ -137,6 +163,9 @@ entity CPPTransformer {
             | BSQAssembly::BinaryNumericExpression => { return this.transformBinaryNumericCompareExpression[recursive]($expr); }
             | BSQAssembly::LiteralSimpleExpression => { return this.transformLiteralSimpleExpression($expr); }
             | BSQAssembly::UnaryExpression => { return this.transformUnaryExpression[recursive]($expr); }
+            | BSQAssembly::BinLogicExpression => { return this.transformBinLogicExpression[recursive]($expr); }
+            | BSQAssembly::LogicActionAndExpression => { return this.transformLogicActionAndExpression[recursive]($expr); }
+            | BSQAssembly::LogicActionOrExpression => { return this.transformLogicActionOrExpression[recursive]($expr); }
             | BSQAssembly::AccessVariableExpression => { return this.transformAccessVariableExpression($expr); }
             | _ => { abort; }
         }

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -490,11 +490,17 @@ class BSQIREmitter {
     }
 
     private emitLogicActionAndExpression(exp: LogicActionAndExpression): string {
-        assert(false, "Not implemented -- LogicActionAnd");
+        const ebase = this.emitExpressionBase(exp);
+        const args = exp.args.map((arg) => this.emitExpression(arg)).join(", ");
+
+        return `BSQAssembly::LogicActionAndExpression{ ${ebase}, args = List<BSQAssembly::Expression>{${args}} }`
     }
     
     private emitLogicActionOrExpression(exp: LogicActionOrExpression): string {
-        assert(false, "Not implemented -- LogicActionOr");
+        const ebase = this.emitExpressionBase(exp);
+        const args = exp.args.map((arg) => this.emitExpression(arg)).join(", ");
+
+        return `BSQAssembly::LogicActionOrExpression{ ${ebase}, args = List<BSQAssembly::Expression>{${args}} }`
     }
     
     private emitParseAsTypeExpression(exp: ParseAsTypeExpression): string {

--- a/test/cppoutput/bin_exps/addition.test.js
+++ b/test/cppoutput/bin_exps/addition.test.js
@@ -3,7 +3,7 @@
 import { runMainCode, runMainCodeError, bsq_max_nat, bsq_max_int,  bsq_max_bignat, bsq_max_bigint } from "../../../bin/test/cppoutput/cppemit_nf.js"
 import { describe, it } from "node:test";
 
-describe( "CPP Evaluate --- Simple addition", () => {
+describe( "CPP Emit Evaluate --- Simple addition", () => {
     it("should cpp emit addition simple", function () {
         runMainCode("public function main(): Nat { return 2n + 2n; }", "4_n");
         runMainCode("public function main(): Int { return 4i + 100i; }", "104_i");

--- a/test/cppoutput/bin_exps/division.test.js
+++ b/test/cppoutput/bin_exps/division.test.js
@@ -3,7 +3,7 @@
 import { runMainCode, runMainCodeError } from "../../../bin/test/cppoutput/cppemit_nf.js"
 import { describe, it } from "node:test";
 
-describe( "CPP Evaluate --- Simple Division", () => {
+describe( "CPP Emit Evaluate --- Simple Division", () => {
     it("should cpp emit division simple", function () {
         runMainCode("public function main(): Nat { return 2n // 2n; }", "1_n");
         runMainCode("public function main(): Int { return 4i // 1i; }", "4_i");

--- a/test/cppoutput/bin_exps/multipication.test.js
+++ b/test/cppoutput/bin_exps/multipication.test.js
@@ -3,7 +3,7 @@
 import { runMainCode, runMainCodeError, bsq_max_nat, bsq_max_int,  bsq_max_bignat, bsq_max_bigint } from "../../../bin/test/cppoutput/cppemit_nf.js"
 import { describe, it } from "node:test";
 
-describe( "CPP Evaluate --- Simple Multiplication", () => {
+describe( "CPP Emit Evaluate --- Simple Multiplication", () => {
     it("should cpp emit multiplication simple", function () {
         runMainCode("public function main(): Nat { return 2n * 2n; }", "4_n");
         runMainCode("public function main(): Nat { return 2n * 0n; }", "0_n");

--- a/test/cppoutput/bin_exps/subtraction.test.js
+++ b/test/cppoutput/bin_exps/subtraction.test.js
@@ -3,7 +3,7 @@
 import { runMainCode, runMainCodeError, bsq_min_int, bsq_min_bigint } from "../../../bin/test/cppoutput/cppemit_nf.js"
 import { describe, it } from "node:test";
 
-describe( "CPP Evaluate --- Simple Subtraction", () => {
+describe( "CPP Emit Evaluate --- Simple Subtraction", () => {
     it("should cpp emit subtraction simple", function () {
         runMainCode("public function main(): Nat { return 2n - 2n; }", "0_n");
         runMainCode("public function main(): Int { return 2i - -2i; }", "4_i");

--- a/test/cppoutput/compare_ops/equality.test.js
+++ b/test/cppoutput/compare_ops/equality.test.js
@@ -1,0 +1,18 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe("CPP Emit Evalutate -- basic equals", () => {
+    it("should exec compare simple types", function () {
+        runMainCode("public function main(): Bool { return 0n == 1n; }", "false");
+        runMainCode("public function main(): Bool { return +2i == 2i; }", "true");
+    })
+});
+
+describe("CPP Emit Evalutate -- basic !equals", () => {
+    it("should exec compare simple types", function () {
+        runMainCode("public function main(): Bool { return 0n != 1n; }", "true");
+        runMainCode("public function main(): Bool { return +2i != 2i; }", "false");
+    })
+});

--- a/test/cppoutput/compare_ops/greater.test.js
+++ b/test/cppoutput/compare_ops/greater.test.js
@@ -1,0 +1,22 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe("CPP Emit Evaluate -- basic >", () => {
+    it("should exec compare simple types", function () {
+        runMainCode("public function main(): Bool { return 0n > 1n; }", "false");
+        runMainCode("public function main(): Bool { return +2i > -2i; }", "true");
+
+        runMainCode("public function main(): Bool { return 1n > 1n; }", "false");
+    });
+});
+
+describe("CPP Emit Evaluate -- basic >", () => {
+    it("should exec compare simple types", function () {
+        runMainCode("public function main(): Bool { return 0n >= 1n; }", "false");
+        runMainCode("public function main(): Bool { return +2i >= -2i; }", "true");
+
+        runMainCode("public function main(): Bool { return 1n >= 1n; }", "true");
+    });
+});

--- a/test/cppoutput/compare_ops/less.test.js
+++ b/test/cppoutput/compare_ops/less.test.js
@@ -1,0 +1,22 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate -- basic <", () => {
+    it("should exec compare simple types", function () {
+        runMainCode("public function main(): Bool { return 0n < 1n; }", "true");
+        runMainCode("public function main(): Bool { return +2i < -2i; }", "false");
+
+        runMainCode("public function main(): Bool { return 1n < 1n; }", "false");
+    });
+});
+
+describe ("CPP Emit Evaluate -- basic <=", () => {
+    it("should exec compare simple types", function () {
+        runMainCode("public function main(): Bool { return 0n <= 1n; }", "true");
+        runMainCode("public function main(): Bool { return +2i <= -2i; }", "false");
+
+        runMainCode("public function main(): Bool { return 1n <= 1n; }", "true");
+    });
+});

--- a/test/cppoutput/literals/numeric.test.js
+++ b/test/cppoutput/literals/numeric.test.js
@@ -1,0 +1,42 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";
+
+describe("CPP Emit Evaluate -- Nat", () => {
+    it("should exec simple nats", function () {
+        runMainCode("public function main(): Nat { return 0n; }", "0_n");
+        runMainCode("public function main(): Nat { return +2n; }", "2_n");
+    });
+});
+
+describe("CPP Emit Evaluate -- Int", () => {
+    it("should check simple ints", function () {
+        runMainCode("public function main(): Int { return 0i; }", "0_i");
+        runMainCode("public function main(): Int { return +2i; }", "2_i");
+        runMainCode("public function main(): Int { return -2i; }", "-2_i");
+    });
+});
+
+describe("CPP Emit Evaluate -- BigNat", () => {
+    it("should exec simple big nats", function () {
+        runMainCode("public function main(): BigNat { return 0N; }", "0_N");
+        runMainCode("public function main(): BigNat { return +2N; }", "2_N");
+    });
+});
+
+describe("CPP Emit Evaluate -- BigInt", () => {
+    it("should exec simple big ints", function () {
+        runMainCode("public function main(): BigInt { return 0I; }", "0_I");
+        runMainCode("public function main(): BigInt { return +2I; }", "2_I");
+        runMainCode("public function main(): BigInt { return -2I; }", "-2_I");
+    });
+});
+
+describe("CPP Emit Evaluate -- Float", () => {
+    it("should exec simple floats", function () {
+        runMainCode("public function main(): Bool { return 0.0f < 0.1f; }", "true");
+        runMainCode("public function main(): Bool { return 1.0f > 0.9f; }", "true");
+        runMainCode("public function main(): Bool { return -2.0f < -1.9f; }", "true");
+    });
+});

--- a/test/cppoutput/literals/special.test.js
+++ b/test/cppoutput/literals/special.test.js
@@ -1,0 +1,11 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";
+
+describe("CPP Emit Evaluate -- Bool", () => {
+    it("should exec simple boolean", function () {
+        runMainCode("public function main(): Bool { return true; }", "true");
+        runMainCode("public function main(): Bool { return false; }", "false");
+    });
+});

--- a/test/cppoutput/logical_ops/logical_and.test.js
+++ b/test/cppoutput/logical_ops/logical_and.test.js
@@ -1,0 +1,15 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate -- logical and", () => {
+    it("should exec simple and", function () {
+        runMainCode("public function main(): Bool { return true && false; }", "false");
+        runMainCode("public function main(): Bool { return true && true; }", "true");
+    });
+
+    it("should exec sc and", function () {
+        runMainCode("public function main(): Bool { return false && (1i // 0i) == 1i; }", "false");
+    });
+});

--- a/test/cppoutput/logical_ops/logical_iff.test.js
+++ b/test/cppoutput/logical_ops/logical_iff.test.js
@@ -1,0 +1,11 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate -- logical iff", () => {
+    it("should exec simple iff", function () {
+        runMainCode("public function main(): Bool { return true <==> false; }", "false");
+        runMainCode("public function main(): Bool { return false <==> false; }", "true");
+    });
+});

--- a/test/cppoutput/logical_ops/logical_implies.test.js
+++ b/test/cppoutput/logical_ops/logical_implies.test.js
@@ -1,0 +1,15 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate -- logical implies", () => {
+    it("should exec simple implies", function () {
+        runMainCode("public function main(): Bool { return true ==> false; }", "false");
+        runMainCode("public function main(): Bool { return false ==> true; }", "true");
+    });
+
+    it("should exec sc implies", function () {
+        runMainCode("public function main(): Bool { return false ==> (1i // 0i) == 1i; }", "true");
+    });
+});

--- a/test/cppoutput/logical_ops/logical_or.test.js
+++ b/test/cppoutput/logical_ops/logical_or.test.js
@@ -1,0 +1,15 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate -- logical or", () => {
+    it("should exec simple or", function () {
+        runMainCode("public function main(): Bool { return true || false; }", "true");
+        runMainCode("public function main(): Bool { return false || false; }", "false");
+    });
+
+    it("should exec sc or", function () {
+        runMainCode("public function main(): Bool { return true || (1i // 0i) == 1i; }", "true");
+    });
+});

--- a/test/cppoutput/logical_ops/op_and.test.js
+++ b/test/cppoutput/logical_ops/op_and.test.js
@@ -1,0 +1,12 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate -- op and", () => {
+    it("should exec simple and", function () {
+        runMainCode("public function main(): Bool { return /\\(true); }", "true");
+        runMainCode("public function main(): Bool { return /\\(true, false); }", "false");
+        runMainCode("public function main(): Bool { return /\\(true, false, true); }", "false");
+    });
+});

--- a/test/cppoutput/logical_ops/op_or.test.js
+++ b/test/cppoutput/logical_ops/op_or.test.js
@@ -1,0 +1,12 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate -- op or", () => {
+    it("should exec simple or", function () {
+        runMainCode("public function main(): Bool { return \\/(true); }", "true");
+        runMainCode("public function main(): Bool { return \\/(true, false); }", "true");
+        runMainCode("public function main(): Bool { return \\/(false, false, false); }", "false");
+    });
+});

--- a/test/cppoutput/unary_exps/not.test.js
+++ b/test/cppoutput/unary_exps/not.test.js
@@ -3,7 +3,7 @@
 import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
 import { describe, it } from "node:test";
 
-describe ("CPP Evaluate -- Simple Boolean not", () => {
+describe ("CPP Emit Evaluate -- Simple Boolean not", () => {
     it("should exec (simplify) not", function() {
         runMainCode("public function main(): Bool { return !false; }", "true");
         runMainCode("public function main(): Bool { return !!true; }", "true");

--- a/test/cppoutput/unary_exps/not.test.js
+++ b/test/cppoutput/unary_exps/not.test.js
@@ -1,0 +1,15 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";
+
+describe ("CPP Evaluate -- Simple Boolean not", () => {
+    it("should exec (simplify) not", function() {
+        runMainCode("public function main(): Bool { return !false; }", "true");
+        runMainCode("public function main(): Bool { return !!true; }", "true");
+    });
+    it("should exec simple not", function () {
+        runMainCode("public function main(): Bool { let x = false; return !x; }", "true");
+        runMainCode("public function main(): Bool { let x = true; return !!x; }", "true");
+    });
+});

--- a/test/cppoutput/unary_exps/sign.test.js
+++ b/test/cppoutput/unary_exps/sign.test.js
@@ -3,7 +3,7 @@
 import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
 import { describe, it } from "node:test";
 
-describe( "CPP Evaluate -- Simple numeric sign", () => {
+describe( "CPP Emit Evaluate -- Simple numeric sign", () => {
     it("should exec (simplfy) simple sign", function () {
         runMainCode("public function main(): Int { return -(3i); }", "-3_i");
         runMainCode("public function main(): Nat { return +(12n); }", "12_n");

--- a/test/cppoutput/unary_exps/sign.test.js
+++ b/test/cppoutput/unary_exps/sign.test.js
@@ -1,0 +1,21 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";
+
+describe( "CPP Evaluate -- Simple numeric sign", () => {
+    it("should exec (simplfy) simple sign", function () {
+        runMainCode("public function main(): Int { return -(3i); }", "-3_i");
+        runMainCode("public function main(): Nat { return +(12n); }", "12_n");
+        runMainCode("public function main(): BigInt { return -3I; }", "-3_I");
+        runMainCode("public function main(): BigNat { return +(12N); }", "12_N");
+        runMainCode("public function main(): Bool { return ( -2.0f < 0.0f ); }", "true");
+    });
+    it("should exec simple sign", function() {
+        runMainCode("public function main(): Int { let x = 3i; return -x; }", "-3_i");
+        runMainCode("public function main(): Nat { let x = 12n; return +x; }", "12_n");
+        runMainCode("public function main(): BigInt { let x = 3I; return -x; }", "-3_I");
+        runMainCode("public function main(): BigNat { let x = 12N; return +x; }", "12_N");
+        runMainCode("public function main(): Bool { let x = 2.0f; return ( -x < 0.0f ); }", "true");
+    });
+});


### PR DESCRIPTION
Cpp emission now supports:
 - unary prefix not
 - unary prefix negation _(properly, before it was not a defined datatype, just a cstring insertion in the emitted cpp)_
 - unary prefix plus
 - logical and
 - logical or
 - logical implies
 - logical iff
 - logical action and
 - logical action or
 
 For example this piece of Bosque code:
```
let neg: Int = -(3i);
let pos: Int = +3i;
let f: Bool = \/(false, false);
let t: Bool = f ==> false;
let tt: Bool = !f;
let ff: Bool = /\(tt, t);
let iff: Bool = true <==> true;
return /\(t, tt, iff); 
```
 Emits this cpp:
 ```
__CoreCpp::Int neg = -3_i;
__CoreCpp::Int pos = +3_i;
bool f = (false || false);
bool t = (!f || false);
bool tt = !f;
bool ff = (tt && t);
bool iff = ((true && true) || (!true && !true));
return (t && tt && iff);
 ```
 
 Also, logical action and/or expressions are now emitted in bsqir.
 