### PR TITLE
Cpp Emit for If Statements

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -20,20 +20,30 @@ concept Operation {
 concept Statement {
 }
 
+entity IfStatement provides Statement {
+    field cond: Expression;
+    field trueBlock: BlockStatement;
+}
+
 entity VariableInitializationStatement provides Statement {
     field name: Identifier; 
     field vtype: TypeSignature;
     field exp: Expression;
 }
 
-entity AccessVariableExpression provides Expression {
-    field vname: VarIdentifier;
-    field layouttype: TypeSignature;
+entity BlockStatement provides Statement {
+    field statements: List<Statement>;
+    field isScoping: Bool;
 }
 
 entity ReturnSingleStatement provides Statement {
     field rtype: TypeSignature;
     field value: Expression;
+}
+
+entity AccessVariableExpression provides Expression {
+    field vname: VarIdentifier;
+    field layouttype: TypeSignature;
 }
 
 entity LiteralSimpleExpression provides Expression {

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -25,6 +25,21 @@ entity IfStatement provides Statement {
     field trueBlock: BlockStatement;
 }
 
+entity IfElseStatement provides Statement {
+    field cond: Expression;
+    field trueBlock: BlockStatement;
+    field falseBlock: BlockStatement;
+}
+
+entity IfElifElseStatement provides Statement {
+    field ifcond: Expression;
+    field ifflow: BlockStatement;
+    field condflow: List<(|Expression, BlockStatement|)>;
+    field elseflow: BlockStatement;
+
+    invariant !$condflow.empty();
+}
+
 entity VariableInitializationStatement provides Statement {
     field name: Identifier; 
     field vtype: TypeSignature;

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -299,7 +299,7 @@ function emitIfElifElseStatement(stmt: CPPAssembly::IfElifElseStatement, indent:
     let ifcond = CString::concat(full_indent, 'if(', emitExpression(stmt.ifcond), ') {%n;');
     let ifbody = CString::concat(emitBlockStatement(stmt.ifflow, full_indent), full_indent, '}%n;');
     let ifblock = CString::concat(ifcond, ifbody);
-    let elseblock = CString::concat(full_indent, 'else {%n;', emitBlockStatement(stmt.elseflow, full_indent), '}%n;');
+    let elseblock = CString::concat(full_indent, 'else {%n;', emitBlockStatement(stmt.elseflow, full_indent), full_indent, '}%n;');
 
     let elifs_list = stmt.condflow.map<CString>(fn(elifs) => {
         let cond = emitExpression(elifs.0);

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -277,14 +277,40 @@ function emitIfStatement(stmt: CPPAssembly::IfStatement, indent: CString): CStri
     let expr = emitExpression(stmt.cond);
     let trueBlock = emitBlockStatement(stmt.trueBlock, full_indent);
     
-    if(stmt.trueBlock.isScoping) {
-        let ifstmt = CString::concat(full_indent, 'if( ', expr, ' ) {%n;');
-        return CString::concat(ifstmt, trueBlock, full_indent, '}');
-    }
-    else {
-        let ifstmt = CString::concat(full_indent, 'if( ', expr, ' )');      
-        return CString::concat(ifstmt, trueBlock);
-    }
+    let ifstmt = CString::concat(full_indent, 'if( ', expr, ' ) {%n;');
+    return CString::concat(ifstmt, trueBlock, full_indent, '}');
+}
+
+function emitIfElseStatement(stmt: CPPAssembly::IfElseStatement, indent: CString): CString {
+    let full_indent = CString::concat('    ', indent); 
+    let expr = emitExpression(stmt.cond);
+    
+    let falseBlock = emitBlockStatement(stmt.falseBlock, full_indent);
+    let elseBlockText = CString::concat(full_indent, 'else {%n;', falseBlock, full_indent, '}%n;');
+
+    let trueBlock = emitBlockStatement(stmt.trueBlock, full_indent);
+    let ifstmt = CString::concat(full_indent, 'if( ', expr, ' ) {%n;'); 
+
+    return CString::concat(ifstmt, trueBlock, full_indent, '}%n;', elseBlockText);
+}
+
+function emitIfElifElseStatement(stmt: CPPAssembly::IfElifElseStatement, indent: CString): CString {
+    let full_indent = CString::concat('    ', indent); 
+    let ifcond = CString::concat(full_indent, 'if(', emitExpression(stmt.ifcond), ') {%n;');
+    let ifbody = CString::concat(emitBlockStatement(stmt.ifflow, full_indent), full_indent, '}%n;');
+    let ifblock = CString::concat(ifcond, ifbody);
+    let elseblock = CString::concat(full_indent, 'else {%n;', emitBlockStatement(stmt.elseflow, full_indent), '}%n;');
+
+    let elifs_list = stmt.condflow.map<CString>(fn(elifs) => {
+        let cond = emitExpression(elifs.0);
+        let body = emitBlockStatement(elifs.1, full_indent);
+
+        let elif_stmt = CString::concat(full_indent, 'else if(', cond, ') {%n;');
+        return CString::concat(elif_stmt, body, full_indent, '}%n;');
+    });
+    let elifs = CString::joinAll('', elifs_list);
+
+    return CString::concat(ifcond, ifbody, elifs, elseblock);
 }
 
 function emitStatement(stmt: CPPAssembly::Statement, indent: CString): CString {
@@ -292,6 +318,8 @@ function emitStatement(stmt: CPPAssembly::Statement, indent: CString): CString {
         CPPAssembly::VariableInitializationStatement => { return emitVariableInitializationStatement($stmt, indent); }
         | CPPAssembly::ReturnSingleStatement => { return emitReturnSingleStatement($stmt, indent); }
         | CPPAssembly::IfStatement => { return emitIfStatement($stmt, indent); }
+        | CPPAssembly::IfElseStatement => { return emitIfElseStatement($stmt, indent); }
+        | CPPAssembly::IfElifElseStatement => { return emitIfElifElseStatement($stmt, indent); }
         | _ => { abort; }
     }
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -267,10 +267,31 @@ function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitiali
     return CString::concat(full_indent, ' ', name, ' = ', exp, ';');
 }
 
+function emitBlockStatement(block: CPPAssembly::BlockStatement, indent: CString): CString {
+    let stmts = block.statements.map<CString>(fn(stmt) => emitStatement(stmt, indent));
+    return CString::joinAll('%n;', stmts);
+}
+
+function emitIfStatement(stmt: CPPAssembly::IfStatement, indent: CString): CString {
+    let full_indent = CString::concat('    ', indent); 
+    let expr = emitExpression(stmt.cond);
+    let trueBlock = emitBlockStatement(stmt.trueBlock, full_indent);
+    
+    if(stmt.trueBlock.isScoping) {
+        let ifstmt = CString::concat(full_indent, 'if( ', expr, ' ) {%n;');
+        return CString::concat(ifstmt, trueBlock, full_indent, '}');
+    }
+    else {
+        let ifstmt = CString::concat(full_indent, 'if( ', expr, ' )');      
+        return CString::concat(ifstmt, trueBlock);
+    }
+}
+
 function emitStatement(stmt: CPPAssembly::Statement, indent: CString): CString {
     match(stmt)@ {
         CPPAssembly::VariableInitializationStatement => { return emitVariableInitializationStatement($stmt, indent); }
         | CPPAssembly::ReturnSingleStatement => { return emitReturnSingleStatement($stmt, indent); }
+        | CPPAssembly::IfStatement => { return emitIfStatement($stmt, indent); }
         | _ => { abort; }
     }
 }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -198,11 +198,32 @@ entity CPPTransformer {
         return CPPAssembly::IfStatement{ cond, trueBlock };
     }
 
+    recursive method transformIfElseStatement(stmt: BSQAssembly::IfElseStatement): CPPAssembly::IfElseStatement {
+        let cond = this.transformExpressionToCpp[recursive](stmt.cond);
+        let trueBlock = this.transformBlockStatement(stmt.trueBlock);
+        let falseBlock = this.transformBlockStatement(stmt.falseBlock);
+
+        return CPPAssembly::IfElseStatement{ cond, trueBlock, falseBlock };
+    }
+
+    recursive method transformIfElifElseStatement(stmt: BSQAssembly::IfElifElseStatement): CPPAssembly::IfElifElseStatement {
+        let ifcond = this.transformExpressionToCpp[recursive](stmt.ifcond);
+        let ifflow = this.transformBlockStatement(stmt.ifflow);
+        let elseflow = this.transformBlockStatement(stmt.elseflow);
+
+        let condflow = stmt.condflow.map<(|CPPAssembly::Expression, CPPAssembly::BlockStatement|)>(fn(block) => 
+            (|this.transformExpressionToCpp[recursive](block.0), this.transformBlockStatement(block.1)|));
+    
+        return CPPAssembly::IfElifElseStatement{ ifcond, ifflow, condflow, elseflow };
+    }
+
     method transformStatementToCpp(stmt: BSQAssembly::Statement): CPPAssembly::Statement {
         match(stmt)@ {
             BSQAssembly::VariableInitializationStatement => { return this.transformVariableInitializationStatementToCpp($stmt); }
             | BSQAssembly::ReturnSingleStatement => { return this.transformReturnSingleStatementToCpp[recursive]($stmt); }
             | BSQAssembly::IfStatement => { return this.transformIfStatement[recursive]($stmt); }
+            | BSQAssembly::IfElseStatement => { return this.transformIfElseStatement[recursive]($stmt); }
+            | BSQAssembly::IfElifElseStatement => { return this.transformIfElifElseStatement[recursive]($stmt); }
             | _ => { abort; }
         }
     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -183,13 +183,26 @@ entity CPPTransformer {
         let stype = CPPTransformNameManager::convertTypeSignature(stmt.vtype);
         let cppexpr = this.transformExpressionToCpp[recursive](stmt.exp);
 
-        return CPPAssembly::VariableInitializationStatement{name, stype, cppexpr};
+        return CPPAssembly::VariableInitializationStatement{ name, stype, cppexpr };
+    }
+
+    method transformBlockStatement(block: BSQAssembly::BlockStatement): CPPAssembly::BlockStatement {
+        let stmts = block.statements.map<CPPAssembly::Statement>(fn(stmt) => this.transformStatementToCpp(stmt));
+        return CPPAssembly::BlockStatement{ stmts, block.isScoping };
+    }
+
+    recursive method transformIfStatement(stmt: BSQAssembly::IfStatement): CPPAssembly::IfStatement {
+        let cond = this.transformExpressionToCpp[recursive](stmt.cond);
+        let trueBlock = this.transformBlockStatement(stmt.trueBlock);
+
+        return CPPAssembly::IfStatement{ cond, trueBlock };
     }
 
     method transformStatementToCpp(stmt: BSQAssembly::Statement): CPPAssembly::Statement {
         match(stmt)@ {
             BSQAssembly::VariableInitializationStatement => { return this.transformVariableInitializationStatementToCpp($stmt); }
             | BSQAssembly::ReturnSingleStatement => { return this.transformReturnSingleStatementToCpp[recursive]($stmt); }
+            | BSQAssembly::IfStatement => { return this.transformIfStatement[recursive]($stmt); }
             | _ => { abort; }
         }
     }

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -1205,8 +1205,29 @@ class BSQIREmitter {
         }
     }
 
+    // Need to extract ifflow I think...?
     private emitIfElifElseStatement(stmt: IfElifElseStatement, fmt: BsqonCodeFormatter): string {  
-        assert(false, "Not Implemented -- emitIfElifElseStatement");
+        const sbase = this.emitStatementBase(stmt);
+        let ifflow: string = '';
+        let ifcond: string = '';
+        const condflow = stmt.condflow.filter((elif, it) => {        
+            // If stmt logic 
+            if(it === 0) {
+                ifcond = this.emitExpression(elif.cond);
+                ifflow = this.emitBlockStatement(elif.block, fmt);
+                return false;
+            }
+            return true;
+        }).map((elif) => {
+            const cond = this.emitExpression(elif.cond);
+            const block = this.emitBlockStatement(elif.block, fmt);
+
+            return `(|${cond}, ${block}|)`; 
+            
+        }).join(", ");
+        const elseflow = this.emitBlockStatement(stmt.elseflow, fmt);
+        
+        return [`BSQAssembly::IfElifElseStatement{ ${sbase}, ifcond = ${ifcond}, ifflow = ${ifflow}, elseflow=${elseflow}, `, fmt.nl(), `condflow = List<(|BSQAssembly::Expression, BSQAssembly::BlockStatement|)>{ ${condflow} }}`].join("");
     }
 
     private emitSwitchStatement(stmt: SwitchStatement, fmt: BsqonCodeFormatter): string {
@@ -1275,7 +1296,7 @@ class BSQIREmitter {
     private emitBlockStatement(stmt: BlockStatement, fmt: BsqonCodeFormatter): string {
         const sbase = this.emitStatementBase(stmt);
         const stmts = this.emitStatementArray(stmt.statements.filter((stmt) => !((stmt instanceof EmptyStatement) || (stmt instanceof DebugStatement))), fmt);
-        return ["BSQAssembly::BlockStatement{", sbase, `,isScoping=${stmt.isScoping}, statements=`, fmt.nl(), "List<BSQAssembly::Statement>{", ...stmts, fmt.indent("}}")].join("");
+        return ["BSQAssembly::BlockStatement{", sbase, `,isScoping=${stmt.isScoping}, statements=`, fmt.nl(), "List<BSQAssembly::Statement>{", ...stmts, "}}"].join("");
     }
 
     private emitStatement(stmt: Statement, fmt: BsqonCodeFormatter): string {

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -1273,8 +1273,9 @@ class BSQIREmitter {
     }
 
     private emitBlockStatement(stmt: BlockStatement, fmt: BsqonCodeFormatter): string {
+        const sbase = this.emitStatementBase(stmt);
         const stmts = this.emitStatementArray(stmt.statements.filter((stmt) => !((stmt instanceof EmptyStatement) || (stmt instanceof DebugStatement))), fmt);
-        return ["BSQAssembly::BlockStatement{", `isScoping=${stmt.isScoping},`, fmt.nl(), "List<BSQAssembly::Statement>{", ...stmts, fmt.indent("}}")].join("");
+        return ["BSQAssembly::BlockStatement{", sbase, `,isScoping=${stmt.isScoping}, statements=`, fmt.nl(), "List<BSQAssembly::Statement>{", ...stmts, fmt.indent("}}")].join("");
     }
 
     private emitStatement(stmt: Statement, fmt: BsqonCodeFormatter): string {

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -1205,25 +1205,17 @@ class BSQIREmitter {
         }
     }
 
-    // Need to extract ifflow I think...?
     private emitIfElifElseStatement(stmt: IfElifElseStatement, fmt: BsqonCodeFormatter): string {  
         const sbase = this.emitStatementBase(stmt);
-        let ifflow: string = '';
-        let ifcond: string = '';
-        const condflow = stmt.condflow.filter((elif, it) => {        
-            // If stmt logic 
-            if(it === 0) {
-                ifcond = this.emitExpression(elif.cond);
-                ifflow = this.emitBlockStatement(elif.block, fmt);
-                return false;
-            }
-            return true;
-        }).map((elif) => {
+        let firstcond = stmt.condflow[0];
+        let ifcond: string = this.emitExpression(firstcond.cond);
+        let ifflow: string = this.emitBlockStatement(firstcond.block, fmt);
+
+        const condflow = stmt.condflow.slice(1).map((elif) => {
             const cond = this.emitExpression(elif.cond);
             const block = this.emitBlockStatement(elif.block, fmt);
 
-            return `(|${cond}, ${block}|)`; 
-            
+            return `(|${cond}, ${block}|)`;  
         }).join(", ");
         const elseflow = this.emitBlockStatement(stmt.elseflow, fmt);
         

--- a/test/cppoutput/if_exp/basic_if.test.js
+++ b/test/cppoutput/if_exp/basic_if.test.js
@@ -1,0 +1,4 @@
+"use strict";
+
+import { runMainCode, runMainCodeError } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";

--- a/test/cppoutput/if_exp/basic_if.test.js
+++ b/test/cppoutput/if_exp/basic_if.test.js
@@ -2,3 +2,7 @@
 
 import { runMainCode, runMainCodeError } from "../../../bin/test/cppoutput/cppemit_nf.js"
 import { describe, it } from "node:test";
+
+//
+// TODO: If expressions are not emitting yet!
+//

--- a/test/cppoutput/if_stmts/simple_if.test.js
+++ b/test/cppoutput/if_stmts/simple_if.test.js
@@ -5,24 +5,7 @@ import { describe, it } from "node:test";
 
 describe ("CPP Emit Evaluate -- If Statement", () => {
     it("should exec simple ifs", function () {
-        runMainCode("public function main(): Int { if(true) { return 3i; } return 1i; }", "3i");
-        runMainCode("public function main(): Int { if(false) { return 3i; } return 1i; }", "1i");
+        runMainCode("public function main(): Int { if(true) { return 3i; } return 1i; }", "3_i");
+        runMainCode("public function main(): Int { if(false) { return 3i; } return 1i; }", "1_i");
     });
-
-    /*
-    it("should exec itest ifs", function () {
-        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)some { return 3i; } return 1i; }", "3i");
-        runMainCode("public function main(): Int { let x: Option<Int> = none; if(x)some { return 3i; } return 1i; }", "1i");
-    });
-
-    it("should exec binder itest ifs", function () {
-        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@some { return $x; } return 1i; }", "3i");
-        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if($y = x)@some { return $y; } return 1i; }", "3i");
-    });
-
-    it("should exec binder & reflow itest ifs", function () {
-        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@@!some { return 0i; } return x; }", "3i");
-        runMainCode("public function main(): Int { let x: Option<Int> = none; if(x)@@!some { return 0i; } return x; }", "0i");
-    });
-    */
 });

--- a/test/cppoutput/if_stmts/simple_if.test.js
+++ b/test/cppoutput/if_stmts/simple_if.test.js
@@ -1,0 +1,28 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate -- If Statement", () => {
+    it("should exec simple ifs", function () {
+        runMainCode("public function main(): Int { if(true) { return 3i; } return 1i; }", "3i");
+        runMainCode("public function main(): Int { if(false) { return 3i; } return 1i; }", "1i");
+    });
+
+    /*
+    it("should exec itest ifs", function () {
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)some { return 3i; } return 1i; }", "3i");
+        runMainCode("public function main(): Int { let x: Option<Int> = none; if(x)some { return 3i; } return 1i; }", "1i");
+    });
+
+    it("should exec binder itest ifs", function () {
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@some { return $x; } return 1i; }", "3i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if($y = x)@some { return $y; } return 1i; }", "3i");
+    });
+
+    it("should exec binder & reflow itest ifs", function () {
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@@!some { return 0i; } return x; }", "3i");
+        runMainCode("public function main(): Int { let x: Option<Int> = none; if(x)@@!some { return 0i; } return x; }", "0i");
+    });
+    */
+});

--- a/test/cppoutput/if_stmts/simple_ifelse.test.js
+++ b/test/cppoutput/if_stmts/simple_ifelse.test.js
@@ -1,0 +1,29 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate -- Simple if-expression", () => {
+    it("should exec simple", function () {
+        runMainCode("public function main(): Int { return if(1n != 2n) then 2i else 3i; }", "2i");
+        runMainCode("public function main(): Int { return if(2n != 2n) then 2i else 3i; }", "3i");
+    });
+
+    /*
+    it("should exec expressions w/ itest", function () {
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)!none then 2i else 3i; }", "2i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)some then 2i else 3i; }", "2i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)<Some<Int>> then 2i else 3i; }", "2i");
+
+        runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if(x)@!none then $x else 3i; }", "1i");
+        runMainCode("public function main(): Int { let x: Int = 1i; return if(x < 3i) then 0i else x; }", "0i");
+        
+        runMainCode("public function main(): Int { let x: Int = 1i; return if(if(x < 3i) then none else some(x))@!none then $_ else 3i; }", "3i");
+        runMainCode("public function main(): Int { let x: Int = 5i; return if(if(x < 3i) then none else some(x))@!none then $_ else 3i; }", "5i");
+        
+        runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if($y = x)@<Some<Int>> then $y.value else 3i; }", "1i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if($y = x)@some then $y else 3i; }", "1i");
+        runMainCode("public function main(): Int { let x: Option<Int> = none; return if($y = x)@some then $y else 3i; }", "3i");
+    });
+    */
+});

--- a/test/cppoutput/if_stmts/simple_ifelse.test.js
+++ b/test/cppoutput/if_stmts/simple_ifelse.test.js
@@ -3,27 +3,11 @@
 import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
 import { describe, it } from "node:test";
 
-describe ("CPP Emit Evaluate -- Simple if-expression", () => {
-    it("should exec simple", function () {
-        runMainCode("public function main(): Int { return if(1n != 2n) then 2i else 3i; }", "2i");
-        runMainCode("public function main(): Int { return if(2n != 2n) then 2i else 3i; }", "3i");
+describe ("CPP Emit Evaluate -- Simple if-elif-else statements", () => {
+    it("should exec simple ifelse", function () {
+        runMainCode("public function main(): Int { if(1n != 2n) { return 2i; } else { return 3i; } }", "2_i")
     });
-
-    /*
-    it("should exec expressions w/ itest", function () {
-        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)!none then 2i else 3i; }", "2i");
-        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)some then 2i else 3i; }", "2i");
-        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)<Some<Int>> then 2i else 3i; }", "2i");
-
-        runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if(x)@!none then $x else 3i; }", "1i");
-        runMainCode("public function main(): Int { let x: Int = 1i; return if(x < 3i) then 0i else x; }", "0i");
-        
-        runMainCode("public function main(): Int { let x: Int = 1i; return if(if(x < 3i) then none else some(x))@!none then $_ else 3i; }", "3i");
-        runMainCode("public function main(): Int { let x: Int = 5i; return if(if(x < 3i) then none else some(x))@!none then $_ else 3i; }", "5i");
-        
-        runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if($y = x)@<Some<Int>> then $y.value else 3i; }", "1i");
-        runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if($y = x)@some then $y else 3i; }", "1i");
-        runMainCode("public function main(): Int { let x: Option<Int> = none; return if($y = x)@some then $y else 3i; }", "3i");
+    it("should exec simple ifelifelse", function () {
+        runMainCode("public function main(): Int { if(1n == 2n) { return 2i; } elif(1n == 3n) { return 1i; } elif(2i == 2i) { return 4i; } else { return 3i; } }", "4_i")
     });
-    */
 });


### PR DESCRIPTION
We can now emit cpp code for:
 - If statements
 - If else statements
 - If elif else statements
 
 For example, Bosque code like so:
 ```
if(1n == 2n) { 
    return 3i; 
} 
elif(1n == 2n) {
    return 2i;
}
elif(3n != 3n) {
    return 5i;
}
elif(1i == 1i) {
    return 0i;
}
else { 
    return 1i;
}
 ```
 
 Emits in cpp:
 ```
if((1_n == 2_n)) {
    return 3_i;
}
else if((1_n == 2_n)) {
    return 2_i;
}
else if((3_n != 3_n)) {
    return 5_i;
}
else if((1_i == 1_i)) {
    return 0_i;
}
else {
    return 1_i;
}
 ```