### PR TITLE
Fix update postfix parse bug

### DIFF
--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -3480,6 +3480,18 @@ class Parser {
         }
     }
 
+    private testPostfixInvokePrefix(): boolean {
+        if(this.testToken(SYM_langle) || this.testToken(SYM_lparen)) {
+            return true;
+        }
+
+        if(this.testToken(SYM_lbrack) && (this.peekTokenKind(1) === KW_recursive || this.peekTokenKind(1) === KW_recursive_q)) {
+            return true;
+        }
+
+        return false;
+    }
+
     private parsePostfixExpression(): Expression {
         let rootexp = this.parsePrimaryExpression();
 
@@ -3535,7 +3547,7 @@ class Parser {
                     }
 
                     const name = this.parseIdentifierAsStdVariable();
-                    if(!this.testToken(SYM_langle) && !this.testToken(SYM_lbrack) && !this.testToken(SYM_lparen)) {
+                    if(!this.testPostfixInvokePrefix()) {
                         if(resolvedScope !== undefined) {
                             this.recordErrorGeneral(sinfo, "Encountered named access but given type resolver (only valid on method calls)");
                         }

--- a/src/frontend/parser_kw.ts
+++ b/src/frontend/parser_kw.ts
@@ -40,6 +40,8 @@ const KW_true = "true";
 const KW_type = "type";
 const KW_var = "var";
 const KW_yield = "yield";
+const KW_contine = "continue";
+const KW_break = "break";
 const KW_under = "_";
 
 const KW_debug = "debug";
@@ -153,6 +155,8 @@ const KeywordStrings = [
     KW_var,
     KW_when,
     KW_yield,
+    KW_contine,
+    KW_break,
     KW_under,
     KW_event,
     KW_status,
@@ -413,6 +417,8 @@ export {
     KW_var,
     KW_when,
     KW_yield,
+    KW_contine,
+    KW_break,
     KW_under,
     KW_event,
     KW_resource,

--- a/test/parser/access_exps/field_updates.test.js
+++ b/test/parser/access_exps/field_updates.test.js
@@ -13,5 +13,9 @@ describe ("Parser -- simple field updates", () => {
         parseTestFunctionInFileError('entity Foo{ field x: Int; } function main(): Int { var v = Foo{1i}; v[x 2i].x; }', 'Expected "=" but got "2i" when parsing "variable update list"');
         parseTestFunctionInFileError('entity Foo{ field x: Int; } function main(): Int { var v = Foo{1i}; v[x] = 2i; return v.x; }', 'Expected "=" but got "]" when parsing "variable update list"');
     });
+
+    it("should parse postfix field updates", function () {
+        parseTestFunctionInFile('entity Foo { field x: Int; field y: Int; } entity Bar { field f: Foo; } [FUNC]', 'function main(): Int { let a = Bar{Foo{1i, 0i}}; let b = a.f[x = 3i]; return b.x; }');
+    });
 });
 

--- a/test/runtime/access_exps/field_updates.test.js
+++ b/test/runtime/access_exps/field_updates.test.js
@@ -8,5 +8,9 @@ describe ("Exec -- simple field updates", () => {
         runMainCode('entity Foo{ field x: Int; } public function main(): Int { var v = Foo{1i}; return v[x = 2i].x; }', "2i");
         runMainCode('entity Foo{ field x: Int; } public function main(): Int { var v = Foo{1i}; return v[x = $x + 1i].x; }', "2i");
     });
+
+    it("should exec postfix field updates", function () {
+        runMainCode('entity Foo { field x: Int; field y: Int; } entity Bar { field f: Foo; } public function main(): Int { let a = Bar{Foo{1i, 0i}}; let b = a.f[x=3i]; return b.x; }', "3i");
+    });
 });
 

--- a/test/typecheck/access_exps/field_updates.test.js
+++ b/test/typecheck/access_exps/field_updates.test.js
@@ -13,5 +13,9 @@ describe ("Checker -- simple field updates", () => {
         checkTestFunctionInFileError('entity Foo{ field x: Int; } function main(): Int { var v = Foo{1i}; return v[x = 2n].x; }', 'Expression of type Nat cannot be assigned to field x of type Int');
         checkTestFunctionInFileError('entity Foo{ field x: Int; } function main(): Int { var v = Foo{1i}; return v[y = 2i].x; }', 'Field y is not a member of type Foo');
     });
+
+    it("should check postfix field updates", function () {
+        checkTestFunctionInFile('entity Foo { field x: Int; field y: Int; } entity Bar { field f: Foo; } function main(): Int { let a = Bar{Foo{1i, 0i}}; let b = a.f[x=3i]; return b.x; }');
+    });
 });
 


### PR DESCRIPTION
Parse error on `x.f[y=2i]` incorrectly trying to parse as an invoke. Fixed + tests.