### PR TITLE
Cpp Emit Namespace Grouping, Namespace Func Calls, Forward Decls

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -25,13 +25,13 @@ datatype ArgumentValue using {
 }
 of
 RefArgumentValue { } %% TODO: Not implemented
-| PositionalArgumentValue { } %% Implemented but broken (no cpp support for named args)
+| PositionalArgumentValue { } 
 | NamedArgumentValue { field name: VarIdentifier; }
 | SpreadArgumentValue { } %% TODO: Not implemented
 ;
 
 entity ArgumentList {
-    field args: List<ArgumentValue>;
+    field args: List<Option<ArgumentValue>>; %% if none get default val in emitter
 }
 
 %*
@@ -83,6 +83,7 @@ entity ReturnSingleStatement provides Statement {
 entity CallNamespaceFunctionExpression provides Expression {
     field ikey: InvokeKey;
     field ns: NamespaceKey;
+    field fullns: List<CString>;
 
     field args: ArgumentList;
 }

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -56,6 +56,13 @@ entity ReturnSingleStatement provides Statement {
     field value: Expression;
 }
 
+entity CallNamespaceFunctionExpression provides Expression {
+    field ikey: InvokeKey;
+    field ns: NamespaceKey;
+
+    field args: None; %% TODO: Not implemented
+}
+
 entity AccessVariableExpression provides Expression {
     field vname: VarIdentifier;
     field layouttype: TypeSignature;

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -25,7 +25,7 @@ datatype ArgumentValue using {
 }
 of
 RefArgumentValue { } %% TODO: Not implemented
-| PositionalArgumentValue { } %% TODO: Not implemented
+| PositionalArgumentValue { } %% Implemented but broken (no cpp support for named args)
 | NamedArgumentValue { field name: VarIdentifier; }
 | SpreadArgumentValue { } %% TODO: Not implemented
 ;
@@ -34,6 +34,7 @@ entity ArgumentList {
     field args: List<ArgumentValue>;
 }
 
+%*
 entity InvokeArgumentInfo {
     field name: Identifier;
     %% field rec: RecursiveAnnotation; %% TODO: Not supported
@@ -41,6 +42,7 @@ entity InvokeArgumentInfo {
 
     %% Not quite sure if we type stuff thats in bsqir
 }
+*%
 
 entity IfStatement provides Statement {
     field cond: Expression;
@@ -82,7 +84,7 @@ entity CallNamespaceFunctionExpression provides Expression {
     field ikey: InvokeKey;
     field ns: NamespaceKey;
 
-    field args: None; %% TODO: Not implemented
+    field args: ArgumentList;
 }
 
 entity AccessVariableExpression provides Expression {

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -20,6 +20,28 @@ concept Operation {
 concept Statement {
 }
 
+datatype ArgumentValue using {
+    field exp: Expression;
+}
+of
+RefArgumentValue { } %% TODO: Not implemented
+| PositionalArgumentValue { } %% TODO: Not implemented
+| NamedArgumentValue { field name: VarIdentifier; }
+| SpreadArgumentValue { } %% TODO: Not implemented
+;
+
+entity ArgumentList {
+    field args: List<ArgumentValue>;
+}
+
+entity InvokeArgumentInfo {
+    field name: Identifier;
+    %% field rec: RecursiveAnnotation; %% TODO: Not supported
+    field args: ArgumentList;
+
+    %% Not quite sure if we type stuff thats in bsqir
+}
+
 entity IfStatement provides Statement {
     field cond: Expression;
     field trueBlock: BlockStatement;

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -41,7 +41,6 @@ entity NamespaceFunctionDecl {
     field name: CString;
     field invokeKey: InvokeKey;
 
-    %% Will be List<InvokeParameterDecl> or something
     field params: None; %% TODO: Parameters not implemented
 
     field resultType: TypeSignature;
@@ -49,8 +48,27 @@ entity NamespaceFunctionDecl {
     field body: BodyImplementation;
 }
 
+%%
+%% What we can do is take the namespace name (not full key, just its name) and look it up from the assembly
+%% entity in order to populate its sub namespaces. This allows us to keep namespaces grouped properly. The
+%% main issue I am having is figuring out a way to actually grab the names themselves. From NamespaceFunctionDecl
+%% in bsqasm, we are able to grab a string of the format 'Main::Foo::Bar' representing namespace. Problem
+%% is there is no way to split lookup in our decks main, then go to its subns and lookup foo, then go to its sub ns
+%% and look up bar. I think a possible answer could be to modify the ir emission itself to include this list directly.
+%%
+entity NamespaceDecl {
+    %% field ns: NamespaceKey;
+    field nsname: CString;
+
+    %% Will need other stuff like nsconsts, enums, typedecls, etc...
+
+    field subns: Map<NamespaceKey, NamespaceDecl>;
+    field nsfuncs: Map<InvokeKey, NamespaceFunctionDecl>;
+}
+
 %% Will need expanding
 entity Assembly {
+    %% field nsdecls: Map<CString, NamespaceDecl>; %% Toplevel decls, traverse to find lower level decls
     field nsfuncs: Map<NamespaceKey, Map<InvokeKey, NamespaceFunctionDecl>>;
     field allfuncs: List<InvokeKey>;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -48,16 +48,7 @@ entity NamespaceFunctionDecl {
     field body: BodyImplementation;
 }
 
-%%
-%% What we can do is take the namespace name (not full key, just its name) and look it up from the assembly
-%% entity in order to populate its sub namespaces. This allows us to keep namespaces grouped properly. The
-%% main issue I am having is figuring out a way to actually grab the names themselves. From NamespaceFunctionDecl
-%% in bsqasm, we are able to grab a string of the format 'Main::Foo::Bar' representing namespace. Problem
-%% is there is no way to split lookup in our decks main, then go to its subns and lookup foo, then go to its sub ns
-%% and look up bar. I think a possible answer could be to modify the ir emission itself to include this list directly.
-%%
 entity NamespaceDecl {
-    %% field ns: NamespaceKey;
     field nsname: CString;
 
     %% Will need other stuff like nsconsts, enums, typedecls, etc...

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -69,6 +69,5 @@ entity NamespaceDecl {
 %% Will need expanding
 entity Assembly {
     field nsdecls: Map<CString, NamespaceDecl>; %% Toplevel decls, traverse to find lower level decls
-    field nsfuncs: Map<NamespaceKey, Map<InvokeKey, NamespaceFunctionDecl>>;
     field allfuncs: List<InvokeKey>;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -38,6 +38,7 @@ entity NamespaceConstDecl provides AbstractCoreDecl {
 %% May want to change this as it doesnt map super well to bsqir (but maps nice to how smtemit)
 entity NamespaceFunctionDecl {
     field ns: NamespaceKey;
+    field fullns: List<CString>;
     field name: CString;
     field invokeKey: InvokeKey;
 

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -40,11 +40,6 @@ entity NamespaceConstDecl provides AbstractCoreDecl {
 }
 *%
 
-%%
-%% Not totaly sure if this is done in the parameter decl or in the args, but we will need to use the shuffle field
-%% to correctly determine the position of our arguments (for the sake of named parameters)
-%%
-
 entity ParameterDecl {
     field pname: Identifier;
     field ptype: TypeSignature;
@@ -52,11 +47,6 @@ entity ParameterDecl {
 
     %% TODO: Support ref/rest param
 }
-
-%%
-%% Will need to move this fullns to a more general entity (or maybe just concept) because
-%% other stuff like types and enums and stuff will also need namespace resolution
-%%
 
 %% May want to change this as it doesnt map super well to bsqir (but maps nice to how smtemit)
 entity NamespaceFunctionDecl provides AbstractDecl {
@@ -67,7 +57,7 @@ entity NamespaceFunctionDecl provides AbstractDecl {
     field body: BodyImplementation;
 }
 
-%% Use for function lookups (and maybe other stuff in the future)
+%% This is not actively being used but MAY prove some use as the emitter expands so ill leave it 
 entity FunctionDecl provides AbstractDecl {
     field ikey: InvokeKey;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -35,6 +35,13 @@ entity NamespaceConstDecl provides AbstractCoreDecl {
 }
 *%
 
+entity ParameterDecl {
+    field pname: Identifier;
+    field ptype: TypeSignature;
+
+    %% TODO: Support ref/rest params, default vals
+}
+
 %% May want to change this as it doesnt map super well to bsqir (but maps nice to how smtemit)
 entity NamespaceFunctionDecl {
     field ns: NamespaceKey;
@@ -42,7 +49,8 @@ entity NamespaceFunctionDecl {
     field name: CString;
     field invokeKey: InvokeKey;
 
-    field params: None; %% TODO: Parameters not implemented
+    %% currently implementing
+    field params: List<ParameterDecl>;
 
     field resultType: TypeSignature;
 

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -62,13 +62,13 @@ entity NamespaceDecl {
 
     %% Will need other stuff like nsconsts, enums, typedecls, etc...
 
-    field subns: Map<NamespaceKey, NamespaceDecl>;
+    field subns: Map<CString, NamespaceDecl>;
     field nsfuncs: Map<InvokeKey, NamespaceFunctionDecl>;
 }
 
 %% Will need expanding
 entity Assembly {
-    %% field nsdecls: Map<CString, NamespaceDecl>; %% Toplevel decls, traverse to find lower level decls
+    field nsdecls: Map<CString, NamespaceDecl>; %% Toplevel decls, traverse to find lower level decls
     field nsfuncs: Map<NamespaceKey, Map<InvokeKey, NamespaceFunctionDecl>>;
     field allfuncs: List<InvokeKey>;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -7,6 +7,11 @@ entity SourceInfo {
     field column: Nat;
 }
 
+concept AbstractDecl {
+    field declaredInNS: NamespaceKey;
+    field fullns: List<CString>;
+}
+
 const namespaceComponentRE: CRegex = /[A-Z][_a-zA-Z0-9]+/c;
 const namespaceKeyRE: CRegex = /(${CPPAssembly::namespaceComponentRE}'::')*${CPPAssembly::namespaceComponentRE}/c;
 type NamespaceComponentKey = CString of CPPAssembly::namespaceComponentRE;
@@ -47,19 +52,23 @@ entity ParameterDecl {
     %% TODO: Support ref/rest params, default vals
 }
 
+%%
+%% Will need to move this fullns to a more general entity (or maybe just concept) because
+%% other stuff like types and enums and stuff will also need namespace resolution
+%%
+
 %% May want to change this as it doesnt map super well to bsqir (but maps nice to how smtemit)
-entity NamespaceFunctionDecl {
-    field ns: NamespaceKey;
-    field fullns: List<CString>;
+entity NamespaceFunctionDecl provides AbstractDecl {
     field name: CString;
-    field invokeKey: InvokeKey;
-
-    %% currently implementing
+    field ikey: InvokeKey;
     field params: List<ParameterDecl>;
-
     field resultType: TypeSignature;
-
     field body: BodyImplementation;
+}
+
+%% Use for function lookups (and maybe other stuff in the future)
+entity FunctionDecl provides AbstractDecl {
+    field ikey: InvokeKey;
 }
 
 entity NamespaceDecl {
@@ -74,5 +83,5 @@ entity NamespaceDecl {
 %% Will need expanding
 entity Assembly {
     field nsdecls: Map<CString, NamespaceDecl>; %% Toplevel decls, traverse to find lower level decls
-    field allfuncs: List<InvokeKey>;
+    field allfuncs: List<FunctionDecl>;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -48,8 +48,9 @@ entity NamespaceConstDecl provides AbstractCoreDecl {
 entity ParameterDecl {
     field pname: Identifier;
     field ptype: TypeSignature;
+    field defaultval: Option<Expression>;
 
-    %% TODO: Support ref/rest params, default vals
+    %% TODO: Support ref/rest param
 }
 
 %%

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -35,6 +35,11 @@ entity NamespaceConstDecl provides AbstractCoreDecl {
 }
 *%
 
+%%
+%% Not totaly sure if this is done in the parameter decl or in the args, but we will need to use the shuffle field
+%% to correctly determine the position of our arguments (for the sake of named parameters)
+%%
+
 entity ParameterDecl {
     field pname: Identifier;
     field ptype: TypeSignature;

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -5,7 +5,7 @@ int main() {
     }
 
     // Calling our emitted main is hardcoded for now
-    __CoreCpp::MainType ret = Main::__main();
+    __CoreCpp::MainType ret = Main::main();
     std::cout << __CoreCpp::to_string(ret) << std::endl;
 
     return 0;

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -5,7 +5,7 @@ int main() {
     }
 
     // Calling our emitted main is hardcoded for now
-    __CoreCpp::MainType ret = Main::main();
+    __CoreCpp::MainType ret = Main::__main();
     std::cout << __CoreCpp::to_string(ret) << std::endl;
 
     return 0;

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -273,10 +273,6 @@ function emitArgumentValue(av: Option<CPPAssembly::ArgumentValue>, i: Nat, func:
             abort; %% Should be impossible
         }
         else {
-            %%
-            %% Current issue is that default parameters just emit of form y: Int = $x and spits out just $x, not resolving whatever x is.
-            %%
-
             return emitExpression[recursive]($param, ctx);
         }
     }
@@ -284,36 +280,42 @@ function emitArgumentValue(av: Option<CPPAssembly::ArgumentValue>, i: Nat, func:
         let arg = $av;
         let expr = emitExpression[recursive](arg.exp, ctx);
         match(arg)@ {
-            CPPAssembly::NamedArgumentValue => { return expr; } %% Not functional, just emits expr no named param
+            CPPAssembly::NamedArgumentValue => { return expr; } 
             | CPPAssembly::PositionalArgumentValue => { return expr; }
             | _ => { abort; }
         }
     }
 }
 
-function emitArgumentList(al: CPPAssembly::ArgumentList, func: CPPAssembly::NamespaceFunctionDecl, ctx: Context): CString {
-    let emit_al = al.args.mapIdx<CString>(fn(arg, ii) => emitArgumentValue(arg, ii, func, ctx));
+recursive function resolveDefaultParams(al: List<CString>, func: CPPAssembly::NamespaceFunctionDecl): List<CString> {
+    if(al.allOf(pred(param) => !(param.startsWithString('$')))) { %% All default params resolved
+        return al;
+    }
     
-    %% Second pass to resolve any default parameters by finding matching param name
-    let resolved_default_params_al = emit_al.map<CString>(fn(arg) => {
-        if(arg.startsWithString('$')) { %% We need to resolve this default params value 
+    let resolved = al.map<CString>(fn(arg) => { %% Resolve one layer of default param nesting
+        if(arg.startsWithString('$')) {
             let ident = arg.removePrefixString('$');
 
-            %% This is a bit hacky but works
-            let idxes = func.params.mapIdx<Nat>(fn(param, ii) => {
+            %% This is a bit hacky but works for getting default val idx
+            let idx = func.params.mapIdx<Nat>(fn(param, ii) => {
                 if(emitIdentifier(param.pname) === ident) {
                     return ii;
                 }
                 return 0n;
-            });
-            let idx = idxes.sum();
+            }).sum();
 
-            return emit_al.get(idx);
+            return al.get(idx);
         }
         return arg; 
     });
+
+    return resolveDefaultParams[recursive](resolved, func);
+}
+
+function emitArgumentList(al: CPPAssembly::ArgumentList, func: CPPAssembly::NamespaceFunctionDecl, ctx: Context): CString {
+    let emit_al = al.args.mapIdx<CString>(fn(arg, ii) => emitArgumentValue(arg, ii, func, ctx));
     
-    return CString::joinAll(', ', resolved_default_params_al);
+    return CString::joinAll(', ', resolveDefaultParams[recursive](emit_al, func));
 }
 
 recursive function findNamespaceFunctionDecl(decls: Map<CString, CPPAssembly::NamespaceDecl>, ikey: CPPAssembly::InvokeKey, fullns: List<CString>): CPPAssembly::NamespaceFunctionDecl {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -428,8 +428,14 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     let ns = CString::concat(indent, 'namespace ', nsdecl.nsname, ' {%n;');
     let full_indent = CString::concat('    ', indent);
 
+    let fwd_decls = nsdecl.nsfuncs.reduce<CString>('', fn(acc, ikey, decl) => {
+        return CString::concat(acc, emitFunctionForwardDeclaration(decl, full_indent));
+    });
+
+    let base = CString::concat(ns, fwd_decls);
+
     %% Emit sub-namespace declarations
-    let subns_emission = nsdecl.subns.reduce<CString>(ns, fn(acc, name, decl) => {
+    let subns_emission = nsdecl.subns.reduce<CString>(base, fn(acc, name, decl) => {
         return CString::concat(acc, emitNamespaceDecl[recursive](decl, ctx, full_indent));
     });
 
@@ -442,7 +448,7 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
 }
 
 %%
-%% May be nice to handle case where func doesnt exist
+%% I think this can be deleted (ill check on tuesday mornign)
 %%
 recursive function findNamespaceFunctionDecl(decls: Map<CString, CPPAssembly::NamespaceDecl>, func: CPPAssembly::FunctionDecl, fullns: List<CString>): CPPAssembly::NamespaceFunctionDecl {
     let ikey = func.ikey;
@@ -469,20 +475,15 @@ recursive function findNamespaceFunctionDecl(decls: Map<CString, CPPAssembly::Na
 }
 
 %% I suspect we will need separate cases for entities, types, enums and such
-function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl): CString {
-    let pre = decl.ikey.value;
+function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl, ident: CString): CString {
+    let pre = decl.name;
     let rtype = emitTypeSignature(decl.resultType); 
     let params = emitParameters(decl.params);
-    return CString::concat(rtype, ' ', pre, '(', params, ');%n;');
+    let first = CString::concat(ident, rtype, ' ', pre );
+    return CString::concat(first, '(', params, ');%n;');
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
-    %% Emit forward declaration (only supports namespace funcs right now :P )
-    let fwddecl_emission = asm.allfuncs.reduce<CString>('', fn(acc, func) => {
-        let funcdecl = findNamespaceFunctionDecl[recursive](asm.nsdecls, func, func.fullns);
-        return CString::concat(acc, emitFunctionForwardDeclaration(funcdecl));
-    });
-
     %% Likely need to add support for an empty namespace (or reserved), when creating ctx
     %% if we pass in no namespace key (or empty string) regex gets mad
     let ctx: Context = Context{CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''}}; %% No known namespace yet
@@ -494,5 +495,5 @@ function emitAssembly(asm: CPPAssembly::Assembly): CString {
 
     %% For CCharBuf and Unicode... will need to emit builtin functions explicitly
 
-    return CString::join('%n;', fwddecl_emission, ns_emission, '%n;');
+    return CString::join('%n;', ns_emission, '%n;');
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -287,12 +287,8 @@ function emitArgumentValue(av: Option<CPPAssembly::ArgumentValue>, i: Nat, func:
     }
 }
 
-recursive function resolveDefaultParams(al: List<CString>, func: CPPAssembly::NamespaceFunctionDecl): List<CString> {
-    if(al.allOf(pred(param) => !(param.startsWithString('$')))) { %% All default params resolved
-        return al;
-    }
-    
-    let resolved = al.map<CString>(fn(arg) => { %% Resolve one layer of default param nesting
+function resolveDefaultParams(al: List<CString>, func: CPPAssembly::NamespaceFunctionDecl): List<CString> {
+    return al.map<CString>(fn(arg) => { 
         if(arg.startsWithString('$')) {
             let ident = arg.removePrefixString('$');
 
@@ -308,8 +304,6 @@ recursive function resolveDefaultParams(al: List<CString>, func: CPPAssembly::Na
         }
         return arg; 
     });
-
-    return resolveDefaultParams[recursive](resolved, func);
 }
 
 function emitArgumentList(al: CPPAssembly::ArgumentList, func: CPPAssembly::NamespaceFunctionDecl, ctx: Context): CString {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -33,24 +33,13 @@ namespace UnicodeCharBuffer {
     %% Emit c++ for buffer creation here
 }
 
-%%
-%% We will want to (look in explicitify) create a namespace emitter entity
-%% and either pass that object around, maybe for each namespace we emit make a new class
-%% lets just pass around context in the arguments to each emitter function
-%%
-
-%% Not sure about this, likely doesnt work
 entity Context {
-    field currentns: CPPAssembly::NamespaceKey;
+    field fullns_key: CPPAssembly::NamespaceKey; %% Main::Foo::Bar::...
+    field fullns_list: List<CString>; %% ['Main', 'Foo', 'Bar', ...]
 
-    method create(): Context {
-        let ns_context = CPPAssembly::NamespaceKey::from(''); %% No namespace known yet
-        return Context{ ns_context };
-    }
-
-    method updateCurrentNamespace(new_ns: CPPAssembly::NamespaceKey ): Context {
+    method updateCurrentNamespace(new_ns: CPPAssembly::NamespaceKey, new_nsname: List<CString> ): Context {
         %% If we need more context will need to modify constructor
-        return Context{ new_ns };
+        return Context{ new_ns, new_nsname };
     }
 }
 
@@ -105,151 +94,151 @@ function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression
     return emitVarIdentifier(exp.vname);
 }
 
-function emitReturnSingleStatement(ret: CPPAssembly::ReturnSingleStatement, indent: CString): CString {
+function emitReturnSingleStatement(ret: CPPAssembly::ReturnSingleStatement, ctx: Context, indent: CString): CString {
     %% let rtype = emitTypeSignature(ret.rtype);
-    let exp = emitExpression(ret.value);
+    let exp = emitExpression(ret.value, ctx);
 
     let full_indent: CString = CString::concat(indent, '    ');
     return CString::concat(full_indent, 'return ', exp, ';%n;');
 }
 
-recursive function emitBinAddExpression(add: CPPAssembly::BinAddExpression): CString {
-    let lhs = emitExpression[recursive](add.lhs);
-    let rhs = emitExpression[recursive](add.rhs);
+recursive function emitBinAddExpression(add: CPPAssembly::BinAddExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](add.lhs, ctx);
+    let rhs = emitExpression[recursive](add.rhs, ctx);
 
     return CString::concat('(', lhs, ' + ', rhs, ')');
 }
 
-recursive function emitBinSubExpression(sub: CPPAssembly::BinSubExpression): CString {
-    let lhs = emitExpression[recursive](sub.lhs);
-    let rhs = emitExpression[recursive](sub.rhs);
+recursive function emitBinSubExpression(sub: CPPAssembly::BinSubExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](sub.lhs, ctx);
+    let rhs = emitExpression[recursive](sub.rhs, ctx);
 
     return CString::concat('(', lhs, ' - ', rhs, ')');
 }
 
-recursive function emitBinDivExpression(div: CPPAssembly::BinDivExpression): CString {
-    let lhs = emitExpression[recursive](div.lhs);
-    let rhs = emitExpression[recursive](div.rhs);
+recursive function emitBinDivExpression(div: CPPAssembly::BinDivExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](div.lhs, ctx);
+    let rhs = emitExpression[recursive](div.rhs, ctx);
 
     return CString::concat('(', lhs, ' / ', rhs, ')');
 }
 
-recursive function emitBinMultExpression(mult: CPPAssembly::BinMultExpression): CString {
-    let lhs = emitExpression[recursive](mult.lhs);
-    let rhs = emitExpression[recursive](mult.rhs);
+recursive function emitBinMultExpression(mult: CPPAssembly::BinMultExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](mult.lhs, ctx);
+    let rhs = emitExpression[recursive](mult.rhs, ctx);
 
     return CString::concat('(', lhs, ' * ', rhs, ')');
 }
 
-recursive function emitBinaryArithExpression(e: CPPAssembly::BinaryArithExpression): CString {
+recursive function emitBinaryArithExpression(e: CPPAssembly::BinaryArithExpression, ctx: Context): CString {
     match(e)@ {
-        CPPAssembly::BinAddExpression => { return emitBinAddExpression[recursive]($e); }
-        | CPPAssembly::BinSubExpression => { return emitBinSubExpression[recursive]($e); }
-        | CPPAssembly::BinDivExpression => { return emitBinDivExpression[recursive]($e); }
-        | CPPAssembly::BinMultExpression => { return emitBinMultExpression[recursive]($e); }
+        CPPAssembly::BinAddExpression => { return emitBinAddExpression[recursive]($e, ctx); }
+        | CPPAssembly::BinSubExpression => { return emitBinSubExpression[recursive]($e, ctx); }
+        | CPPAssembly::BinDivExpression => { return emitBinDivExpression[recursive]($e, ctx); }
+        | CPPAssembly::BinMultExpression => { return emitBinMultExpression[recursive]($e, ctx); }
     }
 }
 
-recursive function emitPrefixNotOpExpression(notop: CPPAssembly::PrefixNotOpExpression): CString {
-    let expr = emitExpression[recursive](notop.expr);
+recursive function emitPrefixNotOpExpression(notop: CPPAssembly::PrefixNotOpExpression, ctx: Context): CString {
+    let expr = emitExpression[recursive](notop.expr, ctx);
     return CString::concat('!', expr);
 }
 
-recursive function emitPrefixNegateOpExpression(negop: CPPAssembly::PrefixNegateOpExpression): CString {
-    let expr = emitExpression[recursive](negop.expr);
+recursive function emitPrefixNegateOpExpression(negop: CPPAssembly::PrefixNegateOpExpression, ctx: Context): CString {
+    let expr = emitExpression[recursive](negop.expr, ctx);
     return CString::concat('-', expr);
 }
 
-recursive function emitPrefixPlusOpExpression(plusop: CPPAssembly::PrefixPlusOpExpression): CString {
-    return emitExpression[recursive](plusop.expr);
+recursive function emitPrefixPlusOpExpression(plusop: CPPAssembly::PrefixPlusOpExpression, ctx: Context): CString {
+    return emitExpression[recursive](plusop.expr, ctx);
 }
 
-recursive function emitUnaryExpression(e: CPPAssembly::UnaryExpression): CString {
+recursive function emitUnaryExpression(e: CPPAssembly::UnaryExpression, ctx: Context): CString {
     match(e)@ {
-        CPPAssembly::PrefixNotOpExpression => { return emitPrefixNotOpExpression[recursive]($e); }
-        | CPPAssembly::PrefixNegateOpExpression => { return emitPrefixNegateOpExpression[recursive]($e); }
-        | CPPAssembly::PrefixPlusOpExpression => { return emitPrefixPlusOpExpression[recursive]($e); }
+        CPPAssembly::PrefixNotOpExpression => { return emitPrefixNotOpExpression[recursive]($e, ctx); }
+        | CPPAssembly::PrefixNegateOpExpression => { return emitPrefixNegateOpExpression[recursive]($e, ctx); }
+        | CPPAssembly::PrefixPlusOpExpression => { return emitPrefixPlusOpExpression[recursive]($e, ctx); }
     }
 }
 
-recursive function emitNumericEqExpression(e: CPPAssembly::NumericEqExpression): CString {
-    let lhs = emitExpression[recursive](e.lhs);
-    let rhs = emitExpression[recursive](e.rhs);
+recursive function emitNumericEqExpression(e: CPPAssembly::NumericEqExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](e.lhs, ctx);
+    let rhs = emitExpression[recursive](e.rhs, ctx);
 
     return CString::concat('(', lhs, ' == ', rhs, ')');   
 }
 
-recursive function emitNumericNeqExpression(e: CPPAssembly::NumericNeqExpression): CString {
-    let lhs = emitExpression[recursive](e.lhs);
-    let rhs = emitExpression[recursive](e.rhs);
+recursive function emitNumericNeqExpression(e: CPPAssembly::NumericNeqExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](e.lhs, ctx);
+    let rhs = emitExpression[recursive](e.rhs, ctx);
 
     return CString::concat('(', lhs, ' != ', rhs, ')');   
 }
 
-recursive function emitNumericLessExpression(e: CPPAssembly::NumericLessExpression): CString {
-    let lhs = emitExpression[recursive](e.lhs);
-    let rhs = emitExpression[recursive](e.rhs);
+recursive function emitNumericLessExpression(e: CPPAssembly::NumericLessExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](e.lhs, ctx);
+    let rhs = emitExpression[recursive](e.rhs, ctx);
 
     return CString::concat('(', lhs, ' < ', rhs, ')');   
 }
 
-recursive function emitNumericLessEqExpression(e: CPPAssembly::NumericLessEqExpression): CString {
-    let lhs = emitExpression[recursive](e.lhs);
-    let rhs = emitExpression[recursive](e.rhs);
+recursive function emitNumericLessEqExpression(e: CPPAssembly::NumericLessEqExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](e.lhs, ctx);
+    let rhs = emitExpression[recursive](e.rhs, ctx);
 
     return CString::concat('(', lhs, ' <= ', rhs, ')');   
 }
 
-recursive function emitNumericGreaterExpression(e: CPPAssembly::NumericGreaterExpression): CString {
-    let lhs = emitExpression[recursive](e.lhs);
-    let rhs = emitExpression[recursive](e.rhs);
+recursive function emitNumericGreaterExpression(e: CPPAssembly::NumericGreaterExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](e.lhs, ctx);
+    let rhs = emitExpression[recursive](e.rhs, ctx);
 
     return CString::concat('(', lhs, ' > ', rhs, ')');   
 }
 
-recursive function emitNumericGreaterEqExpression(e: CPPAssembly::NumericGreaterEqExpression): CString {
-    let lhs = emitExpression[recursive](e.lhs);
-    let rhs = emitExpression[recursive](e.rhs);
+recursive function emitNumericGreaterEqExpression(e: CPPAssembly::NumericGreaterEqExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](e.lhs, ctx);
+    let rhs = emitExpression[recursive](e.rhs, ctx);
 
     return CString::concat('(', lhs, ' >= ', rhs, ')');   
 }
 
-recursive function emitBinaryNumericExpression(e: CPPAssembly::BinaryNumericExpression): CString {
+recursive function emitBinaryNumericExpression(e: CPPAssembly::BinaryNumericExpression, ctx: Context): CString {
     match(e)@ {
-        CPPAssembly::NumericEqExpression => { return emitNumericEqExpression[recursive]($e); }
-        | CPPAssembly::NumericNeqExpression => { return emitNumericNeqExpression[recursive]($e); }
-        | CPPAssembly::NumericLessExpression => { return emitNumericLessExpression[recursive]($e); }
-        | CPPAssembly::NumericLessEqExpression => { return emitNumericLessEqExpression[recursive]($e); }
-        | CPPAssembly::NumericGreaterExpression => { return emitNumericGreaterExpression[recursive]($e); }
-        | CPPAssembly::NumericGreaterEqExpression => { return emitNumericGreaterEqExpression[recursive]($e); }
+        CPPAssembly::NumericEqExpression => { return emitNumericEqExpression[recursive]($e, ctx); }
+        | CPPAssembly::NumericNeqExpression => { return emitNumericNeqExpression[recursive]($e, ctx); }
+        | CPPAssembly::NumericLessExpression => { return emitNumericLessExpression[recursive]($e, ctx); }
+        | CPPAssembly::NumericLessEqExpression => { return emitNumericLessEqExpression[recursive]($e, ctx); }
+        | CPPAssembly::NumericGreaterExpression => { return emitNumericGreaterExpression[recursive]($e, ctx); }
+        | CPPAssembly::NumericGreaterEqExpression => { return emitNumericGreaterEqExpression[recursive]($e, ctx); }
     }
 }
 
-recursive function emitBinLogicAndExpression(e: CPPAssembly::BinLogicAndExpression): CString {
-    let lhs = emitExpression[recursive](e.lhs);
-    let rhs = emitExpression[recursive](e.rhs);   
+recursive function emitBinLogicAndExpression(e: CPPAssembly::BinLogicAndExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](e.lhs, ctx);
+    let rhs = emitExpression[recursive](e.rhs, ctx);   
 
     return CString::concat('(', lhs, ' && ', rhs, ')');
 }
 
-recursive function emitBinLogicOrExpression(e: CPPAssembly::BinLogicOrExpression): CString {
-    let lhs = emitExpression[recursive](e.lhs);
-    let rhs = emitExpression[recursive](e.rhs);   
+recursive function emitBinLogicOrExpression(e: CPPAssembly::BinLogicOrExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](e.lhs, ctx);
+    let rhs = emitExpression[recursive](e.rhs, ctx);   
 
     return CString::concat('(', lhs, ' || ', rhs, ')');
 }
 
-recursive function emitBinLogicImpliesExpression(e: CPPAssembly::BinLogicImpliesExpression): CString {
-    let lhs = emitExpression[recursive](e.lhs);
-    let rhs = emitExpression[recursive](e.rhs);  
+recursive function emitBinLogicImpliesExpression(e: CPPAssembly::BinLogicImpliesExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](e.lhs, ctx);
+    let rhs = emitExpression[recursive](e.rhs, ctx);  
 
     let implies: CString = CString::concat('!', lhs, ' || ', rhs);
     return CString::concat('(', implies ,')');
 }
 
-recursive function emitBinLogicIFFExpression(e: CPPAssembly::BinLogicIFFExpression): CString {
-    let lhs = emitExpression[recursive](e.lhs);
-    let rhs = emitExpression[recursive](e.rhs); 
+recursive function emitBinLogicIFFExpression(e: CPPAssembly::BinLogicIFFExpression, ctx: Context): CString {
+    let lhs = emitExpression[recursive](e.lhs, ctx);
+    let rhs = emitExpression[recursive](e.rhs, ctx); 
     let nlhs: CString = CString::concat('!', lhs);
     let nrhs: CString = CString::concat('!', rhs);
 
@@ -259,94 +248,120 @@ recursive function emitBinLogicIFFExpression(e: CPPAssembly::BinLogicIFFExpressi
     return CString::concat('(', first, ' || ', second, ')');
 }
 
-recursive function emitBinLogicExpression(e: CPPAssembly::BinLogicExpression): CString {
+recursive function emitBinLogicExpression(e: CPPAssembly::BinLogicExpression, ctx: Context): CString {
     match(e)@ {
-        CPPAssembly::BinLogicAndExpression => { return emitBinLogicAndExpression[recursive]($e); }
-        | CPPAssembly::BinLogicOrExpression => { return emitBinLogicOrExpression[recursive]($e); }
-        | CPPAssembly::BinLogicImpliesExpression => { return emitBinLogicImpliesExpression[recursive]($e); }
-        | CPPAssembly::BinLogicIFFExpression => { return emitBinLogicIFFExpression[recursive]($e); }
+        CPPAssembly::BinLogicAndExpression => { return emitBinLogicAndExpression[recursive]($e, ctx); }
+        | CPPAssembly::BinLogicOrExpression => { return emitBinLogicOrExpression[recursive]($e, ctx); }
+        | CPPAssembly::BinLogicImpliesExpression => { return emitBinLogicImpliesExpression[recursive]($e, ctx); }
+        | CPPAssembly::BinLogicIFFExpression => { return emitBinLogicIFFExpression[recursive]($e, ctx); }
     }
 }
 
-recursive function emitLogicActionAndExpression(e: CPPAssembly::LogicActionAndExpression): CString {
-    let args = e.args.map<CString>(fn(expr) => emitExpression[recursive](expr));
+recursive function emitLogicActionAndExpression(e: CPPAssembly::LogicActionAndExpression, ctx: Context): CString {
+    let args = e.args.map<CString>(fn(expr) => emitExpression[recursive](expr, ctx));
     return CString::concat('(', CString::joinAll(' && ', args), ')');
 }
 
-recursive function emitLogicActionOrExpression(e: CPPAssembly::LogicActionOrExpression): CString {
-    let args = e.args.map<CString>(fn(expr) => emitExpression[recursive](expr));
+recursive function emitLogicActionOrExpression(e: CPPAssembly::LogicActionOrExpression, ctx: Context): CString {
+    let args = e.args.map<CString>(fn(expr) => emitExpression[recursive](expr, ctx));
     return CString::concat('(', CString::joinAll(' || ', args), ')');
 }
 
-function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFunctionExpression): CString { 
-    let nsdecl = emitResolvedNamespace(e.ikey, e.ns);
+function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFunctionExpression, ctx: Context): CString { 
     let ident = emitInvokeKey(e.ikey);
+    
+    let declaredns = e.ns.value;
+    let cur_fullns = ctx.fullns_list; %% ns we are currently in
+
+    %% Remove all matching prefix strings
+    let resolvedns = cur_fullns.reduce<CString>(declaredns, fn(acc, s) => {
+        if(acc.startsWithString(s)) {
+            let nopre = acc.removePrefixString(s);
+            if(nopre.startsWithString('::')) {
+                return nopre.removePrefixString('::');
+            }
+            return nopre;
+        }
+        return acc;
+    });
+
+    let name = ident.removePrefixString(declaredns);
+    var resolvedName: CString;
+    if(name.startsWithString('::')) {
+        resolvedName = name.removePrefixString('::');
+    }
+    else {
+        resolvedName = name;
+    }
 
     %% No arguments supported currently
-    return CString::concat(ident, '()');
+    if(resolvedns !== '') {
+        return CString::concat(resolvedns, '::', resolvedName,'()');
+    }
+    return CString::concat(resolvedName, '()');
 }
 
-function emitExpression(e: CPPAssembly::Expression): CString {
+function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
     match(e)@ {
-        CPPAssembly::BinaryArithExpression => { return emitBinaryArithExpression[recursive]($e); }
-        | CPPAssembly::BinaryNumericExpression => { return emitBinaryNumericExpression[recursive]($e); }
-        | CPPAssembly::UnaryExpression => { return emitUnaryExpression[recursive]($e); }
-        | CPPAssembly::BinLogicExpression => { return emitBinLogicExpression[recursive]($e); }
-        | CPPAssembly::LogicActionAndExpression => { return emitLogicActionAndExpression[recursive]($e); }
-        | CPPAssembly::LogicActionOrExpression => { return emitLogicActionOrExpression[recursive]($e); }
+        CPPAssembly::BinaryArithExpression => { return emitBinaryArithExpression[recursive]($e, ctx); }
+        | CPPAssembly::BinaryNumericExpression => { return emitBinaryNumericExpression[recursive]($e, ctx); }
+        | CPPAssembly::UnaryExpression => { return emitUnaryExpression[recursive]($e, ctx); }
+        | CPPAssembly::BinLogicExpression => { return emitBinLogicExpression[recursive]($e, ctx); }
+        | CPPAssembly::LogicActionAndExpression => { return emitLogicActionAndExpression[recursive]($e, ctx); }
+        | CPPAssembly::LogicActionOrExpression => { return emitLogicActionOrExpression[recursive]($e, ctx); }
         | CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($e); }
         | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e); }
-        | CPPAssembly::CallNamespaceFunctionExpression => { return emitCallNamespaceFunctionExpression($e); }
+        | CPPAssembly::CallNamespaceFunctionExpression => { return emitCallNamespaceFunctionExpression($e, ctx); }
         | _ => { abort; }
     }
 }
 
-function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitializationStatement, indent: CString): CString {
+function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitializationStatement, ctx: Context, indent: CString): CString {
     let name = emitIdentifier(stmt.name);
     let stype = emitTypeSignature(stmt.vtype);
-    let exp = emitExpression(stmt.exp);
+    let exp = emitExpression(stmt.exp, ctx);
 
     let full_indent: CString = CString::concat(indent, '    ', stype); %% List constructor size max 6
     return CString::concat(full_indent, ' ', name, ' = ', exp, ';');
 }
 
-function emitBlockStatement(block: CPPAssembly::BlockStatement, indent: CString): CString {
-    let stmts = block.statements.map<CString>(fn(stmt) => emitStatement(stmt, indent));
+function emitBlockStatement(block: CPPAssembly::BlockStatement, ctx: Context, indent: CString): CString {
+    let stmts = block.statements.map<CString>(fn(stmt) => emitStatement(stmt, ctx, indent));
     return CString::joinAll('%n;', stmts);
 }
 
-function emitIfStatement(stmt: CPPAssembly::IfStatement, indent: CString): CString {
+function emitIfStatement(stmt: CPPAssembly::IfStatement, ctx: Context, indent: CString): CString {
     let full_indent = CString::concat('    ', indent); 
-    let expr = emitExpression(stmt.cond);
-    let trueBlock = emitBlockStatement(stmt.trueBlock, full_indent);
+    let expr = emitExpression(stmt.cond, ctx);
+    let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, full_indent);
     
     let ifstmt = CString::concat(full_indent, 'if( ', expr, ' ) {%n;');
     return CString::concat(ifstmt, trueBlock, full_indent, '}');
 }
 
-function emitIfElseStatement(stmt: CPPAssembly::IfElseStatement, indent: CString): CString {
+function emitIfElseStatement(stmt: CPPAssembly::IfElseStatement, ctx: Context, indent: CString): CString {
     let full_indent = CString::concat('    ', indent); 
-    let expr = emitExpression(stmt.cond);
+    let expr = emitExpression(stmt.cond, ctx);
     
-    let falseBlock = emitBlockStatement(stmt.falseBlock, full_indent);
+    let falseBlock = emitBlockStatement(stmt.falseBlock, ctx, full_indent);
     let elseBlockText = CString::concat(full_indent, 'else {%n;', falseBlock, full_indent, '}%n;');
 
-    let trueBlock = emitBlockStatement(stmt.trueBlock, full_indent);
+    let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, full_indent);
     let ifstmt = CString::concat(full_indent, 'if( ', expr, ' ) {%n;'); 
 
     return CString::concat(ifstmt, trueBlock, full_indent, '}%n;', elseBlockText);
 }
 
-function emitIfElifElseStatement(stmt: CPPAssembly::IfElifElseStatement, indent: CString): CString {
+function emitIfElifElseStatement(stmt: CPPAssembly::IfElifElseStatement, ctx: Context, indent: CString): CString {
     let full_indent = CString::concat('    ', indent); 
-    let ifcond = CString::concat(full_indent, 'if(', emitExpression(stmt.ifcond), ') {%n;');
-    let ifbody = CString::concat(emitBlockStatement(stmt.ifflow, full_indent), full_indent, '}%n;');
+    let ifcond = CString::concat(full_indent, 'if(', emitExpression(stmt.ifcond, ctx), ') {%n;');
+    let ifbody = CString::concat(emitBlockStatement(stmt.ifflow, ctx, full_indent), full_indent, '}%n;');
     let ifblock = CString::concat(ifcond, ifbody);
-    let elseblock = CString::concat(full_indent, 'else {%n;', emitBlockStatement(stmt.elseflow, full_indent), full_indent, '}%n;');
+    let elseblock = CString::concat(full_indent, 'else {%n;', emitBlockStatement(stmt.elseflow, ctx, full_indent), full_indent, '}%n;');
 
     let elifs_list = stmt.condflow.map<CString>(fn(elifs) => {
-        let cond = emitExpression(elifs.0);
-        let body = emitBlockStatement(elifs.1, full_indent);
+        let cond = emitExpression(elifs.0, ctx);
+        let body = emitBlockStatement(elifs.1, ctx, full_indent);
 
         let elif_stmt = CString::concat(full_indent, 'else if(', cond, ') {%n;');
         return CString::concat(elif_stmt, body, full_indent, '}%n;');
@@ -356,68 +371,71 @@ function emitIfElifElseStatement(stmt: CPPAssembly::IfElifElseStatement, indent:
     return CString::concat(ifcond, ifbody, elifs, elseblock);
 }
 
-function emitStatement(stmt: CPPAssembly::Statement, indent: CString): CString {
+function emitStatement(stmt: CPPAssembly::Statement, ctx: Context, indent: CString): CString {
     match(stmt)@ {
-        CPPAssembly::VariableInitializationStatement => { return emitVariableInitializationStatement($stmt, indent); }
-        | CPPAssembly::ReturnSingleStatement => { return emitReturnSingleStatement($stmt, indent); }
-        | CPPAssembly::IfStatement => { return emitIfStatement($stmt, indent); }
-        | CPPAssembly::IfElseStatement => { return emitIfElseStatement($stmt, indent); }
-        | CPPAssembly::IfElifElseStatement => { return emitIfElifElseStatement($stmt, indent); }
+        CPPAssembly::VariableInitializationStatement => { return emitVariableInitializationStatement($stmt, ctx, indent); }
+        | CPPAssembly::ReturnSingleStatement => { return emitReturnSingleStatement($stmt, ctx, indent); }
+        | CPPAssembly::IfStatement => { return emitIfStatement($stmt, ctx, indent); }
+        | CPPAssembly::IfElseStatement => { return emitIfElseStatement($stmt, ctx, indent); }
+        | CPPAssembly::IfElifElseStatement => { return emitIfElifElseStatement($stmt, ctx, indent); }
         | _ => { abort; }
     }
 }
 
-function emitStandardBodyImplementation(body: CPPAssembly::StandardBodyImplementation, indent: CString): CString {
-    return CString::joinAll('%n;', body.statements.map<CString>(fn(stmt) => emitStatement(stmt, indent)));
+function emitStandardBodyImplementation(body: CPPAssembly::StandardBodyImplementation, ctx: Context, indent: CString): CString {
+    return CString::joinAll('%n;', body.statements.map<CString>(fn(stmt) => emitStatement(stmt, ctx, indent)));
 }
 
-function emitBodyImplementation(body: CPPAssembly::BodyImplementation, indent: CString): CString {
+function emitBodyImplementation(body: CPPAssembly::BodyImplementation, ctx: Context, indent: CString): CString {
     match(body)@ {
         %% CPPAssembly::AbstractBodyImplementation => { abort; }
         %% | CPPAssembly::PredicateUFBodyImplementation => { abort; }
         %% | CPPAssembly::BuiltinBodyImplementation => { abort; }
         %% | CPPAssembly::SynthesisBodyImplementation => { abort; }
         %% | CPPAssembly::ExpressionBodyImplementation => { abort; }
-        CPPAssembly::StandardBodyImplementation => { return emitStandardBodyImplementation($body, indent); }
+        CPPAssembly::StandardBodyImplementation => { return emitStandardBodyImplementation($body, ctx, indent); }
         | _ => { abort; }
     }
 }
 
-function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, indent: CString): CString {
+function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ctx: Context, indent: CString): CString {
     let name = func.name;
     let nskey = emitNamespaceKey(func.ns);
     let params = ''; %% TODO: Parameters not implemented
     let rtype = emitTypeSignature(func.resultType); 
 
+    let nctx = ctx.updateCurrentNamespace(func.ns, func.fullns);
+
     let pre: CString = CString::concat(indent, rtype, ' ', name );
     let params_impl: CString = CString::concat('(', params, ')');
 
-    return CString::concat(pre, params_impl, ' {%n;', emitBodyImplementation(func.body, indent), indent, '}%n;');
+    return CString::concat(pre, params_impl, ' {%n;', emitBodyImplementation(func.body, nctx, indent), indent, '}%n;');
 }
 
-recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, indent: CString): CString {
+recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: CString): CString {
     %% Emit namespace 
     let ns = CString::concat(indent, 'namespace ', nsdecl.nsname, ' {%n;');
     let full_indent = CString::concat('    ', indent);
 
     %% Emit sub-namespace declarations
     let subns_emission = nsdecl.subns.reduce<CString>(ns, fn(acc, name, decl) => {
-        return CString::concat(acc, emitNamespaceDecl[recursive](decl, full_indent));
+        return CString::concat(acc, emitNamespaceDecl[recursive](decl, ctx, full_indent));
     });
 
     %% Emit functions in current namespace
     let funcs_emission = nsdecl.nsfuncs.reduce<CString>(subns_emission, fn(acc, key, func) => {
-        return CString::concat(acc, emitNamespaceFunctionDecl(func, full_indent)); 
+        return CString::concat(acc, emitNamespaceFunctionDecl(func, ctx, full_indent)); 
     });
 
     return CString::concat(funcs_emission, indent, '}%n;');
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
-    %% Need to give some thought to best way to approach this constructor
-    let ctx: Context = Context{}.create();
+    %% Likely need to add support for an empty namespace (or reserved), when creating ctx
+    %% if we pass in no namespace key (or empty string) it gets mad
+    let ctx: Context = Context{CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''}}; %% No known namespace yet
     let ns_emission = asm.nsdecls.reduce<CString>('', fn(acc, name, nsdecl) => {
-        return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ''));
+        return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, ''));
     });
 
     %% TODO: Other non namespace functions

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -374,25 +374,51 @@ function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ind
     return CString::concat(pre, params_impl, ' {%n;', emitBodyImplementation(func.body, indent), indent, '}%n;');
 }
 
-%% Emits all funcions inside a given namespace
-function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceKey, funcs: CString): CString {
-    return CString::concat('namespace ', nsdecl.value, ' {%n;', funcs, '}%n;%n;');
+%% I suspect we will need to be a bit more cleveer with how we emit names, just a cstr for now
+function emitNamespaceDecl(nsdecl: CString, funcs: CString): CString {
+    return CString::concat('namespace ', nsdecl, ' {%n;', funcs, '}%n;%n;');
+}
+
+%% This name isnt very descriptinve since we emit from subns too
+recursive function emitNamespaceFromTopLevel(nsdecl: CPPAssembly::NamespaceDecl): CString {
+    %% Emit namespace 
+    let ns = CString::concat('namespace ', nsdecl.nsname, '{%n;');
+
+    %% Emit functions
+    %*
+    let funcs_emission = nsdecl.nsfuncs.reduce<CString>(ns, fn(acc, key, func) => {
+        let indent: CString = '    ';
+        return CString::concat(indent, acc, emitNamespaceFunctionDecl(func, indent));           
+    });
+    *%
+
+    %% Emit sub-namespace functions and their declarations
+    let subns_emission = nsdecl.subns.reduce<CString>(ns, fn(acc, name, decl) => {
+        return CString::concat(acc, emitNamespaceFromTopLevel[recursive](decl));
+    });
+
+    return CString::concat(subns_emission, '}%n;');
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
     %% First emit all namespace blocks with their functions
+
+    let ns_emission = asm.nsdecls.reduce<CString>('', fn(acc, name, nsdecl) => {
+        return CString::concat(acc, emitNamespaceFromTopLevel(nsdecl));
+    });
+
     let nsblocks = asm.nsfuncs.reduce<CString>('', fn(acc, nskey, funcs) => {
         let emission = funcs.reduce<CString>('', fn(funcacc, ikey, func) => {
             let indent: CString = '    ';
             return CString::concat(indent, funcacc, emitNamespaceFunctionDecl(func, indent));
         });
         
-        return CString::concat(acc, emitNamespaceDecl(nskey, emission));
+        return CString::concat(acc, emitNamespaceDecl(nskey.value, emission));
     });
 
     %% TODO: Other non namespace functions
 
     %% For CCharBuf and Unicode... will need to emit builtin functions explicitly
 
-    return CString::join('%n;', nsblocks);
+    return CString::join('%n;', ns_emission);
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -33,6 +33,27 @@ namespace UnicodeCharBuffer {
     %% Emit c++ for buffer creation here
 }
 
+%%
+%% We will want to (look in explicitify) create a namespace emitter entity
+%% and either pass that object around, maybe for each namespace we emit make a new class
+%% lets just pass around context in the arguments to each emitter function
+%%
+
+%% Not sure about this, likely doesnt work
+entity Context {
+    field currentns: CPPAssembly::NamespaceKey;
+
+    method create(): Context {
+        let ns_context = CPPAssembly::NamespaceKey::from(''); %% No namespace known yet
+        return Context{ ns_context };
+    }
+
+    method updateCurrentNamespace(new_ns: CPPAssembly::NamespaceKey ): Context {
+        %% If we need more context will need to modify constructor
+        return Context{ new_ns };
+    }
+}
+
 function emitTypeSignature(ts: CPPAssembly::TypeSignature): CString {
     return ts.tkeystr.value;
 }
@@ -374,18 +395,17 @@ function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ind
     return CString::concat(pre, params_impl, ' {%n;', emitBodyImplementation(func.body, indent), indent, '}%n;');
 }
 
-%% This name isnt very descriptinve since we emit from subns too
 recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, indent: CString): CString {
     %% Emit namespace 
     let ns = CString::concat(indent, 'namespace ', nsdecl.nsname, ' {%n;');
     let full_indent = CString::concat('    ', indent);
 
-    %% Emit sub-namespace functions and their declarations
+    %% Emit sub-namespace declarations
     let subns_emission = nsdecl.subns.reduce<CString>(ns, fn(acc, name, decl) => {
         return CString::concat(acc, emitNamespaceDecl[recursive](decl, full_indent));
     });
 
-    %% Emit functions
+    %% Emit functions in current namespace
     let funcs_emission = nsdecl.nsfuncs.reduce<CString>(subns_emission, fn(acc, key, func) => {
         return CString::concat(acc, emitNamespaceFunctionDecl(func, full_indent)); 
     });
@@ -394,6 +414,8 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, indent:
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
+    %% Need to give some thought to best way to approach this constructor
+    let ctx: Context = Context{}.create();
     let ns_emission = asm.nsdecls.reduce<CString>('', fn(acc, name, nsdecl) => {
         return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ''));
     });

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1,11 +1,5 @@
 namespace CPPEmitter;
 
-%%
-%% TODO: We will need to properly overload our conversion from bosque types to cpp types to ensure
-%% everything stays safe (such as Nat in bosque only being 63 bits not 64) and all operations on 
-%% these values need to be provided via overloading and using compiler builtins (like __builtin_add_overflow__)
-%%
-
 %% CPP Pre-defined backend
 namespace PathStack {
     function emitPathStackCreate(): CString {
@@ -38,7 +32,6 @@ entity Context {
     field fullns_list: List<CString>; %% ['Main', 'Foo', 'Bar', ...]
 
     method updateCurrentNamespace(new_ns: CPPAssembly::NamespaceKey, new_nsname: List<CString> ): Context {
-        %% If we need more context will need to modify constructor
         return Context{ new_ns, new_nsname };
     }
 }
@@ -272,6 +265,21 @@ recursive function emitLogicActionOrExpression(e: CPPAssembly::LogicActionOrExpr
     return CString::concat('(', CString::joinAll(' || ', args), ')');
 }
 
+function emitArgumentValue(av: CPPAssembly::ArgumentValue, ctx: Context): CString {
+    let expr = emitExpression[recursive](av.exp, ctx);
+
+    match(av)@ {
+        CPPAssembly::NamedArgumentValue => { return expr; } %% Not functional, just emits expr no named param
+        | CPPAssembly::PositionalArgumentValue => { return expr; }
+        | _ => { abort; } %% TODO: Not Implemented
+    }
+}
+
+function emitArgumentList(al: CPPAssembly::ArgumentList, ctx: Context): CString {
+    let emit_al = al.args.map<CString>(fn(arg) => emitArgumentValue(arg, ctx));
+    return CString::joinAll(', ', emit_al);
+}
+
 function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFunctionExpression, ctx: Context): CString { 
     let resolvedns = emitResolvedNamespace(ctx.fullns_list, e.ns); 
 
@@ -286,11 +294,12 @@ function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFuncti
         resolvedName = name;
     }
 
-    %% No arguments supported currently
+    let args = emitArgumentList(e.args, ctx);
+
     if(resolvedns !== '') {
-        return CString::concat(resolvedns, '::', resolvedName,'()');
+        return CString::concat(resolvedns, '::', resolvedName,'(', args, ')');
     }
-    return CString::concat(resolvedName, '()');
+    return CString::concat(resolvedName, '(', args, ')');
 }
 
 function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
@@ -403,7 +412,7 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>): CString {
 function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ctx: Context, indent: CString): CString {
     let name = func.name;
     let nskey = emitNamespaceKey(func.ns);
-    let params = emitParameters(func.params); %% TODO: Parameters not implemented
+    let params = emitParameters(func.params);
     let rtype = emitTypeSignature(func.resultType); 
 
     let nctx = ctx.updateCurrentNamespace(func.ns, func.fullns);
@@ -434,7 +443,7 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
     %% Likely need to add support for an empty namespace (or reserved), when creating ctx
-    %% if we pass in no namespace key (or empty string) it gets mad
+    %% if we pass in no namespace key (or empty string) regex gets mad
     let ctx: Context = Context{CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''}}; %% No known namespace yet
     let ns_emission = asm.nsdecls.reduce<CString>('', fn(acc, name, nsdecl) => {
         return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, ''));

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -441,11 +441,39 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     return CString::concat(funcs_emission, indent, '}%n;');
 }
 
+function findNamespaceFunctionDecl(decls: List<NamespaceDecl>, ikey: CPPAssembly::InvokeKey): CPPAssembly::NamespaceFunctionDecl {
+    
+    %%
+    %% This is actually a bit trickier than I thought because we nneed to traverse subns for every ns as well?
+    %% May not quite work...
+    %%
+    return decls.reduce<CPPAssembly::NamespaceFunctionDecl>(CPPAssembly::NamespaceFunctionDecl{},
+        fn(acc, decl) => {
+            if(decl.nsfuncs.has(ikey)) {
+                return decl.nsfuncs.get(ikey);
+            }
+
+        });
+}
+
+%% I suspect we will need separate cases for entities, types, enums and such
+function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl): CString {
+    let pre = decl.invokeKey.value;
+    let params = emitParameters(decl.params);
+    return CString::concat(pre, '(', params, ');%n;');
+}
+
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
+    %% Emit forward declaration (only supports ns funcs right now :P )
+    let fwd_decl_emission = asm.allfuncs.reduce<CString>('', fn(acc, ikey) => {
+        let funcdecl = findNamespaceFunctionDecl(asm.nsdecls, ikey);
+        return CString::concat(acc, emitFunctionForwardDeclaration(funcdecl));
+    });
+
     %% Likely need to add support for an empty namespace (or reserved), when creating ctx
     %% if we pass in no namespace key (or empty string) regex gets mad
     let ctx: Context = Context{CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''}}; %% No known namespace yet
-    let ns_emission = asm.nsdecls.reduce<CString>('', fn(acc, name, nsdecl) => {
+    let ns_emission = asm.nsdecls.reduce<CString>('', fn(acc, nsname, nsdecl) => {
         return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, ''));
     });
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -63,17 +63,22 @@ function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): CString {
     return nsk.value;
 }
 
-function emitResolvedNamespace(ikey: CPPAssembly::InvokeKey, ns: CPPAssembly::NamespaceKey): CString {
-    let kval = emitInvokeKey(ikey);
-    let nsval = emitNamespaceKey(ns);
-
-    %% We can compare the invoke key and namespace value - emit only portion of ikey that is not in
-    %% nskey
-    let resolved = kval.removePrefixString(nsval);
-    if(resolved.startsWithString('::')) {
-        return resolved.removePrefixString('::');
-    }
-    return resolved;
+%%
+%% Given a namespace key (like Main::Foo::Bar), remove all matching prefix strings
+%% giving resolved namespace for given scope
+%%
+function emitResolvedNamespace(fullns_list: List<CString>, fullns_key: CPPAssembly::NamespaceKey): CString {
+    let fullns: CString = emitNamespaceKey(fullns_key);
+    return fullns_list.reduce<CString>(fullns, fn(acc, s) => {
+        if(acc.startsWithString(s)) {
+            let nopre = acc.removePrefixString(s);
+            if(nopre.startsWithString('::')) {
+                return nopre.removePrefixString('::');
+            }
+            return nopre;
+        }
+        return acc;
+    });
 }
 
 function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression): CString {
@@ -268,24 +273,11 @@ recursive function emitLogicActionOrExpression(e: CPPAssembly::LogicActionOrExpr
 }
 
 function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFunctionExpression, ctx: Context): CString { 
+    let resolvedns = emitResolvedNamespace(ctx.fullns_list, e.ns); 
+
     let ident = emitInvokeKey(e.ikey);
+    let name = ident.removePrefixString(e.ns.value);
     
-    let declaredns = e.ns.value;
-    let cur_fullns = ctx.fullns_list; %% ns we are currently in
-
-    %% Remove all matching prefix strings
-    let resolvedns = cur_fullns.reduce<CString>(declaredns, fn(acc, s) => {
-        if(acc.startsWithString(s)) {
-            let nopre = acc.removePrefixString(s);
-            if(nopre.startsWithString('::')) {
-                return nopre.removePrefixString('::');
-            }
-            return nopre;
-        }
-        return acc;
-    });
-
-    let name = ident.removePrefixString(declaredns);
     var resolvedName: CString;
     if(name.startsWithString('::')) {
         resolvedName = name.removePrefixString('::');
@@ -398,10 +390,20 @@ function emitBodyImplementation(body: CPPAssembly::BodyImplementation, ctx: Cont
     }
 }
 
+function emitParameters(params: List<CPPAssembly::ParameterDecl>): CString {
+    let all_params = params.map<CString>(fn(param) => {
+        let ptype = emitTypeSignature(param.ptype);
+        let pident = emitIdentifier(param.pname);
+        return CString::concat(ptype, ' ', pident);
+    });
+
+    return CString::joinAll(', ', all_params);
+}
+
 function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ctx: Context, indent: CString): CString {
     let name = func.name;
     let nskey = emitNamespaceKey(func.ns);
-    let params = ''; %% TODO: Parameters not implemented
+    let params = emitParameters(func.params); %% TODO: Parameters not implemented
     let rtype = emitTypeSignature(func.resultType); 
 
     let nctx = ctx.updateCurrentNamespace(func.ns, func.fullns);

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -368,52 +368,34 @@ function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ind
     let params = ''; %% TODO: Parameters not implemented
     let rtype = emitTypeSignature(func.resultType); 
 
-    let pre: CString = CString::concat(rtype, ' ', name );
+    let pre: CString = CString::concat(indent, rtype, ' ', name );
     let params_impl: CString = CString::concat('(', params, ')');
 
     return CString::concat(pre, params_impl, ' {%n;', emitBodyImplementation(func.body, indent), indent, '}%n;');
 }
 
-%% I suspect we will need to be a bit more cleveer with how we emit names, just a cstr for now
-function emitNamespaceDecl(nsdecl: CString, funcs: CString): CString {
-    return CString::concat('namespace ', nsdecl, ' {%n;', funcs, '}%n;%n;');
-}
-
 %% This name isnt very descriptinve since we emit from subns too
-recursive function emitNamespaceFromTopLevel(nsdecl: CPPAssembly::NamespaceDecl): CString {
+recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, indent: CString): CString {
     %% Emit namespace 
-    let ns = CString::concat('namespace ', nsdecl.nsname, '{%n;');
-
-    %% Emit functions
-    %*
-    let funcs_emission = nsdecl.nsfuncs.reduce<CString>(ns, fn(acc, key, func) => {
-        let indent: CString = '    ';
-        return CString::concat(indent, acc, emitNamespaceFunctionDecl(func, indent));           
-    });
-    *%
+    let ns = CString::concat(indent, 'namespace ', nsdecl.nsname, ' {%n;');
+    let full_indent = CString::concat('    ', indent);
 
     %% Emit sub-namespace functions and their declarations
     let subns_emission = nsdecl.subns.reduce<CString>(ns, fn(acc, name, decl) => {
-        return CString::concat(acc, emitNamespaceFromTopLevel[recursive](decl));
+        return CString::concat(acc, emitNamespaceDecl[recursive](decl, full_indent));
     });
 
-    return CString::concat(subns_emission, '}%n;');
+    %% Emit functions
+    let funcs_emission = nsdecl.nsfuncs.reduce<CString>(subns_emission, fn(acc, key, func) => {
+        return CString::concat(acc, emitNamespaceFunctionDecl(func, full_indent)); 
+    });
+
+    return CString::concat(funcs_emission, indent, '}%n;');
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
-    %% First emit all namespace blocks with their functions
-
     let ns_emission = asm.nsdecls.reduce<CString>('', fn(acc, name, nsdecl) => {
-        return CString::concat(acc, emitNamespaceFromTopLevel(nsdecl));
-    });
-
-    let nsblocks = asm.nsfuncs.reduce<CString>('', fn(acc, nskey, funcs) => {
-        let emission = funcs.reduce<CString>('', fn(funcacc, ikey, func) => {
-            let indent: CString = '    ';
-            return CString::concat(indent, funcacc, emitNamespaceFunctionDecl(func, indent));
-        });
-        
-        return CString::concat(acc, emitNamespaceDecl(nskey.value, emission));
+        return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ''));
     });
 
     %% TODO: Other non namespace functions

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -411,11 +411,11 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>): CString {
 
 function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ctx: Context, indent: CString): CString {
     let name = func.name;
-    let nskey = emitNamespaceKey(func.ns);
+    let nskey = emitNamespaceKey(func.declaredInNS);
     let params = emitParameters(func.params);
     let rtype = emitTypeSignature(func.resultType); 
 
-    let nctx = ctx.updateCurrentNamespace(func.ns, func.fullns);
+    let nctx = ctx.updateCurrentNamespace(func.declaredInNS, func.fullns);
 
     let pre: CString = CString::concat(indent, rtype, ' ', name );
     let params_impl: CString = CString::concat('(', params, ')');
@@ -441,32 +441,45 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     return CString::concat(funcs_emission, indent, '}%n;');
 }
 
-function findNamespaceFunctionDecl(decls: List<NamespaceDecl>, ikey: CPPAssembly::InvokeKey): CPPAssembly::NamespaceFunctionDecl {
-    
-    %%
-    %% This is actually a bit trickier than I thought because we nneed to traverse subns for every ns as well?
-    %% May not quite work...
-    %%
-    return decls.reduce<CPPAssembly::NamespaceFunctionDecl>(CPPAssembly::NamespaceFunctionDecl{},
-        fn(acc, decl) => {
-            if(decl.nsfuncs.has(ikey)) {
-                return decl.nsfuncs.get(ikey);
-            }
+%%
+%% May be nice to handle case where func doesnt exist
+%%
+recursive function findNamespaceFunctionDecl(decls: Map<CString, CPPAssembly::NamespaceDecl>, func: CPPAssembly::FunctionDecl, fullns: List<CString>): CPPAssembly::NamespaceFunctionDecl {
+    let ikey = func.ikey;
 
-        });
+    let ns_name = fullns.front();
+    let remaining_ns_names = fullns.popFront().1;
+
+    %% Found func we are looking for
+    if(remaining_ns_names.empty() && decls.has(ns_name)) {
+        let cur_nsfuncs = decls.get(ns_name).nsfuncs;
+        if(!cur_nsfuncs.has(func.ikey)) {
+            abort; %% Func does not exist
+        }
+        return cur_nsfuncs.get(func.ikey);
+    }
+
+    if(decls.has(ns_name)) {
+        let cur_nsdecl = decls.get(ns_name);
+        return findNamespaceFunctionDecl[recursive](cur_nsdecl.subns, func, remaining_ns_names);
+    }
+    else {
+        abort; %% Namespace does not exist
+    }
 }
 
 %% I suspect we will need separate cases for entities, types, enums and such
 function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl): CString {
-    let pre = decl.invokeKey.value;
+    let pre = decl.ikey.value;
+    let rtype = emitTypeSignature(decl.resultType); 
     let params = emitParameters(decl.params);
-    return CString::concat(pre, '(', params, ');%n;');
+    return CString::concat(rtype, ' ', pre, '(', params, ');%n;');
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
-    %% Emit forward declaration (only supports ns funcs right now :P )
-    let fwd_decl_emission = asm.allfuncs.reduce<CString>('', fn(acc, ikey) => {
-        let funcdecl = findNamespaceFunctionDecl(asm.nsdecls, ikey);
+    %% Emit forward declaration (only supports namespace funcs right now :P )
+    let fwddecl_emission = asm.allfuncs.reduce<CString>('', fn(acc, func) => {
+        let funcdecl = findNamespaceFunctionDecl[recursive](asm.nsdecls, func, func.fullns);
         return CString::concat(acc, emitFunctionForwardDeclaration(funcdecl));
     });
 
@@ -481,5 +494,5 @@ function emitAssembly(asm: CPPAssembly::Assembly): CString {
 
     %% For CCharBuf and Unicode... will need to emit builtin functions explicitly
 
-    return CString::join('%n;', ns_emission);
+    return CString::join('%n;', fwddecl_emission, ns_emission, '%n;');
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -45,12 +45,25 @@ function emitVarIdentifier(vident: CPPAssembly::VarIdentifier): CString {
     return vident.value;
 }
 
-function emitFunction(ik: CPPAssembly::InvokeKey): CString {
+function emitInvokeKey(ik: CPPAssembly::InvokeKey): CString {
     return ik.value;
 }
 
 function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): CString {
     return nsk.value;
+}
+
+function emitResolvedNamespace(ikey: CPPAssembly::InvokeKey, ns: CPPAssembly::NamespaceKey): CString {
+    let kval = emitInvokeKey(ikey);
+    let nsval = emitNamespaceKey(ns);
+
+    %% We can compare the invoke key and namespace value - emit only portion of ikey that is not in
+    %% nskey
+    let resolved = kval.removePrefixString(nsval);
+    if(resolved.startsWithString('::')) {
+        return resolved.removePrefixString('::');
+    }
+    return resolved;
 }
 
 function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression): CString {
@@ -244,6 +257,14 @@ recursive function emitLogicActionOrExpression(e: CPPAssembly::LogicActionOrExpr
     return CString::concat('(', CString::joinAll(' || ', args), ')');
 }
 
+function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFunctionExpression): CString { 
+    let nsdecl = emitResolvedNamespace(e.ikey, e.ns);
+    let ident = emitInvokeKey(e.ikey);
+
+    %% No arguments supported currently
+    return CString::concat(ident, '()');
+}
+
 function emitExpression(e: CPPAssembly::Expression): CString {
     match(e)@ {
         CPPAssembly::BinaryArithExpression => { return emitBinaryArithExpression[recursive]($e); }
@@ -254,6 +275,7 @@ function emitExpression(e: CPPAssembly::Expression): CString {
         | CPPAssembly::LogicActionOrExpression => { return emitLogicActionOrExpression[recursive]($e); }
         | CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($e); }
         | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e); }
+        | CPPAssembly::CallNamespaceFunctionExpression => { return emitCallNamespaceFunctionExpression($e); }
         | _ => { abort; }
     }
 }
@@ -340,7 +362,6 @@ function emitBodyImplementation(body: CPPAssembly::BodyImplementation, indent: C
     }
 }
 
-%% Will need to specific namespace of function
 function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, indent: CString): CString {
     let name = func.name;
     let nskey = emitNamespaceKey(func.ns);
@@ -366,7 +387,7 @@ function emitAssembly(asm: CPPAssembly::Assembly): CString {
             return CString::concat(indent, funcacc, emitNamespaceFunctionDecl(func, indent));
         });
         
-        return emitNamespaceDecl(nskey, emission);
+        return CString::concat(acc, emitNamespaceDecl(nskey, emission));
     });
 
     %% TODO: Other non namespace functions

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -30,9 +30,10 @@ namespace UnicodeCharBuffer {
 entity Context {
     field fullns_key: CPPAssembly::NamespaceKey; %% Main::Foo::Bar::...
     field fullns_list: List<CString>; %% ['Main', 'Foo', 'Bar', ...]
+    field nsdecls: Map<CString, CPPAssembly::NamespaceDecl>;
 
-    method updateCurrentNamespace(new_ns: CPPAssembly::NamespaceKey, new_nsname: List<CString> ): Context {
-        return Context{ new_ns, new_nsname };
+    method updateCurrentNamespace(new_ns: CPPAssembly::NamespaceKey, new_nsname: List<CString>): Context {
+        return Context{ new_ns, new_nsname, this.nsdecls };
     }
 }
 
@@ -265,19 +266,76 @@ recursive function emitLogicActionOrExpression(e: CPPAssembly::LogicActionOrExpr
     return CString::concat('(', CString::joinAll(' || ', args), ')');
 }
 
-function emitArgumentValue(av: CPPAssembly::ArgumentValue, ctx: Context): CString {
-    let expr = emitExpression[recursive](av.exp, ctx);
+function emitArgumentValue(av: Option<CPPAssembly::ArgumentValue>, i: Nat, func: CPPAssembly::NamespaceFunctionDecl, ctx: Context): CString {
+    if(av)@none {
+        let param = func.params.get(i).defaultval;
+        if(param)@none {
+            abort; %% Should be impossible
+        }
+        else {
+            %%
+            %% Current issue is that default parameters just emit of form y: Int = $x and spits out just $x, not resolving whatever x is.
+            %%
 
-    match(av)@ {
-        CPPAssembly::NamedArgumentValue => { return expr; } %% Not functional, just emits expr no named param
-        | CPPAssembly::PositionalArgumentValue => { return expr; }
-        | _ => { abort; } %% TODO: Not Implemented
+            return emitExpression[recursive]($param, ctx);
+        }
+    }
+    else {
+        let arg = $av;
+        let expr = emitExpression[recursive](arg.exp, ctx);
+        match(arg)@ {
+            CPPAssembly::NamedArgumentValue => { return expr; } %% Not functional, just emits expr no named param
+            | CPPAssembly::PositionalArgumentValue => { return expr; }
+            | _ => { abort; }
+        }
     }
 }
 
-function emitArgumentList(al: CPPAssembly::ArgumentList, ctx: Context): CString {
-    let emit_al = al.args.map<CString>(fn(arg) => emitArgumentValue(arg, ctx));
-    return CString::joinAll(', ', emit_al);
+function emitArgumentList(al: CPPAssembly::ArgumentList, func: CPPAssembly::NamespaceFunctionDecl, ctx: Context): CString {
+    let emit_al = al.args.mapIdx<CString>(fn(arg, ii) => emitArgumentValue(arg, ii, func, ctx));
+    
+    %% Second pass to resolve any default parameters by finding matching param name
+    let resolved_default_params_al = emit_al.map<CString>(fn(arg) => {
+        if(arg.startsWithString('$')) { %% We need to resolve this default params value 
+            let ident = arg.removePrefixString('$');
+
+            %% This is a bit hacky but works
+            let idxes = func.params.mapIdx<Nat>(fn(param, ii) => {
+                if(emitIdentifier(param.pname) === ident) {
+                    return ii;
+                }
+                return 0n;
+            });
+            let idx = idxes.sum();
+
+            return emit_al.get(idx);
+        }
+        return arg; 
+    });
+    
+    return CString::joinAll(', ', resolved_default_params_al);
+}
+
+recursive function findNamespaceFunctionDecl(decls: Map<CString, CPPAssembly::NamespaceDecl>, ikey: CPPAssembly::InvokeKey, fullns: List<CString>): CPPAssembly::NamespaceFunctionDecl {
+    let ns_name = fullns.front();
+    let remaining_ns_names = fullns.popFront().1;
+
+    %% Found func we are looking for
+    if(remaining_ns_names.empty() && decls.has(ns_name)) {
+        let cur_nsfuncs = decls.get(ns_name).nsfuncs;
+        if(!cur_nsfuncs.has(ikey)) {
+            abort; %% Func does not exist
+        }
+        return cur_nsfuncs.get(ikey);
+    }
+
+    if(decls.has(ns_name)) {
+        let cur_nsdecl = decls.get(ns_name);
+        return findNamespaceFunctionDecl[recursive](cur_nsdecl.subns, ikey, remaining_ns_names);
+    }
+    else {
+        abort; %% Namespace does not exist
+    }
 }
 
 function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFunctionExpression, ctx: Context): CString { 
@@ -294,7 +352,8 @@ function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFuncti
         resolvedName = name;
     }
 
-    let args = emitArgumentList(e.args, ctx);
+    let func = findNamespaceFunctionDecl(ctx.nsdecls, e.ikey, e.fullns);
+    let args = emitArgumentList(e.args, func, ctx);
 
     if(resolvedns !== '') {
         return CString::concat(resolvedns, '::', resolvedName,'(', args, ')');
@@ -428,50 +487,21 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     let ns = CString::concat(indent, 'namespace ', nsdecl.nsname, ' {%n;');
     let full_indent = CString::concat('    ', indent);
 
-    let fwd_decls = nsdecl.nsfuncs.reduce<CString>('', fn(acc, ikey, decl) => {
-        return CString::concat(acc, emitFunctionForwardDeclaration(decl, full_indent));
-    });
-
-    let base = CString::concat(ns, fwd_decls);
-
     %% Emit sub-namespace declarations
-    let subns_emission = nsdecl.subns.reduce<CString>(base, fn(acc, name, decl) => {
+    let subns = nsdecl.subns.reduce<CString>(ns, fn(acc, name, decl) => {
         return CString::concat(acc, emitNamespaceDecl[recursive](decl, ctx, full_indent));
     });
 
+    let fwd_decls = nsdecl.nsfuncs.reduce<CString>(subns, fn(acc, ikey, decl) => {
+        return CString::concat(acc, emitFunctionForwardDeclaration(decl, full_indent));
+    });
+
     %% Emit functions in current namespace
-    let funcs_emission = nsdecl.nsfuncs.reduce<CString>(subns_emission, fn(acc, key, func) => {
+    let funcs = nsdecl.nsfuncs.reduce<CString>(CString::concat(fwd_decls, '%n;'), fn(acc, key, func) => {
         return CString::concat(acc, emitNamespaceFunctionDecl(func, ctx, full_indent)); 
     });
 
-    return CString::concat(funcs_emission, indent, '}%n;');
-}
-
-%%
-%% I think this can be deleted (ill check on tuesday mornign)
-%%
-recursive function findNamespaceFunctionDecl(decls: Map<CString, CPPAssembly::NamespaceDecl>, func: CPPAssembly::FunctionDecl, fullns: List<CString>): CPPAssembly::NamespaceFunctionDecl {
-    let ikey = func.ikey;
-
-    let ns_name = fullns.front();
-    let remaining_ns_names = fullns.popFront().1;
-
-    %% Found func we are looking for
-    if(remaining_ns_names.empty() && decls.has(ns_name)) {
-        let cur_nsfuncs = decls.get(ns_name).nsfuncs;
-        if(!cur_nsfuncs.has(func.ikey)) {
-            abort; %% Func does not exist
-        }
-        return cur_nsfuncs.get(func.ikey);
-    }
-
-    if(decls.has(ns_name)) {
-        let cur_nsdecl = decls.get(ns_name);
-        return findNamespaceFunctionDecl[recursive](cur_nsdecl.subns, func, remaining_ns_names);
-    }
-    else {
-        abort; %% Namespace does not exist
-    }
+    return CString::concat(funcs, indent, '}%n;');
 }
 
 %% I suspect we will need separate cases for entities, types, enums and such
@@ -484,9 +514,7 @@ function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
-    %% Likely need to add support for an empty namespace (or reserved), when creating ctx
-    %% if we pass in no namespace key (or empty string) regex gets mad
-    let ctx: Context = Context{CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''}}; %% No known namespace yet
+    let ctx: Context = Context{CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''}, asm.nsdecls}; %% No known namespace yet
     let ns_emission = asm.nsdecls.reduce<CString>('', fn(acc, nsname, nsdecl) => {
         return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, ''));
     });

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -213,16 +213,23 @@ entity CPPTransformer {
         }
     }
 
-    method transformArgumentList(bsqargs: BSQAssembly::ArgumentList): CPPAssembly::ArgumentList {
-        let alist = bsqargs.args.map<CPPAssembly::ArgumentValue>(fn(arg) => this.transformArgument(arg));
-        return CPPAssembly::ArgumentList{ alist };   
+    method transformArgumentList(bsqargs: BSQAssembly::InvokeArgumentInfo): CPPAssembly::ArgumentList {
+        let alist = bsqargs.args.args.map<CPPAssembly::ArgumentValue>(fn(arg) => this.transformArgument(arg));
+        let shuffled = alist.mapIdx<CPPAssembly::ArgumentValue>(fn(cpparg, ii) => {
+            let cur_shuffleinfo = bsqargs.shuffleinfo.get(ii).0;
+            match(cur_shuffleinfo)@ {
+                None => { abort; } %% TODO: Handle default parameter
+                | _ => { return alist.get($cur_shuffleinfo.value); }
+            }
+        });
+        return CPPAssembly::ArgumentList{ shuffled };   
     }
 
     method transformCallNamespaceFunctionExpression(expr: BSQAssembly::CallNamespaceFunctionExpression): CPPAssembly::CallNamespaceFunctionExpression {
         let ts = CPPTransformNameManager::convertTypeSignature(expr.etype);
         let ikey = CPPTransformNameManager::convertInvokeKey(expr.ikey);
         let ns = CPPTransformNameManager::convertNamespaceKey(expr.ns);
-        let args = this.transformArgumentList(expr.argsinfo.args);
+        let args = this.transformArgumentList(expr.argsinfo);
 
         return CPPAssembly::CallNamespaceFunctionExpression{ ts, ikey, ns, args };
     }
@@ -327,6 +334,14 @@ entity CPPTransformer {
     }
 
     method transformNamespaceFunctionDeclToCpp(decl: BSQAssembly::NamespaceFunctionDecl): CPPAssembly::NamespaceFunctionDecl {
+        var name: CString;
+        if(decl.name.value === 'main') {
+            name = '__main';
+        }
+        else {
+            name = decl.name.value;
+        }
+
         let nskey = CPPTransformNameManager::convertNamespaceKey(decl.declaredInNS);
         let fullns = decl.fullns;
         let ikey = CPPTransformNameManager::convertInvokeKey(decl.ikey);
@@ -335,7 +350,7 @@ entity CPPTransformer {
 
         let body = this.transformBodyToCpp(decl.body);
 
-        return CPPAssembly::NamespaceFunctionDecl{nskey, fullns, decl.name.value, ikey, params, res, body};
+        return CPPAssembly::NamespaceFunctionDecl{nskey, fullns, name, ikey, params, res, body};
     }   
 
     %*

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -354,11 +354,21 @@ entity CPPTransformer {
                 fn(acc, ikey) => {
                     let bsqdecl = bsqasm.nsfuncs.get(ikey);
                     let cppdecl = transformer.transformNamespaceFunctionDeclToCpp(bsqdecl);
-                    return CPPTransformNameManager::getNamespaceDeclMapping(bsqdecl.fullns, acc, cppdecl.invokeKey, cppdecl);
+                    return CPPTransformNameManager::getNamespaceDeclMapping(bsqdecl.fullns, acc, cppdecl.ikey, cppdecl);
                 }
             );
 
-        let transformer_allfuncs = bsqasm.allfuncs.map<CPPAssembly::InvokeKey>(fn(ikey) => CPPTransformNameManager::convertInvokeKey(ikey));
+        let transformer_allfuncs = bsqasm.allfuncs.map<CPPAssembly::FunctionDecl>(fn(ikey) => {
+            let cppikey = CPPTransformNameManager::convertInvokeKey(ikey);
+            if(bsqasm.nsfuncs.has(ikey)) {
+                let bsqfunc = bsqasm.nsfuncs.get(ikey);
+                return CPPAssembly::FunctionDecl{ CPPTransformNameManager::convertNamespaceKey(bsqfunc.declaredInNS), 
+                    bsqfunc.fullns, cppikey };
+            }
+            else {
+                abort; 
+            }
+        });
 
         return CPPAssembly::Assembly {
             nsdecls = transformer_nsdecls,

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -40,10 +40,10 @@ namespace CPPTransformNameManager {
     }
 
     %%
-    %% Note: This DOES appear to correctly build up the namespace hierarchy like we want,
-    %% but we do not correctly emit corresponding cpp code
+    %% Note: This does not correctly build up our map if there are mulstple namespaces of
+    %% same nesting
     %%
-    recursive function getNamespaceDeclMapping(fullns: List<CString>, nsdecls: Map<CString, CPPAssembly::NamespaceDecl>): Map<CString, CPPAssembly::NamespaceDecl> {
+    recursive function getNamespaceDeclMapping(fullns: List<CString>, nsdecls: Map<CString, CPPAssembly::NamespaceDecl>, func_key: CPPAssembly::InvokeKey, func_val: CPPAssembly::NamespaceFunctionDecl): Map<CString, CPPAssembly::NamespaceDecl> {
         if(fullns.empty()) { %% Base case, we have recursed through all subdecls
             return nsdecls;
         }
@@ -59,15 +59,27 @@ namespace CPPTransformNameManager {
             cur_nsdecl = createNamespaceDecl(ns_name);
         }
 
-        %% Recursively process remaining names
-        let subns = getNamespaceDeclMapping[recursive](remaining_ns_names, cur_nsdecl.subns);
+        %% See if we can insert our namespace function decl
+        var func: Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>;
+        if(remaining_ns_names.empty()) {
+            func = cur_nsdecl.nsfuncs.insert(func_key, func_val);
+        }
+        else{
+            func = cur_nsdecl.nsfuncs;
+        }
 
-        let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, subns, cur_nsdecl.nsfuncs };
-        
-        if(!nsdecls.has(updated_nsdecl.nsname)) {
+        %% Recursively process remaining names
+        let subns = getNamespaceDeclMapping[recursive](remaining_ns_names, cur_nsdecl.subns, func_key, func_val);
+        let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, subns, func };
+
+        %% We need to always update the map as sub namespaces may change (this handle multiple ns at same depth)
+        if(!nsdecls.has(ns_name)) {
             return nsdecls.insert(ns_name, updated_nsdecl);
         }
-        return nsdecls;
+        else {
+            let tmp_map = nsdecls.delete(ns_name);
+            return tmp_map.insert(ns_name, updated_nsdecl);
+        }
     }
 }
 
@@ -312,39 +324,21 @@ entity CPPTransformer {
     function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {
         let transformer = CPPTransformer{ bsqasm };            
 
-        %%
-        %% As of now we do two passes, first builds the correct hierarchy of namespaces for
-        %% our nsdecls field, second inserts functions into correct namespace declaration
-        %% (I suspect these can and should be merged)
-        %%
         let transformer_nsdecls = bsqasm.allfuncs
             .filter(pred(ikey) => bsqasm.nsfuncs.has(ikey))
             .reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
                 Map<CString, CPPAssembly::NamespaceDecl>{},
                 fn(acc, ikey) => {
-                    let fullns = bsqasm.nsfuncs.get(ikey).fullns;
-                    return CPPTransformNameManager::getNamespaceDeclMapping(fullns, acc);
-                }
-            );
- 
-
-        %% Will leave for now
-        let transformer_nsfuncs = bsqasm.allfuncs
-            .filter(pred(ikey) => bsqasm.nsfuncs.has(ikey))
-            .reduce<Map<CPPAssembly::NamespaceKey, Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>>>(
-                Map<CPPAssembly::NamespaceKey, Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>>{},
-                fn(acc, ikey) => {
                     let bsqdecl = bsqasm.nsfuncs.get(ikey);
                     let cppdecl = transformer.transformNamespaceFunctionDeclToCpp(bsqdecl);
-                    let map = Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>{cppdecl.invokeKey => cppdecl};
-                    return acc.insert(cppdecl.ns, map);
-                });
+                    return CPPTransformNameManager::getNamespaceDeclMapping(bsqdecl.fullns, acc, cppdecl.invokeKey, cppdecl);
+                }
+            );
 
         let transformer_allfuncs = bsqasm.allfuncs.map<CPPAssembly::InvokeKey>(fn(ikey) => CPPTransformNameManager::convertInvokeKey(ikey));
 
         return CPPAssembly::Assembly {
             nsdecls = transformer_nsdecls,
-            nsfuncs = transformer_nsfuncs,
             allfuncs = transformer_allfuncs
         };
     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -213,27 +213,23 @@ entity CPPTransformer {
         }
     }
 
-    %%
-    %% We can do these two loops together
-    %%
     method transformArgumentList(bsqargs: BSQAssembly::InvokeArgumentInfo): CPPAssembly::ArgumentList {
-        let alist = bsqargs.args.args.map<CPPAssembly::ArgumentValue>(fn(arg) => this.transformArgument(arg));
         let shuffled = bsqargs.shuffleinfo.mapIdx<Option<CPPAssembly::ArgumentValue>>(fn(e, ii) => {
             var cur_arg: CPPAssembly::ArgumentValue;
-            if(ii >= alist.size()) {
+            if(ii >= bsqargs.args.args.size()) {
                 return none;
             }
             else { %% Resolve shuffle value
                 let shuffle_idx = e.0;
                 if(shuffle_idx)@none {
-                    return none;
+                    let arg = bsqargs.args.args.get(ii);
+                    return some(this.transformArgument(arg));
                 }
                 else {
-                    cur_arg = alist.get($shuffle_idx);
+                    let arg = bsqargs.args.args.get($shuffle_idx);
+                    return some(this.transformArgument(arg));
                 }
             }
-
-            return some(cur_arg);
         });
         return CPPAssembly::ArgumentList{ shuffled };   
     }
@@ -356,14 +352,7 @@ entity CPPTransformer {
     }
 
     method transformNamespaceFunctionDeclToCpp(decl: BSQAssembly::NamespaceFunctionDecl): CPPAssembly::NamespaceFunctionDecl {
-        var name: CString;
-        if(decl.name.value === 'main') {
-            name = '__main';
-        }
-        else {
-            name = decl.name.value;
-        }
-
+        let name = decl.name.value;
         let nskey = CPPTransformNameManager::convertNamespaceKey(decl.declaredInNS);
         let fullns = decl.fullns;
         let ikey = CPPTransformNameManager::convertInvokeKey(decl.ikey);
@@ -403,7 +392,7 @@ entity CPPTransformer {
                     bsqfunc.fullns, cppikey };
             }
             else {
-                abort; %% I suspect we will need to eventually support non-ns funcs
+                abort; %% We will need to eventually support non-ns funcs
             }
         });
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -213,14 +213,27 @@ entity CPPTransformer {
         }
     }
 
+    %%
+    %% We can do these two loops together
+    %%
     method transformArgumentList(bsqargs: BSQAssembly::InvokeArgumentInfo): CPPAssembly::ArgumentList {
         let alist = bsqargs.args.args.map<CPPAssembly::ArgumentValue>(fn(arg) => this.transformArgument(arg));
-        let shuffled = alist.mapIdx<CPPAssembly::ArgumentValue>(fn(cpparg, ii) => {
-            let cur_shuffleinfo = bsqargs.shuffleinfo.get(ii).0;
-            match(cur_shuffleinfo)@ {
-                None => { abort; } %% TODO: Handle default parameter
-                | _ => { return alist.get($cur_shuffleinfo.value); }
+        let shuffled = bsqargs.shuffleinfo.mapIdx<Option<CPPAssembly::ArgumentValue>>(fn(e, ii) => {
+            var cur_arg: CPPAssembly::ArgumentValue;
+            if(ii >= alist.size()) {
+                return none;
             }
+            else { %% Resolve shuffle value
+                let shuffle_idx = e.0;
+                if(shuffle_idx)@none {
+                    return none;
+                }
+                else {
+                    cur_arg = alist.get($shuffle_idx);
+                }
+            }
+
+            return some(cur_arg);
         });
         return CPPAssembly::ArgumentList{ shuffled };   
     }
@@ -230,8 +243,9 @@ entity CPPTransformer {
         let ikey = CPPTransformNameManager::convertInvokeKey(expr.ikey);
         let ns = CPPTransformNameManager::convertNamespaceKey(expr.ns);
         let args = this.transformArgumentList(expr.argsinfo);
+        let fullns = expr.fullns; %% For looking up func we are calling
 
-        return CPPAssembly::CallNamespaceFunctionExpression{ ts, ikey, ns, args };
+        return CPPAssembly::CallNamespaceFunctionExpression{ ts, ikey, ns, fullns, args };
     }
 
     recursive method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
@@ -314,11 +328,19 @@ entity CPPTransformer {
         return stmts.map<CPPAssembly::Statement>(fn(stmt) => this.transformStatementToCpp(stmt));
     }
 
+    method transformDefaultVal(val: Option<BSQAssembly::Expression>): Option<CPPAssembly::Expression> {
+        match(val)@ {
+            None => { return none; }
+            | _ => { return some(this.transformExpressionToCpp[recursive]($val.value)); }
+        }
+    }
+
     method transformParameterDecl(decl: List<BSQAssembly::InvokeParameterDecl>): List<CPPAssembly::ParameterDecl> {
         return decl.map<CPPAssembly::ParameterDecl>(fn(pdecl) => {
             return CPPAssembly::ParameterDecl{ 
                 CPPTransformNameManager::convertIdentifier(pdecl.pname), 
-                CPPTransformNameManager::convertTypeSignature(pdecl.ptype) 
+                CPPTransformNameManager::convertTypeSignature(pdecl.ptype),
+                this.transformDefaultVal(pdecl.defaultval)
             };
         });
     }
@@ -381,7 +403,7 @@ entity CPPTransformer {
                     bsqfunc.fullns, cppikey };
             }
             else {
-                abort; 
+                abort; %% I suspect we will need to eventually support non-ns funcs
             }
         });
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -32,6 +32,43 @@ namespace CPPTransformNameManager {
     function convertVarIdentifier(vident: BSQAssembly::VarIdentifier): CPPAssembly::VarIdentifier {
         return CPPAssembly::VarIdentifier::from(vident.value);
     }
+
+    function createNamespaceDecl(name: CString): CPPAssembly::NamespaceDecl {
+        let subns = Map<CString, CPPAssembly::NamespaceDecl>{};
+        let nsfuncs = Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>{};
+        return CPPAssembly::NamespaceDecl{ name, subns, nsfuncs };
+    }
+
+    %%
+    %% Note: This DOES appear to correctly build up the namespace hierarchy like we want,
+    %% but we do not correctly emit corresponding cpp code
+    %%
+    recursive function getNamespaceDeclMapping(fullns: List<CString>, nsdecls: Map<CString, CPPAssembly::NamespaceDecl>): Map<CString, CPPAssembly::NamespaceDecl> {
+        if(fullns.empty()) { %% Base case, we have recursed through all subdecls
+            return nsdecls;
+        }
+
+        let ns_name = fullns.front();
+        let remaining_ns_names = fullns.popFront().1;
+
+        var cur_nsdecl: CPPAssembly::NamespaceDecl;
+        if(nsdecls.has(ns_name)) {
+            cur_nsdecl = nsdecls.get(ns_name);
+        }
+        else {
+            cur_nsdecl = createNamespaceDecl(ns_name);
+        }
+
+        %% Recursively process remaining names
+        let subns = getNamespaceDeclMapping[recursive](remaining_ns_names, cur_nsdecl.subns);
+
+        let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, subns, cur_nsdecl.nsfuncs };
+        
+        if(!nsdecls.has(updated_nsdecl.nsname)) {
+            return nsdecls.insert(ns_name, updated_nsdecl);
+        }
+        return nsdecls;
+    }
 }
 
 entity CPPTransformer {
@@ -272,36 +309,24 @@ entity CPPTransformer {
     }
     *%
 
-    %%
-    %% Take our bsqasm namespace function, iterate through fullns field, then extract namespace decl
-    %% at lowest scope (last element in fullns)
-    %%
-    recursive method getNamespaceDecl(fullns: List<CString>, nsdecls: Map<CString, CPPAssembly::NamespaceDecl>): CPPAssembly::NamespaceDecl {
-        if(fullns.empty()) {
-            abort; %% Should not happen
-        }
-
-        let cur_ns = fullns.front();
-        let remaining_ns = fullns.popFront().1;
-
-        %%
-        %% I think we need to do some logic for the inserted map here to make sure it
-        %% actually is initialized maybe...? Gonna wrestle this tomorrow.
-        %%
-
-        abort;
-    }
-
     function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {
         let transformer = CPPTransformer{ bsqasm };            
 
-        %% let transformer_nsdecls = Map<CString, NamespaceDecl>{};
-
         %%
-        %% I think we will need to just call this getNamespaceDecl in a loop like this one for
-        %% iterating functions, but instead we just insert the cppdecl version of the bsqasm function
-        %% and return this transformer_nsdecls map as nsdecls in the cppassembly
+        %% As of now we do two passes, first builds the correct hierarchy of namespaces for
+        %% our nsdecls field, second inserts functions into correct namespace declaration
+        %% (I suspect these can and should be merged)
         %%
+        let transformer_nsdecls = bsqasm.allfuncs
+            .filter(pred(ikey) => bsqasm.nsfuncs.has(ikey))
+            .reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
+                Map<CString, CPPAssembly::NamespaceDecl>{},
+                fn(acc, ikey) => {
+                    let fullns = bsqasm.nsfuncs.get(ikey).fullns;
+                    return CPPTransformNameManager::getNamespaceDeclMapping(fullns, acc);
+                }
+            );
+ 
 
         %% Will leave for now
         let transformer_nsfuncs = bsqasm.allfuncs
@@ -318,6 +343,7 @@ entity CPPTransformer {
         let transformer_allfuncs = bsqasm.allfuncs.map<CPPAssembly::InvokeKey>(fn(ikey) => CPPTransformNameManager::convertInvokeKey(ikey));
 
         return CPPAssembly::Assembly {
+            nsdecls = transformer_nsdecls,
             nsfuncs = transformer_nsfuncs,
             allfuncs = transformer_allfuncs
         };

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -202,12 +202,29 @@ entity CPPTransformer {
         return CPPAssembly::LogicActionOrExpression{cpptype, args};
     }
 
+    method transformArgument(arg: BSQAssembly::ArgumentValue): CPPAssembly::ArgumentValue {
+        let exp = this.transformExpressionToCpp[recursive](arg.exp);
+
+        match(arg)@ {
+            BSQAssembly::NamedArgumentValue => { return CPPAssembly::NamedArgumentValue{ 
+                exp, CPPTransformNameManager::convertVarIdentifier($arg.name) }; }
+            | BSQAssembly::PositionalArgumentValue => { return CPPAssembly::PositionalArgumentValue{ exp }; }
+            | _ => { abort; } %% TODO: Not implemented
+        }
+    }
+
+    method transformArgumentList(bsqargs: BSQAssembly::ArgumentList): CPPAssembly::ArgumentList {
+        let alist = bsqargs.args.map<CPPAssembly::ArgumentValue>(fn(arg) => this.transformArgument(arg));
+        return CPPAssembly::ArgumentList{ alist };   
+    }
+
     method transformCallNamespaceFunctionExpression(expr: BSQAssembly::CallNamespaceFunctionExpression): CPPAssembly::CallNamespaceFunctionExpression {
         let ts = CPPTransformNameManager::convertTypeSignature(expr.etype);
         let ikey = CPPTransformNameManager::convertInvokeKey(expr.ikey);
         let ns = CPPTransformNameManager::convertNamespaceKey(expr.ns);
+        let args = this.transformArgumentList(expr.argsinfo.args);
 
-        return CPPAssembly::CallNamespaceFunctionExpression{ ts, ikey, ns, none };
+        return CPPAssembly::CallNamespaceFunctionExpression{ ts, ikey, ns, args };
     }
 
     recursive method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -290,6 +290,15 @@ entity CPPTransformer {
         return stmts.map<CPPAssembly::Statement>(fn(stmt) => this.transformStatementToCpp(stmt));
     }
 
+    method transformParameterDecl(decl: List<BSQAssembly::InvokeParameterDecl>): List<CPPAssembly::ParameterDecl> {
+        return decl.map<CPPAssembly::ParameterDecl>(fn(pdecl) => {
+            return CPPAssembly::ParameterDecl{ 
+                CPPTransformNameManager::convertIdentifier(pdecl.pname), 
+                CPPTransformNameManager::convertTypeSignature(pdecl.ptype) 
+            };
+        });
+    }
+
     method transformBodyToCpp(body: BSQAssembly::BodyImplementation): CPPAssembly::BodyImplementation {
         match(body)@ {
             BSQAssembly::StandardBodyImplementation => { 
@@ -304,12 +313,12 @@ entity CPPTransformer {
         let nskey = CPPTransformNameManager::convertNamespaceKey(decl.declaredInNS);
         let fullns = decl.fullns;
         let ikey = CPPTransformNameManager::convertInvokeKey(decl.ikey);
-        %% Parameters
+        let params = this.transformParameterDecl(decl.params);
         let res = CPPTransformNameManager::convertTypeSignature(decl.resultType);
 
         let body = this.transformBodyToCpp(decl.body);
 
-        return CPPAssembly::NamespaceFunctionDecl{nskey, fullns, decl.name.value, ikey, none, res, body};
+        return CPPAssembly::NamespaceFunctionDecl{nskey, fullns, decl.name.value, ikey, params, res, body};
     }   
 
     %*

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -302,13 +302,14 @@ entity CPPTransformer {
 
     method transformNamespaceFunctionDeclToCpp(decl: BSQAssembly::NamespaceFunctionDecl): CPPAssembly::NamespaceFunctionDecl {
         let nskey = CPPTransformNameManager::convertNamespaceKey(decl.declaredInNS);
+        let fullns = decl.fullns;
         let ikey = CPPTransformNameManager::convertInvokeKey(decl.ikey);
         %% Parameters
         let res = CPPTransformNameManager::convertTypeSignature(decl.resultType);
 
         let body = this.transformBodyToCpp(decl.body);
 
-        return CPPAssembly::NamespaceFunctionDecl{nskey, decl.name.value, ikey, none, res, body};
+        return CPPAssembly::NamespaceFunctionDecl{nskey, fullns, decl.name.value, ikey, none, res, body};
     }   
 
     %*

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -39,10 +39,6 @@ namespace CPPTransformNameManager {
         return CPPAssembly::NamespaceDecl{ name, subns, nsfuncs };
     }
 
-    %%
-    %% Note: This does not correctly build up our map if there are mulstple namespaces of
-    %% same nesting
-    %%
     recursive function getNamespaceDeclMapping(fullns: List<CString>, nsdecls: Map<CString, CPPAssembly::NamespaceDecl>, func_key: CPPAssembly::InvokeKey, func_val: CPPAssembly::NamespaceFunctionDecl): Map<CString, CPPAssembly::NamespaceDecl> {
         if(fullns.empty()) { %% Base case, we have recursed through all subdecls
             return nsdecls;
@@ -72,7 +68,7 @@ namespace CPPTransformNameManager {
         let subns = getNamespaceDeclMapping[recursive](remaining_ns_names, cur_nsdecl.subns, func_key, func_val);
         let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, subns, func };
 
-        %% We need to always update the map as sub namespaces may change (this handle multiple ns at same depth)
+        %% We need to always update the nsdecls map as sub namespaces may change (this handles multiple nsdecls at same depth)
         if(!nsdecls.has(ns_name)) {
             return nsdecls.insert(ns_name, updated_nsdecl);
         }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -157,6 +157,14 @@ entity CPPTransformer {
         return CPPAssembly::LogicActionOrExpression{cpptype, args};
     }
 
+    method transformCallNamespaceFunctionExpression(expr: BSQAssembly::CallNamespaceFunctionExpression): CPPAssembly::CallNamespaceFunctionExpression {
+        let ts = CPPTransformNameManager::convertTypeSignature(expr.etype);
+        let ikey = CPPTransformNameManager::convertInvokeKey(expr.ikey);
+        let ns = CPPTransformNameManager::convertNamespaceKey(expr.ns);
+
+        return CPPAssembly::CallNamespaceFunctionExpression{ ts, ikey, ns, none };
+    }
+
     recursive method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
         match(expr)@ {
             BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpression[recursive]($expr); }
@@ -167,6 +175,7 @@ entity CPPTransformer {
             | BSQAssembly::LogicActionAndExpression => { return this.transformLogicActionAndExpression[recursive]($expr); }
             | BSQAssembly::LogicActionOrExpression => { return this.transformLogicActionOrExpression[recursive]($expr); }
             | BSQAssembly::AccessVariableExpression => { return this.transformAccessVariableExpression($expr); }
+            | BSQAssembly::CallNamespaceFunctionExpression => { return this.transformCallNamespaceFunctionExpression($expr); }
             | _ => { abort; }
         }
     }
@@ -263,10 +272,38 @@ entity CPPTransformer {
     }
     *%
 
-    function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {
-        let transformer = CPPTransformer{ bsqasm };
+    %%
+    %% Take our bsqasm namespace function, iterate through fullns field, then extract namespace decl
+    %% at lowest scope (last element in fullns)
+    %%
+    recursive method getNamespaceDecl(fullns: List<CString>, nsdecls: Map<CString, CPPAssembly::NamespaceDecl>): CPPAssembly::NamespaceDecl {
+        if(fullns.empty()) {
+            abort; %% Should not happen
+        }
 
-        %% Maps each namespace key to a map for each function in the namespace 
+        let cur_ns = fullns.front();
+        let remaining_ns = fullns.popFront().1;
+
+        %%
+        %% I think we need to do some logic for the inserted map here to make sure it
+        %% actually is initialized maybe...? Gonna wrestle this tomorrow.
+        %%
+
+        abort;
+    }
+
+    function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {
+        let transformer = CPPTransformer{ bsqasm };            
+
+        %% let transformer_nsdecls = Map<CString, NamespaceDecl>{};
+
+        %%
+        %% I think we will need to just call this getNamespaceDecl in a loop like this one for
+        %% iterating functions, but instead we just insert the cppdecl version of the bsqasm function
+        %% and return this transformer_nsdecls map as nsdecls in the cppassembly
+        %%
+
+        %% Will leave for now
         let transformer_nsfuncs = bsqasm.allfuncs
             .filter(pred(ikey) => bsqasm.nsfuncs.has(ikey))
             .reduce<Map<CPPAssembly::NamespaceKey, Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>>>(

--- a/src/bsqir/asm/assembly.bsq
+++ b/src/bsqir/asm/assembly.bsq
@@ -4,6 +4,7 @@ concept AbstractDecl {
     field file: String;
     field sinfo: SourceInfo;
 
+    field fullns: List<CString>; %% Useful for namespace resolution in our cppemitter
     field declaredInNS: NamespaceKey;
 }
 
@@ -72,7 +73,6 @@ enum FunctionDeclKindTag {
 
 entity NamespaceFunctionDecl provides FunctionInvokeDecl {
     field fkind: FunctionDeclKindTag;
-    field fullns: List<CString>; %% I will need to also move this (I think)
 }
 
 entity TypeFunctionDecl provides FunctionInvokeDecl {

--- a/src/bsqir/asm/assembly.bsq
+++ b/src/bsqir/asm/assembly.bsq
@@ -72,6 +72,7 @@ enum FunctionDeclKindTag {
 
 entity NamespaceFunctionDecl provides FunctionInvokeDecl {
     field fkind: FunctionDeclKindTag;
+    field fullns: List<CString>;
 }
 
 entity TypeFunctionDecl provides FunctionInvokeDecl {

--- a/src/bsqir/asm/assembly.bsq
+++ b/src/bsqir/asm/assembly.bsq
@@ -72,7 +72,7 @@ enum FunctionDeclKindTag {
 
 entity NamespaceFunctionDecl provides FunctionInvokeDecl {
     field fkind: FunctionDeclKindTag;
-    field fullns: List<CString>;
+    field fullns: List<CString>; %% I will need to also move this (I think)
 }
 
 entity TypeFunctionDecl provides FunctionInvokeDecl {

--- a/src/bsqir/asm/body.bsq
+++ b/src/bsqir/asm/body.bsq
@@ -183,6 +183,7 @@ entity LambdaInvokeExpression provides Expression {
 entity CallNamespaceFunctionExpression provides Expression {
     field ikey: InvokeKey;
     field ns: NamespaceKey;
+    field fullns: List<CString>;
 
     field argsinfo: InvokeArgumentInfo;
 }

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -654,7 +654,8 @@ entity ConstantSimplification {
 
             preconditions = nsfunc.preconditions.map<PreConditionDecl>(fn(precond) => this.processPrecondition(precond)),
             postconditions = nsfunc.postconditions.map<PostConditionDecl>(fn(postcond) => this.processPostcondition(postcond)),
-            fkind = nsfunc.fkind
+            fkind = nsfunc.fkind,
+            fullns = nsfunc.fullns
         };
     }
 

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -640,6 +640,7 @@ entity ConstantSimplification {
         return NamespaceFunctionDecl{
             file = nsfunc.file,
             sinfo = nsfunc.sinfo,
+            fullns = nsfunc.fullns,
             declaredInNS = nsfunc.declaredInNS,
 
             attributes = nsfunc.attributes,
@@ -654,8 +655,7 @@ entity ConstantSimplification {
 
             preconditions = nsfunc.preconditions.map<PreConditionDecl>(fn(precond) => this.processPrecondition(precond)),
             postconditions = nsfunc.postconditions.map<PostConditionDecl>(fn(postcond) => this.processPostcondition(postcond)),
-            fkind = nsfunc.fkind,
-            fullns = nsfunc.fullns
+            fkind = nsfunc.fkind
         };
     }
 
@@ -703,6 +703,7 @@ entity ConstantSimplification {
         return EntityTypeDecl{
             file=etype.file,
             sinfo=etype.sinfo,
+            fullns = etype.fullns,
             declaredInNS=etype.declaredInNS,
             
             tkey=etype.tkey,

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -429,6 +429,7 @@ entity ExplicitifyTransform {
         return NamespaceFunctionDecl{
             file = nsfunc.file,
             sinfo = nsfunc.sinfo,
+            fullns = nsfunc.fullns,
             declaredInNS = nsfunc.declaredInNS,
 
             attributes = nsfunc.attributes,
@@ -443,8 +444,7 @@ entity ExplicitifyTransform {
 
             preconditions = nsfunc.preconditions.map<PreConditionDecl>(fn(precond) => this.processPrecondition(precond)),
             postconditions = nsfunc.postconditions.map<PostConditionDecl>(fn(postcond) => this.processPostcondition(postcond)),
-            fkind = nsfunc.fkind,
-            fullns = nsfunc.fullns
+            fkind = nsfunc.fkind
         };
     }
 
@@ -476,6 +476,7 @@ entity ExplicitifyTransform {
         return EntityTypeDecl{
             file=etype.file,
             sinfo=etype.sinfo,
+            fullns=etype.fullns,
             declaredInNS=etype.declaredInNS,
             
             tkey=etype.tkey,

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -443,7 +443,8 @@ entity ExplicitifyTransform {
 
             preconditions = nsfunc.preconditions.map<PreConditionDecl>(fn(precond) => this.processPrecondition(precond)),
             postconditions = nsfunc.postconditions.map<PostConditionDecl>(fn(postcond) => this.processPostcondition(postcond)),
-            fkind = nsfunc.fkind
+            fkind = nsfunc.fkind,
+            fullns = nsfunc.fullns
         };
     }
 

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -475,7 +475,10 @@ class BSQIREmitter {
 
         const arginfo = this.emitInvokeArgumentInfo(exp.name, ffinv.recursive, exp.args, exp.shuffleinfo, exp.resttype, exp.restinfo);
 
-        return `BSQAssembly::CallNamespaceFunctionExpression{ ${ebase}, ikey='${ikey}'<BSQAssembly::InvokeKey>, ns='${nskey}'<BSQAssembly::NamespaceKey>, argsinfo=${arginfo} }`;
+        const cstrns = exp.ns.ns.map(e => `'${e}'`).join(", ");
+        const fmt_cstrns = `fullns = List<CString>{${cstrns}}`;
+        
+        return `BSQAssembly::CallNamespaceFunctionExpression{ ${ebase}, ikey='${ikey}'<BSQAssembly::InvokeKey>, ns='${nskey}'<BSQAssembly::NamespaceKey>, ${fmt_cstrns}, argsinfo=${arginfo} }`;
     }
     
     private emitCallTypeFunctionExpression(exp: CallTypeFunctionExpression): string {

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -243,7 +243,7 @@ class BSQIREmitter {
 
         const resttypecc = resttype !== undefined ? `some(${this.emitTypeSignature(resttype)})` : "none"
         
-        return `BSQAssembly::InvokeArgumentInfo{ name='${name}'<BSQAssembly::Identifier>, rec=${this.emitRecInfo(rec)}, args=${this.emitArgumentList(args)}, shuffleinfo=List<(|Option<Nat>, TypeSignature|)>{${sinfocc}}, resttype=${resttypecc}, restinfo=List<(|Nat, Bool, TypeSignature|)>{${restinfocc}} }`;
+        return `BSQAssembly::InvokeArgumentInfo{ name='${name}'<BSQAssembly::Identifier>, rec=${this.emitRecInfo(rec)}, args=${this.emitArgumentList(args)}, shuffleinfo=List<(|Option<Nat>, BSQAssembly::TypeSignature|)>{${sinfocc}}, resttype=${resttypecc}, restinfo=List<(|Nat, Bool, BSQAssembly::TypeSignature|)>{${restinfocc}} }`;
     }
 
     private emitITestGeneral(itest: ITest): string {
@@ -475,7 +475,7 @@ class BSQIREmitter {
 
         const arginfo = this.emitInvokeArgumentInfo(exp.name, ffinv.recursive, exp.args, exp.shuffleinfo, exp.resttype, exp.restinfo);
 
-        return `BSQAssembly::CallNamespaceFunctionExpression{ ${ebase}, ikey='${ikey}'<BSQAssembly::InvokeKey>, ns='${nskey}'<BSQAssembly::NamespaceKey>, arginfo=${arginfo} }`;
+        return `BSQAssembly::CallNamespaceFunctionExpression{ ${ebase}, ikey='${ikey}'<BSQAssembly::InvokeKey>, ns='${nskey}'<BSQAssembly::NamespaceKey>, argsinfo=${arginfo} }`;
     }
     
     private emitCallTypeFunctionExpression(exp: CallTypeFunctionExpression): string {
@@ -1545,11 +1545,14 @@ class BSQIREmitter {
                 fmt.indentPush();
                 const ibase = this.emitExplicitInvokeDecl(fdecl, nskey, ikey, fmt);
                 const fkind = fmt.indent(`fkind=${this.emitFKindTag((fdecl as NamespaceFunctionDecl).fkind)}`);
-                
+
+                const cstrns = ns.ns.map(e => `'${e}'`).join(", ");
+                const fmt_cstrns = fmt.indent(`fullns = List<CString>{${cstrns}}`);
+
                 this.mapper = omap;
                 fmt.indentPop();
 
-                this.nsfuncs.push(`'${ikey}'<BSQAssembly::InvokeKey> => BSQAssembly::NamespaceFunctionDecl{ ${ibase},${fmt.nl()}${fkind}${fmt.nl() + fmt.indent("}")}`);
+                this.nsfuncs.push(`'${ikey}'<BSQAssembly::InvokeKey> => BSQAssembly::NamespaceFunctionDecl{ ${ibase}, ${fmt.nl() + fmt_cstrns}, ${fmt.nl()}${fkind}${fmt.nl() + fmt.indent("}")}`);
                 this.allfuncs.push(`'${ikey}'<BSQAssembly::InvokeKey>`);
             }
         }
@@ -2016,6 +2019,8 @@ class BSQIREmitter {
                 this.emitNamespaceDeclaration(decl.subns[i], nsii, aainsts, fmt);
             }
         }
+
+        console.log(decl);
 
         this.emitNamespaceConstDecls(decl.fullnamespace, decl.consts);
 

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -1551,6 +1551,10 @@ class BSQIREmitter {
 
                 this.mapper = omap;
                 fmt.indentPop();
+                
+                if(ns.ns.length > 6) { 
+                    assert(false, "Not Implemented -- Namespace nesting of depth > 6" + cstrns);
+                }
 
                 this.nsfuncs.push(`'${ikey}'<BSQAssembly::InvokeKey> => BSQAssembly::NamespaceFunctionDecl{ ${ibase}, ${fmt.nl() + fmt_cstrns}, ${fmt.nl()}${fkind}${fmt.nl() + fmt.indent("}")}`);
                 this.allfuncs.push(`'${ikey}'<BSQAssembly::InvokeKey>`);

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -2024,8 +2024,6 @@ class BSQIREmitter {
             }
         }
 
-        console.log(decl);
-
         this.emitNamespaceConstDecls(decl.fullnamespace, decl.consts);
 
         this.emitFunctionDecls(decl.fullnamespace, undefined, decl.functions.map((fd) => [fd, asminstantiation.functionbinds.get(fd.name)]), fmt);

--- a/test/cppoutput/fcall_exps/ns_fcalls.test.js
+++ b/test/cppoutput/fcall_exps/ns_fcalls.test.js
@@ -1,0 +1,26 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("Exec -- NamespaceFunction (no template)", () => {
+    it("should exec simple positional", function () {
+        runMainCode("function foo(): Int { return 1i; } public function main(): Int { return foo(); }", "1_i");
+        runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(1i, true); }", "1_i");
+    });
+
+    it("should exec simple named", function () {
+        runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(x=1i, y=true); }", "1_i");
+        runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(y=true, x=1i); }", "1_i");
+    });
+
+    it("should exec simple mixed", function () {
+        runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(1i, y=true); }", "1_i");
+        runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(y=true, x=1i); }", "1_i");
+    });
+
+    it("should exec simple default", function () {
+        runMainCode("function foo(x: Int, y: Int = $x): Int { return x + y; } public function main(): Int { return foo(1i, 2i); }", "3_i");
+        runMainCode("function foo(x: Int, y: Int = $x): Int { return x + y; } public function main(): Int { return foo(1i); }", "2_i");
+    });
+});

--- a/test/cppoutput/fcall_exps/ns_fcalls.test.js
+++ b/test/cppoutput/fcall_exps/ns_fcalls.test.js
@@ -9,6 +9,7 @@ describe ("Exec -- NamespaceFunction (no template)", () => {
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(1i, true); }", "1_i");
     });
 
+    /*
     it("should exec simple named", function () {
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(x=1i, y=true); }", "1_i");
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(y=true, x=1i); }", "1_i");
@@ -23,4 +24,5 @@ describe ("Exec -- NamespaceFunction (no template)", () => {
         runMainCode("function foo(x: Int, y: Int = $x): Int { return x + y; } public function main(): Int { return foo(1i, 2i); }", "3_i");
         runMainCode("function foo(x: Int, y: Int = $x): Int { return x + y; } public function main(): Int { return foo(1i); }", "2_i");
     });
+    */
 });

--- a/test/cppoutput/fcall_exps/ns_fcalls.test.js
+++ b/test/cppoutput/fcall_exps/ns_fcalls.test.js
@@ -9,12 +9,12 @@ describe ("Exec -- NamespaceFunction (no template)", () => {
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(1i, true); }", "1_i");
     });
 
-    /*
     it("should exec simple named", function () {
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(x=1i, y=true); }", "1_i");
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(y=true, x=1i); }", "1_i");
     });
 
+    /*
     it("should exec simple mixed", function () {
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(1i, y=true); }", "1_i");
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(y=true, x=1i); }", "1_i");

--- a/test/cppoutput/fcall_exps/ns_fcalls.test.js
+++ b/test/cppoutput/fcall_exps/ns_fcalls.test.js
@@ -14,7 +14,6 @@ describe ("Exec -- NamespaceFunction (no template)", () => {
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(y=true, x=1i); }", "1_i");
     });
 
-    /*
     it("should exec simple mixed", function () {
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(1i, y=true); }", "1_i");
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(y=true, x=1i); }", "1_i");
@@ -24,5 +23,4 @@ describe ("Exec -- NamespaceFunction (no template)", () => {
         runMainCode("function foo(x: Int, y: Int = $x): Int { return x + y; } public function main(): Int { return foo(1i, 2i); }", "3_i");
         runMainCode("function foo(x: Int, y: Int = $x): Int { return x + y; } public function main(): Int { return foo(1i); }", "2_i");
     });
-    */
-});
+ });


### PR DESCRIPTION
This adds support for cpp emission of properly nested namespaces, forward declarations, calling namespace functions, function arguments, and resolving named, positional, and default parameters. I also added a context entity to the emitter so we can easily resolve what namespace we are currently in and find functions. And a new field to `AbstractDecl` in bsqir, `fullns: List<CString>` which we use to find namespace function declarations (and more generally just resolving namespaces).

If we have some Bosque code like so:
```
declare namespace Main;

namespace Foo {
    function foo(x: Int, y: Int = $x): Int {
        return x * y;
    }
}

public function main(): Int {
    return Foo::foo(10i);
}
```
This emits this cpp:
```
namespace Main {
    namespace Foo {
        __CoreCpp::Int foo(__CoreCpp::Int x, __CoreCpp::Int y);

        __CoreCpp::Int foo(__CoreCpp::Int x, __CoreCpp::Int y) {
            return (x * y);
        }
    }
    __CoreCpp::Int main();

    __CoreCpp::Int main() {
        return Foo::foo(10_i, 10_i);
    }
}
```