### PR TITLE
Cpp Emit Simple Entity

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -148,8 +148,6 @@ concept ConstructorPrimaryExpression provides ConstructorExpression {
 }
 
 entity ConstructorStdExpression provides ConstructorPrimaryExpression {
-    %% I suspect we will want to move this to ConstructorPrimaryExpression or just more generally
-    %% ConstructorExpression...
     field fullns: List<CString>;
 }
 

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -34,16 +34,6 @@ entity ArgumentList {
     field args: List<Option<ArgumentValue>>; %% if none get default val in emitter
 }
 
-%*
-entity InvokeArgumentInfo {
-    field name: Identifier;
-    %% field rec: RecursiveAnnotation; %% TODO: Not supported
-    field args: ArgumentList;
-
-    %% Not quite sure if we type stuff thats in bsqir
-}
-*%
-
 entity IfStatement provides Statement {
     field cond: Expression;
     field trueBlock: BlockStatement;
@@ -148,6 +138,33 @@ BinLogicAndExpression { }
 | BinLogicImpliesExpression { }
 | BinLogicIFFExpression { }
 ;
+
+concept ConstructorExpression provides Expression {
+    field args: ArgumentList;
+}
+
+concept ConstructorPrimaryExpression provides ConstructorExpression {
+    field ctype: NominalTypeSignature;
+}
+
+entity ConstructorStdExpression provides ConstructorPrimaryExpression {
+}
+
+datatype PostfixOperation using {
+    field baseType: TypeSignature;
+}
+of
+PostfixAccessFromName {
+    field name: Identifier;
+    field declaredInType: NominalTypeSignature;
+    field ftype: TypeSignature;
+}
+;
+
+entity PostfixOp provides Expression {
+    field rootExp: Expression;
+    field ops: List<PostfixOperation>;
+}
 
 datatype BodyImplementation 
 of

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -148,6 +148,9 @@ concept ConstructorPrimaryExpression provides ConstructorExpression {
 }
 
 entity ConstructorStdExpression provides ConstructorPrimaryExpression {
+    %% I suspect we will want to move this to ConstructorPrimaryExpression or just more generally
+    %% ConstructorExpression...
+    field fullns: List<CString>;
 }
 
 datatype PostfixOperation using {

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -54,7 +54,6 @@ entity EntityTypeDecl provides AbstractEntityTypeDecl{
     field fields: List<MemberFieldDecl>;
 }
 
-
 entity ParameterDecl {
     field pname: Identifier;
     field ptype: TypeSignature;

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -29,7 +29,6 @@ concept AbstractDecl {
 }
 
 concept AbstractCoreDecl provides AbstractDecl {
-    %% bsqir has field 'attributes'. Not sure how these work.
     field name: Identifier;
 }
 
@@ -38,7 +37,6 @@ entity MemberFieldDecl provides AbstractCoreDecl {
     
     field declaredType: TypeSignature;
     field defaultval: Option<Expression>;
-    %% bsqir has 'isSpecialAccess` field. No clue what that means
 }
 
 concept AbstractNominalTypeDecl provides AbstractDecl {

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -2,16 +2,6 @@ declare namespace CPPAssembly;
 
 %% Most map well from Bosque/SMT emit
 
-entity SourceInfo {
-    field line: Nat;
-    field column: Nat;
-}
-
-concept AbstractDecl {
-    field declaredInNS: NamespaceKey;
-    field fullns: List<CString>;
-}
-
 const namespaceComponentRE: CRegex = /[A-Z][_a-zA-Z0-9]+/c;
 const namespaceKeyRE: CRegex = /(${CPPAssembly::namespaceComponentRE}'::')*${CPPAssembly::namespaceComponentRE}/c;
 type NamespaceComponentKey = CString of CPPAssembly::namespaceComponentRE;
@@ -33,12 +23,37 @@ const videntifierRE: CRegex = /'$'?[_a-z][_a-zA-Z0-9$]*/c; %%we allow & inside t
 type Identifier = CString of CPPAssembly::identifierRE;
 type VarIdentifier = CString of CPPAssembly::videntifierRE;
 
-%* 
-entity NamespaceConstDecl provides AbstractCoreDecl {
-    field declaredType: TypeSignature;
-    field value: Expression;
+concept AbstractDecl {
+    field declaredInNS: NamespaceKey;
+    field fullns: List<CString>;
 }
-*%
+
+concept AbstractCoreDecl provides AbstractDecl {
+    %% bsqir has field 'attributes'. Not sure how these work.
+    field name: Identifier;
+}
+
+entity MemberFieldDecl provides AbstractCoreDecl {
+    field declaredInType: NominalTypeSignature; %% What entity is this field in?
+    
+    field declaredType: TypeSignature;
+    field defaultval: Option<Expression>;
+    %% bsqir has 'isSpecialAccess` field. No clue what that means
+}
+
+concept AbstractNominalTypeDecl provides AbstractDecl {
+    field tkey: TypeKey;
+
+    %% invariants, validates, methods, saturated, as well
+}
+
+concept AbstractEntityTypeDecl provides AbstractNominalTypeDecl {
+}
+
+entity EntityTypeDecl provides AbstractEntityTypeDecl{
+    field fields: List<MemberFieldDecl>;
+}
+
 
 entity ParameterDecl {
     field pname: Identifier;
@@ -68,6 +83,7 @@ entity NamespaceDecl {
     %% Will need other stuff like nsconsts, enums, typedecls, etc...
 
     field subns: Map<CString, NamespaceDecl>;
+    field entities: Map<TypeKey, EntityTypeDecl>; %% Will have to do forward decls too
     field nsfuncs: Map<InvokeKey, NamespaceFunctionDecl>;
 }
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -314,22 +314,18 @@ function emitArgumentList(al: CPPAssembly::ArgumentList, func: CPPAssembly::Name
     return CString::joinAll(', ', resolveDefaultParams[recursive](emit_al, func));
 }
 
-recursive function findNamespaceFunctionDecl(decls: Map<CString, CPPAssembly::NamespaceDecl>, ikey: CPPAssembly::InvokeKey, fullns: List<CString>): CPPAssembly::NamespaceFunctionDecl {
+recursive function findNamespaceDecl(decls: Map<CString, CPPAssembly::NamespaceDecl>, fullns: List<CString>): CPPAssembly::NamespaceDecl {
     let ns_name = fullns.front();
     let remaining_ns_names = fullns.popFront().1;
 
     %% Found func we are looking for
     if(remaining_ns_names.empty() && decls.has(ns_name)) {
-        let cur_nsfuncs = decls.get(ns_name).nsfuncs;
-        if(!cur_nsfuncs.has(ikey)) {
-            abort; %% Func does not exist
-        }
-        return cur_nsfuncs.get(ikey);
+        return decls.get(ns_name);
     }
 
     if(decls.has(ns_name)) {
         let cur_nsdecl = decls.get(ns_name);
-        return findNamespaceFunctionDecl[recursive](cur_nsdecl.subns, ikey, remaining_ns_names);
+        return findNamespaceDecl[recursive](cur_nsdecl.subns, remaining_ns_names);
     }
     else {
         abort; %% Namespace does not exist
@@ -350,7 +346,7 @@ function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFuncti
         resolvedName = name;
     }
 
-    let func = findNamespaceFunctionDecl(ctx.nsdecls, e.ikey, e.fullns);
+    let func = findNamespaceDecl(ctx.nsdecls, e.fullns).nsfuncs.get(e.ikey); %% TODO: Check that this is safe
     let args = emitArgumentList(e.args, func, ctx);
 
     if(resolvedns !== '') {
@@ -377,9 +373,16 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
 %% most of this method is just copy pasted :(
 %%
 function emitConstructorStdExpression(e: CPPAssembly::ConstructorStdExpression, ctx: Context): CString {
-    let emitargs =  CString::joinAll(', ', e.args.args.map<CString>(fn(av) => {
+    let emitargs =  CString::joinAll(', ', e.args.args.mapIdx<CString>(fn(av, ii) => {
         if(av)@none {
-            abort; %% TODO: Default parameters not supported for entity connstructors yet!
+            let ns_entity = findNamespaceDecl(ctx.nsdecls, e.fullns).entities.get(e.ctype.tkeystr);
+            let member_defval = ns_entity.fields.get(ii).defaultval;
+            if(member_defval)@none {
+                abort; %% Default value detected in transform, yet none provided for emission
+            }
+            else {
+                return emitExpression[recursive]($member_defval, ctx);
+            }
         }
         else {
             let arg = $av;

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -265,9 +265,6 @@ recursive function emitLogicActionOrExpression(e: CPPAssembly::LogicActionOrExpr
     return CString::concat('(', CString::joinAll(' || ', args), ')');
 }
 
-%%
-%% Hmmm this will not allow us to emit args for constructors...
-%%
 function emitArgumentValue(av: Option<CPPAssembly::ArgumentValue>, i: Nat, func: CPPAssembly::NamespaceFunctionDecl, ctx: Context): CString {
     if(av)@none {
         let param = func.params.get(i).defaultval;
@@ -346,7 +343,7 @@ function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFuncti
         resolvedName = name;
     }
 
-    let func = findNamespaceDecl(ctx.nsdecls, e.fullns).nsfuncs.get(e.ikey); %% TODO: Check that this is safe
+    let func = findNamespaceDecl(ctx.nsdecls, e.fullns).nsfuncs.get(e.ikey);
     let args = emitArgumentList(e.args, func, ctx);
 
     if(resolvedns !== '') {
@@ -368,11 +365,8 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
     return CString::concat(rootExp, CString::joinAll(', ', ops));
 }
 
-%%
-%% TODO: Need to fix the emitArguments or whatever method so we dont have to duplicate loads of code,
-%% most of this method is just copy pasted :(
-%%
 function emitConstructorStdExpression(e: CPPAssembly::ConstructorStdExpression, ctx: Context): CString {
+    %% Eventually might want to rework emitArgumentList to support constructors too 
     let emitargs =  CString::joinAll(', ', e.args.args.mapIdx<CString>(fn(av, ii) => {
         if(av)@none {
             let ns_entity = findNamespaceDecl(ctx.nsdecls, e.fullns).entities.get(e.ctype.tkeystr);
@@ -570,7 +564,6 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     let entityfwd_decls = nsdecl.entities.reduce<CString>(funcfwd_decls, fn(acc, tk, e) => {
         return CString::concat(acc, emitEntityForwardDeclaration(e, ctx, full_indent));
     });
-
 
     %% All entities
     let entities = nsdecl.entities.reduce<CString>(entityfwd_decls, fn(acc, tk, e) => {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -266,6 +266,9 @@ recursive function emitLogicActionOrExpression(e: CPPAssembly::LogicActionOrExpr
     return CString::concat('(', CString::joinAll(' || ', args), ')');
 }
 
+%%
+%% Hmmm this will not allow us to emit args for constructors...
+%%
 function emitArgumentValue(av: Option<CPPAssembly::ArgumentValue>, i: Nat, func: CPPAssembly::NamespaceFunctionDecl, ctx: Context): CString {
     if(av)@none {
         let param = func.params.get(i).defaultval;
@@ -357,6 +360,27 @@ function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFuncti
     return CString::concat(resolvedName, '(', args, ')');
 }
 
+function emitPostfixOpImpl(op: CPPAssembly::PostfixOperation): CString {
+    %%if(op)@<CPPAssembly::PostfixAccessFromName> {
+        return CString::concat( '.', emitIdentifier(op@<CPPAssembly::PostfixAccessFromName>.name));
+    %%}
+
+%%    abort;
+}
+
+function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
+    let rootExp = emitExpression(pop.rootExp, ctx);
+    let ops = pop.ops.map<CString>(fn(op) => {
+        return emitPostfixOpImpl(op); 
+    });
+
+    return CString::concat(rootExp, CString::joinAll(', ', ops));
+}
+
+function emitConstructorStdExpression(e: CPPAssembly::ConstructorStdExpression, ctx: Context): CString {
+    return e.ctype.tkeystr.value;
+}
+
 function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
     match(e)@ {
         CPPAssembly::BinaryArithExpression => { return emitBinaryArithExpression[recursive]($e, ctx); }
@@ -368,6 +392,8 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
         | CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($e); }
         | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e); }
         | CPPAssembly::CallNamespaceFunctionExpression => { return emitCallNamespaceFunctionExpression($e, ctx); }
+        | CPPAssembly::PostfixOp => { return emitPostfixOp($e, ctx); }
+        | CPPAssembly::ConstructorStdExpression => { return emitConstructorStdExpression($e, ctx); }
         | _ => { abort; }
     }
 }
@@ -478,6 +504,20 @@ function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ctx
     return CString::concat(pre, params_impl, ' {%n;', emitBodyImplementation(func.body, nctx, indent), indent, '}%n;');
 }
 
+function emitMemberFieldDecl(member: CPPAssembly::MemberFieldDecl, indent: CString): CString {
+    let name = emitIdentifier(member.name);
+    let mtype = emitTypeSignature(member.declaredType);
+    return CString::concat(indent, mtype, ' ', name, ';%n;');
+}
+
+function emitEntityTypeDecl(e: CPPAssembly::EntityTypeDecl, tk: CString, indent: CString): CString {
+    let entries = e.fields.reduce<CString>(CString::concat(indent, 'class ', tk, '{%n;'), fn(acc, entry) => {
+        return CString::concat(acc, emitMemberFieldDecl(entry, CString::concat('    ', indent)));
+    });
+
+    return CString::concat(entries, indent, '}%n;');
+}
+
 recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: CString): CString {
     %% Emit namespace 
     let ns = CString::concat(indent, 'namespace ', nsdecl.nsname, ' {%n;');
@@ -488,12 +528,20 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
         return CString::concat(acc, emitNamespaceDecl[recursive](decl, ctx, full_indent));
     });
 
-    let fwd_decls = nsdecl.nsfuncs.reduce<CString>(subns, fn(acc, ikey, decl) => {
+    let entities = nsdecl.entities.reduce<CString>(subns, fn(acc, tk, e) => {
+        let typekey = tk.value;
+        let emit_entity = emitEntityTypeDecl(e, typekey, full_indent);
+
+        return CString::concat(acc, indent, emit_entity);
+    });
+
+    %% TODO: Fwd decls for entities
+    let fwd_decls = nsdecl.nsfuncs.reduce<CString>(entities, fn(acc, ikey, decl) => {
         return CString::concat(acc, emitFunctionForwardDeclaration(decl, full_indent));
     });
 
     %% Emit functions in current namespace
-    let funcs = nsdecl.nsfuncs.reduce<CString>(CString::concat(fwd_decls, '%n;'), fn(acc, key, func) => {
+    let funcs = nsdecl.nsfuncs.reduce<CString>(fwd_decls, fn(acc, key, func) => {
         return CString::concat(acc, emitNamespaceFunctionDecl(func, ctx, full_indent)); 
     });
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -556,17 +556,17 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     let ns = CString::concat(indent, 'namespace ', nsdecl.nsname, ' {%n;');
     let full_indent = CString::concat('    ', indent);
 
-    %% Emit our function and entity forward decls (all that is supported for now)
-    let funcfwd_decls = nsdecl.nsfuncs.reduce<CString>(ns, fn(acc, ikey, decl) => {
-        return CString::concat(acc, emitFunctionForwardDeclaration(decl, ctx, full_indent));
-    });
-
-    let entityfwd_decls = nsdecl.entities.reduce<CString>(funcfwd_decls, fn(acc, tk, e) => {
+    let entityfwd_decls = nsdecl.entities.reduce<CString>(ns, fn(acc, tk, e) => {
         return CString::concat(acc, emitEntityForwardDeclaration(e, ctx, full_indent));
     });
 
+    %% Emit our function and entity forward decls (all that is supported for now)
+    let funcfwd_decls = nsdecl.nsfuncs.reduce<CString>(entityfwd_decls, fn(acc, ikey, decl) => {
+        return CString::concat(acc, emitFunctionForwardDeclaration(decl, ctx, full_indent));
+    });
+
     %% All entities
-    let entities = nsdecl.entities.reduce<CString>(entityfwd_decls, fn(acc, tk, e) => {
+    let entities = nsdecl.entities.reduce<CString>(funcfwd_decls, fn(acc, tk, e) => {
         let typekey = tk.value;
         let emit_entity = emitEntityTypeDecl(e, typekey, ctx, full_indent);
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -61,8 +61,7 @@ function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): CString {
 %% Given a namespace key (like Main::Foo::Bar), remove all matching prefix strings
 %% giving resolved namespace for given scope
 %%
-function emitResolvedNamespace(fullns_list: List<CString>, fullns_key: CPPAssembly::NamespaceKey): CString {
-    let fullns: CString = emitNamespaceKey(fullns_key);
+function emitResolvedNamespace(fullns_list: List<CString>, fullns: CString): CString {
     return fullns_list.reduce<CString>(fullns, fn(acc, s) => {
         if(acc.startsWithString(s)) {
             let nopre = acc.removePrefixString(s);
@@ -338,7 +337,7 @@ recursive function findNamespaceFunctionDecl(decls: Map<CString, CPPAssembly::Na
 }
 
 function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFunctionExpression, ctx: Context): CString { 
-    let resolvedns = emitResolvedNamespace(ctx.fullns_list, e.ns); 
+    let resolvedns = emitResolvedNamespace(ctx.fullns_list, e.ns.value); 
 
     let ident = emitInvokeKey(e.ikey);
     let name = ident.removePrefixString(e.ns.value);
@@ -361,11 +360,7 @@ function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFuncti
 }
 
 function emitPostfixOpImpl(op: CPPAssembly::PostfixOperation): CString {
-    %%if(op)@<CPPAssembly::PostfixAccessFromName> {
-        return CString::concat( '.', emitIdentifier(op@<CPPAssembly::PostfixAccessFromName>.name));
-    %%}
-
-%%    abort;
+    return CString::concat( '.', emitIdentifier(op@<CPPAssembly::PostfixAccessFromName>.name));
 }
 
 function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
@@ -377,8 +372,28 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
     return CString::concat(rootExp, CString::joinAll(', ', ops));
 }
 
+%%
+%% TODO: Need to fix the emitArguments or whatever method so we dont have to duplicate loads of code,
+%% most of this method is just copy pasted :(
+%%
 function emitConstructorStdExpression(e: CPPAssembly::ConstructorStdExpression, ctx: Context): CString {
-    return e.ctype.tkeystr.value;
+    let emitargs =  CString::joinAll(', ', e.args.args.map<CString>(fn(av) => {
+        if(av)@none {
+            abort; %% TODO: Default parameters not supported for entity connstructors yet!
+        }
+        else {
+            let arg = $av;
+            let expr = emitExpression[recursive](arg.exp, ctx);
+            match(arg)@ {
+                CPPAssembly::NamedArgumentValue => { return expr; } 
+                | CPPAssembly::PositionalArgumentValue => { return expr; }
+                | _ => { abort; }
+            }
+        }
+    }));
+
+    let resolved_type = emitResolvedNamespace(ctx.fullns_list, e.ctype.tkeystr.value);
+    return CString::concat(resolved_type, '{ ', emitargs, ' }');
 }
 
 function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
@@ -480,23 +495,24 @@ function emitBodyImplementation(body: CPPAssembly::BodyImplementation, ctx: Cont
     }
 }
 
-function emitParameters(params: List<CPPAssembly::ParameterDecl>): CString {
+function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context): CString {
     let all_params = params.map<CString>(fn(param) => {
         let ptype = emitTypeSignature(param.ptype);
+        let resolved_ptype = emitResolvedNamespace(ctx.fullns_list, ptype);
         let pident = emitIdentifier(param.pname);
-        return CString::concat(ptype, ' ', pident);
+        return CString::concat(resolved_ptype, ' ', pident);
     });
 
     return CString::joinAll(', ', all_params);
 }
 
 function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ctx: Context, indent: CString): CString {
+    let nctx = ctx.updateCurrentNamespace(func.declaredInNS, func.fullns);
+
     let name = func.name;
     let nskey = emitNamespaceKey(func.declaredInNS);
-    let params = emitParameters(func.params);
+    let params = emitParameters(func.params, nctx);
     let rtype = emitTypeSignature(func.resultType); 
-
-    let nctx = ctx.updateCurrentNamespace(func.declaredInNS, func.fullns);
 
     let pre: CString = CString::concat(indent, rtype, ' ', name );
     let params_impl: CString = CString::concat('(', params, ')');
@@ -504,18 +520,38 @@ function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ctx
     return CString::concat(pre, params_impl, ' {%n;', emitBodyImplementation(func.body, nctx, indent), indent, '}%n;');
 }
 
-function emitMemberFieldDecl(member: CPPAssembly::MemberFieldDecl, indent: CString): CString {
+function emitMemberFieldDecl(member: CPPAssembly::MemberFieldDecl, ctx: Context, indent: CString): CString {
     let name = emitIdentifier(member.name);
     let mtype = emitTypeSignature(member.declaredType);
     return CString::concat(indent, mtype, ' ', name, ';%n;');
 }
 
-function emitEntityTypeDecl(e: CPPAssembly::EntityTypeDecl, tk: CString, indent: CString): CString {
-    let entries = e.fields.reduce<CString>(CString::concat(indent, 'class ', tk, '{%n;'), fn(acc, entry) => {
-        return CString::concat(acc, emitMemberFieldDecl(entry, CString::concat('    ', indent)));
+function emitEntityTypeDecl(e: CPPAssembly::EntityTypeDecl, tk: CString, ctx: Context, indent: CString): CString {
+    let nctx = ctx.updateCurrentNamespace(e.declaredInNS, e.fullns);
+    
+    let resolved_tk = emitResolvedNamespace(nctx.fullns_list, tk);
+    let entries = e.fields.reduce<CString>(CString::concat(indent, 'class ', resolved_tk, '{ %n;', indent, 'public:%n;'), 
+    fn(acc, entry) => {
+        return CString::concat(acc, emitMemberFieldDecl(entry, nctx, CString::concat('    ', indent)));
     });
 
-    return CString::concat(entries, indent, '}%n;');
+    return CString::concat(entries, indent, '};%n;');
+}
+
+function emitEntityForwardDeclaration(e: CPPAssembly::EntityTypeDecl, ctx: Context, indent: CString): CString {
+    let nctx = ctx.updateCurrentNamespace(e.declaredInNS, e.fullns);
+    return CString::concat(indent, 'class ', emitResolvedNamespace(nctx.fullns_list, e.tkey.value), ';%n;');
+}
+
+%% I suspect we will need separate cases for entities, types, enums and such
+function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl, ctx: Context, ident: CString): CString {
+    let nctx = ctx.updateCurrentNamespace(decl.declaredInNS, decl.fullns);
+
+    let pre = decl.name;
+    let rtype = emitTypeSignature(decl.resultType); 
+    let params = emitParameters(decl.params, nctx);
+    let first = CString::concat(ident, rtype, ' ', pre );
+    return CString::concat(first, '(', params, ');%n;');
 }
 
 recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: CString): CString {
@@ -523,38 +559,35 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     let ns = CString::concat(indent, 'namespace ', nsdecl.nsname, ' {%n;');
     let full_indent = CString::concat('    ', indent);
 
-    %% Emit sub-namespace declarations
-    let subns = nsdecl.subns.reduce<CString>(ns, fn(acc, name, decl) => {
-        return CString::concat(acc, emitNamespaceDecl[recursive](decl, ctx, full_indent));
+    %% Emit our function and entity forward decls (all that is supported for now)
+    let funcfwd_decls = nsdecl.nsfuncs.reduce<CString>(ns, fn(acc, ikey, decl) => {
+        return CString::concat(acc, emitFunctionForwardDeclaration(decl, ctx, full_indent));
     });
 
-    let entities = nsdecl.entities.reduce<CString>(subns, fn(acc, tk, e) => {
+    let entityfwd_decls = nsdecl.entities.reduce<CString>(funcfwd_decls, fn(acc, tk, e) => {
+        return CString::concat(acc, emitEntityForwardDeclaration(e, ctx, full_indent));
+    });
+
+
+    %% All entities
+    let entities = nsdecl.entities.reduce<CString>(entityfwd_decls, fn(acc, tk, e) => {
         let typekey = tk.value;
-        let emit_entity = emitEntityTypeDecl(e, typekey, full_indent);
+        let emit_entity = emitEntityTypeDecl(e, typekey, ctx, full_indent);
 
         return CString::concat(acc, indent, emit_entity);
     });
 
-    %% TODO: Fwd decls for entities
-    let fwd_decls = nsdecl.nsfuncs.reduce<CString>(entities, fn(acc, ikey, decl) => {
-        return CString::concat(acc, emitFunctionForwardDeclaration(decl, full_indent));
+    %% Emit sub-namespace declarations
+    let subns = nsdecl.subns.reduce<CString>(entities, fn(acc, name, decl) => {
+        return CString::concat(acc, emitNamespaceDecl[recursive](decl, ctx, full_indent));
     });
 
     %% Emit functions in current namespace
-    let funcs = nsdecl.nsfuncs.reduce<CString>(fwd_decls, fn(acc, key, func) => {
+    let funcs = nsdecl.nsfuncs.reduce<CString>(subns, fn(acc, key, func) => {
         return CString::concat(acc, emitNamespaceFunctionDecl(func, ctx, full_indent)); 
     });
 
     return CString::concat(funcs, indent, '}%n;');
-}
-
-%% I suspect we will need separate cases for entities, types, enums and such
-function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl, ident: CString): CString {
-    let pre = decl.name;
-    let rtype = emitTypeSignature(decl.resultType); 
-    let params = emitParameters(decl.params);
-    let first = CString::concat(ident, rtype, ' ', pre );
-    return CString::concat(first, '(', params, ');%n;');
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -37,8 +37,10 @@ entity Context {
     }
 }
 
-function emitTypeSignature(ts: CPPAssembly::TypeSignature): CString {
-    return ts.tkeystr.value;
+function emitTypeSignature(ts: CPPAssembly::TypeSignature, ctx: Context): CString {
+    let resolved_typesig = emitResolvedNamespace(ctx.fullns_list, ts.tkeystr.value);
+    
+    return resolved_typesig;
 }
 
 function emitIdentifier(ident: CPPAssembly::Identifier): CString {
@@ -412,7 +414,7 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
 
 function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitializationStatement, ctx: Context, indent: CString): CString {
     let name = emitIdentifier(stmt.name);
-    let stype = emitTypeSignature(stmt.vtype);
+    let stype = emitTypeSignature(stmt.vtype, ctx);
     let exp = emitExpression(stmt.exp, ctx);
 
     let full_indent: CString = CString::concat(indent, '    ', stype); %% List constructor size max 6
@@ -494,7 +496,7 @@ function emitBodyImplementation(body: CPPAssembly::BodyImplementation, ctx: Cont
 
 function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context): CString {
     let all_params = params.map<CString>(fn(param) => {
-        let ptype = emitTypeSignature(param.ptype);
+        let ptype = emitTypeSignature(param.ptype, ctx);
         let resolved_ptype = emitResolvedNamespace(ctx.fullns_list, ptype);
         let pident = emitIdentifier(param.pname);
         return CString::concat(resolved_ptype, ' ', pident);
@@ -509,25 +511,25 @@ function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ctx
     let name = func.name;
     let nskey = emitNamespaceKey(func.declaredInNS);
     let params = emitParameters(func.params, nctx);
-    let rtype = emitTypeSignature(func.resultType); 
+    let rtype = emitTypeSignature(func.resultType, ctx); 
 
     let pre: CString = CString::concat(indent, rtype, ' ', name );
-    let params_impl: CString = CString::concat('(', params, ')');
+    let params_impl: CString = CString::concat('(', params, ') noexcept ');
 
     return CString::concat(pre, params_impl, ' {%n;', emitBodyImplementation(func.body, nctx, indent), indent, '}%n;');
 }
 
 function emitMemberFieldDecl(member: CPPAssembly::MemberFieldDecl, ctx: Context, indent: CString): CString {
     let name = emitIdentifier(member.name);
-    let mtype = emitTypeSignature(member.declaredType);
-    return CString::concat(indent, mtype, ' ', name, ';%n;');
+    let mtype = emitTypeSignature(member.declaredType, ctx);
+    return CString::concat(indent, 'const ',mtype, ' ', name, ';%n;');
 }
 
 function emitEntityTypeDecl(e: CPPAssembly::EntityTypeDecl, tk: CString, ctx: Context, indent: CString): CString {
     let nctx = ctx.updateCurrentNamespace(e.declaredInNS, e.fullns);
     
     let resolved_tk = emitResolvedNamespace(nctx.fullns_list, tk);
-    let entries = e.fields.reduce<CString>(CString::concat(indent, 'class ', resolved_tk, '{ %n;', indent, 'public:%n;'), 
+    let entries = e.fields.reduce<CString>(CString::concat(indent, 'struct ', resolved_tk, '{ %n;'), 
     fn(acc, entry) => {
         return CString::concat(acc, emitMemberFieldDecl(entry, nctx, CString::concat('    ', indent)));
     });
@@ -537,7 +539,7 @@ function emitEntityTypeDecl(e: CPPAssembly::EntityTypeDecl, tk: CString, ctx: Co
 
 function emitEntityForwardDeclaration(e: CPPAssembly::EntityTypeDecl, ctx: Context, indent: CString): CString {
     let nctx = ctx.updateCurrentNamespace(e.declaredInNS, e.fullns);
-    return CString::concat(indent, 'class ', emitResolvedNamespace(nctx.fullns_list, e.tkey.value), ';%n;');
+    return CString::concat(indent, 'struct ', emitResolvedNamespace(nctx.fullns_list, e.tkey.value), ';%n;');
 }
 
 %% I suspect we will need separate cases for entities, types, enums and such
@@ -545,10 +547,10 @@ function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl
     let nctx = ctx.updateCurrentNamespace(decl.declaredInNS, decl.fullns);
 
     let pre = decl.name;
-    let rtype = emitTypeSignature(decl.resultType); 
+    let rtype = emitTypeSignature(decl.resultType, ctx); 
     let params = emitParameters(decl.params, nctx);
     let first = CString::concat(ident, rtype, ' ', pre );
-    return CString::concat(first, '(', params, ');%n;');
+    return CString::concat(first, '(', params, ') noexcept;%n;');
 }
 
 recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: CString): CString {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -10,6 +10,10 @@ namespace CPPTransformNameManager {
         return CPPAssembly::InvokeKey::from(ikey.value);
     }
 
+    function convertTypeKey(tk: BSQAssembly::TypeKey): CPPAssembly::TypeKey {
+        return CPPAssembly::TypeKey::from(tk.value);
+    }
+
     function convertTypeSignature(tsig: BSQAssembly::TypeSignature): CPPAssembly::TypeSignature {
         let tk = CPPAssembly::TypeKey::from(tsig.tkeystr.value);
 
@@ -21,7 +25,7 @@ namespace CPPTransformNameManager {
             | 'BigNat' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::BigNat') }; }
             | 'Float' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::Float') }; }
             | 'Bool' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('bool') }; }
-            | _ => { abort; }
+            | _ => { return CPPAssembly::NominalTypeSignature{ tk }; }
         }
     }
 
@@ -36,7 +40,8 @@ namespace CPPTransformNameManager {
     function createNamespaceDecl(name: CString): CPPAssembly::NamespaceDecl {
         let subns = Map<CString, CPPAssembly::NamespaceDecl>{};
         let nsfuncs = Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>{};
-        return CPPAssembly::NamespaceDecl{ name, subns, nsfuncs };
+        let entities = Map<CPPAssembly::TypeKey, CPPAssembly::EntityTypeDecl>{};
+        return CPPAssembly::NamespaceDecl{ name, subns, entities, nsfuncs };
     }
 
     recursive function getNamespaceDeclMapping(fullns: List<CString>, nsdecls: Map<CString, CPPAssembly::NamespaceDecl>, func_key: CPPAssembly::InvokeKey, func_val: CPPAssembly::NamespaceFunctionDecl): Map<CString, CPPAssembly::NamespaceDecl> {
@@ -66,7 +71,7 @@ namespace CPPTransformNameManager {
 
         %% Recursively process remaining names
         let subns = getNamespaceDeclMapping[recursive](remaining_ns_names, cur_nsdecl.subns, func_key, func_val);
-        let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, subns, func };
+        let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, subns, cur_nsdecl.entities, func }; %% Need to be cautious here
 
         %% We need to always update the nsdecls map as sub namespaces may change (this handles multiple nsdecls at same depth)
         if(!nsdecls.has(ns_name)) {
@@ -75,6 +80,34 @@ namespace CPPTransformNameManager {
         else {
             let tmp_map = nsdecls.delete(ns_name);
             return tmp_map.insert(ns_name, updated_nsdecl);
+        }
+    }
+
+    %%
+    %% We will need to be able to handle a namespace with no func, only entities. This is possible adn valid code.
+    %% This likely means we do something similar to getNamespaceDeclMappign (prehaps make a bse method that recurses
+    %% until entityns is emtpty and generates necessary NamespaceDecl when needed as we recurse, then returns last mapping)
+    %%
+    recursive function insertEntityDecl(ens: List<CString>, nsdecls: Map<CString, CPPAssembly::NamespaceDecl>, e: CPPAssembly::EntityTypeDecl, etk: CPPAssembly::TypeKey): Map<CString, CPPAssembly::NamespaceDecl> {
+        if(ens.empty()) {
+            return nsdecls;
+        }
+
+        let ns_name = ens.front();
+        let remaining_ns_names = ens.popFront().1;
+
+        if(remaining_ns_names.empty()) {
+            %% This feels incredibly clunky
+            let tmp_entities = nsdecls.get(ns_name).entities.insert(etk, e);
+            let tmp_subns = nsdecls.get(ns_name).subns;
+            let tmp_funcs = nsdecls.get(ns_name).nsfuncs;
+            let tmp_map = nsdecls.delete(ns_name);
+            let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, tmp_subns, tmp_entities, tmp_funcs };
+
+            return tmp_map.insert(ns_name, updated_nsdecl);
+        }
+        else {
+            return insertEntityDecl[recursive](remaining_ns_names, nsdecls.get(ns_name).subns, e, etk);
         }
     }
 }
@@ -364,6 +397,33 @@ entity CPPTransformer {
         return CPPAssembly::NamespaceFunctionDecl{nskey, fullns, name, ikey, params, res, body};
     }   
 
+    method transformMemberFieldDecl(fields: List<BSQAssembly::MemberFieldDecl>): List<CPPAssembly::MemberFieldDecl> {
+        return fields.map<CPPAssembly::MemberFieldDecl>(fn(f) => {
+            let declaredInNS = CPPTransformNameManager::convertNamespaceKey(f.declaredInNS);
+            let name = CPPTransformNameManager::convertIdentifier(f.name);
+            let declaredInType = CPPAssembly::NominalTypeSignature{ CPPTransformNameManager::convertTypeKey(f.declaredInType.tkeystr) };
+            let declaredType = CPPTransformNameManager::convertTypeSignature(f.declaredType);
+            let defv = f.defaultValue;
+            var defaultval: Option<CPPAssembly::Expression>;
+            if(defv)@none { %% Maybe add this converstion of default val to the name manager
+                defaultval = none;
+            }
+            else {
+                defaultval = some(this.transformExpressionToCpp($defv));
+            }
+            return CPPAssembly::MemberFieldDecl{ declaredInNS, f.fullns, name, declaredInType, declaredType, defaultval };
+        });
+    }
+
+    method transformEntityDeclToCpp(e: BSQAssembly::EntityTypeDecl): CPPAssembly::EntityTypeDecl {
+        let declaredInNS = CPPTransformNameManager::convertNamespaceKey(e.declaredInNS);
+        let tkey = CPPTransformNameManager::convertTypeKey(e.tkey);
+        
+        let fields = this.transformMemberFieldDecl(e.fields);
+
+        return CPPAssembly::EntityTypeDecl{ declaredInNS, e.fullns, tkey, fields };
+    }
+
     %*
     method transformNamespaceConstDecl(decl: BSQAssembly::NamespaceConstDecl): CPPAssembly::NamespaceConstDecl {
         abort;
@@ -381,8 +441,14 @@ entity CPPTransformer {
                     let bsqdecl = bsqasm.nsfuncs.get(ikey);
                     let cppdecl = transformer.transformNamespaceFunctionDeclToCpp(bsqdecl);
                     return CPPTransformNameManager::getNamespaceDeclMapping(bsqdecl.fullns, acc, cppdecl.ikey, cppdecl);
-                }
-            );
+        });
+
+        let nsdecls_entities = bsqasm.entities.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
+            transformer_nsdecls, fn(acc, tk, e) => {
+                let key = CPPTransformNameManager::convertTypeKey(tk);
+                let cppentity = transformer.transformEntityDeclToCpp(e);
+                return CPPTransformNameManager::insertEntityDecl(cppentity.fullns, acc, cppentity, key);
+        });
 
         let transformer_allfuncs = bsqasm.allfuncs.map<CPPAssembly::FunctionDecl>(fn(ikey) => {
             let cppikey = CPPTransformNameManager::convertInvokeKey(ikey);
@@ -397,7 +463,7 @@ entity CPPTransformer {
         });
 
         return CPPAssembly::Assembly {
-            nsdecls = transformer_nsdecls,
+            nsdecls = nsdecls_entities,
             allfuncs = transformer_allfuncs
         };
     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -327,7 +327,7 @@ entity CPPTransformer {
         let ctype = CPPAssembly::NominalTypeSignature{ CPPTransformNameManager::convertTypeKey(e.ctype.tkeystr) };
         let etype = CPPTransformNameManager::convertTypeSignature(e.etype);
 
-        return CPPAssembly::ConstructorStdExpression{ etype, CPPAssembly::ArgumentList{ args }, ctype };
+        return CPPAssembly::ConstructorStdExpression{ etype, CPPAssembly::ArgumentList{ args }, ctype, e.fullns };
     } 
 
     recursive method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -245,8 +245,6 @@ entity CPPTransformer {
         let baseType = CPPTransformNameManager::convertTypeSignature(op.baseType);
         if(op)@ <BSQAssembly::PostfixAccessFromName> {
             let name = CPPTransformNameManager::convertIdentifier($op.name);
-
-            %% I really should add this nominal type sign conversion to the transform name manager...
             let declaredInType = CPPAssembly::NominalTypeSignature{ CPPTransformNameManager::convertTypeKey($op.declaredInType.tkeystr) };
             let ftype = CPPTransformNameManager::convertTypeSignature($op.ftype);
 
@@ -267,10 +265,7 @@ entity CPPTransformer {
     }
 
     method transformConstructorStdExpression(e: BSQAssembly::ConstructorStdExpression): CPPAssembly::ConstructorStdExpression {
-        %%
-        %% This is quite silly as its legit the same code from transformArgumentInfo, so we will need to 
-        %% do some hacking with transformArg.. to get the constructor tomatch what we got here.
-        %%
+        %% Would be good to have transformArgumentInfo eventually be able to handle different format shuffleinfo
         let args = e.shuffleinfo.mapIdx<Option<CPPAssembly::ArgumentValue>>(fn(she, ii) => {
             var cur_arg: CPPAssembly::ArgumentValue;
             if(ii >= e.args.args.size()) {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -246,7 +246,7 @@ entity CPPTransformer {
         }
     }
 
-    method transformArgumentList(bsqargs: BSQAssembly::InvokeArgumentInfo): CPPAssembly::ArgumentList {
+    method transformArgumentInfo(bsqargs: BSQAssembly::InvokeArgumentInfo): CPPAssembly::ArgumentList {
         let shuffled = bsqargs.shuffleinfo.mapIdx<Option<CPPAssembly::ArgumentValue>>(fn(e, ii) => {
             var cur_arg: CPPAssembly::ArgumentValue;
             if(ii >= bsqargs.args.args.size()) {
@@ -271,11 +271,64 @@ entity CPPTransformer {
         let ts = CPPTransformNameManager::convertTypeSignature(expr.etype);
         let ikey = CPPTransformNameManager::convertInvokeKey(expr.ikey);
         let ns = CPPTransformNameManager::convertNamespaceKey(expr.ns);
-        let args = this.transformArgumentList(expr.argsinfo);
+        let args = this.transformArgumentInfo(expr.argsinfo);
         let fullns = expr.fullns; %% For looking up func we are calling
 
         return CPPAssembly::CallNamespaceFunctionExpression{ ts, ikey, ns, fullns, args };
     }
+
+    method transformPostfixOpImpl(op: BSQAssembly::PostfixOperation): CPPAssembly::PostfixOperation {
+        let baseType = CPPTransformNameManager::convertTypeSignature(op.baseType);
+        if(op)@ <BSQAssembly::PostfixAccessFromName> {
+            let name = CPPTransformNameManager::convertIdentifier($op.name);
+
+            %% I really should add this nominal type sign conversion to the transform name manager...
+            let declaredInType = CPPAssembly::NominalTypeSignature{ CPPTransformNameManager::convertTypeKey($op.declaredInType.tkeystr) };
+            let ftype = CPPTransformNameManager::convertTypeSignature($op.ftype);
+
+            return CPPAssembly::PostfixAccessFromName{ baseType, name, declaredInType, ftype };
+        }
+
+        abort;
+    }
+
+    method transformPostfixOp(pop: BSQAssembly::PostfixOp): CPPAssembly::PostfixOp {
+        let etype = CPPTransformNameManager::convertTypeSignature(pop.etype);
+        let rootExp = this.transformExpressionToCpp(pop.rootExp);
+        let ops = pop.ops.map<CPPAssembly::PostfixOperation>(fn(op) => {
+            return this.transformPostfixOpImpl(op);
+        });
+
+        return CPPAssembly::PostfixOp{ etype, rootExp, ops };
+    }
+
+    method transformConstructorStdExpression(e: BSQAssembly::ConstructorStdExpression): CPPAssembly::ConstructorStdExpression {
+        %%
+        %% This is quite silly as its legit the same code from transformArgumentInfo, so we will need to 
+        %% do some hacking with transformArg.. to get the constructor tomatch what we got here.
+        %%
+        let args = e.shuffleinfo.mapIdx<Option<CPPAssembly::ArgumentValue>>(fn(she, ii) => {
+            var cur_arg: CPPAssembly::ArgumentValue;
+            if(ii >= e.args.args.size()) {
+                return none;
+            }
+            else { %% Resolve shuffle value
+                let shuffle_idx = she.0;
+                if(shuffle_idx)@none {
+                    let arg = e.args.args.get(ii);
+                    return some(this.transformArgument(arg));
+                }
+                else {
+                    let arg = e.args.args.get($shuffle_idx);
+                    return some(this.transformArgument(arg));
+                }
+            }
+         });
+        let ctype = CPPAssembly::NominalTypeSignature{ CPPTransformNameManager::convertTypeKey(e.ctype.tkeystr) };
+        let etype = CPPTransformNameManager::convertTypeSignature(e.etype);
+
+        return CPPAssembly::ConstructorStdExpression{ etype, CPPAssembly::ArgumentList{ args }, ctype };
+    } 
 
     recursive method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
         match(expr)@ {
@@ -287,7 +340,9 @@ entity CPPTransformer {
             | BSQAssembly::LogicActionAndExpression => { return this.transformLogicActionAndExpression[recursive]($expr); }
             | BSQAssembly::LogicActionOrExpression => { return this.transformLogicActionOrExpression[recursive]($expr); }
             | BSQAssembly::AccessVariableExpression => { return this.transformAccessVariableExpression($expr); }
-            | BSQAssembly::CallNamespaceFunctionExpression => { return this.transformCallNamespaceFunctionExpression($expr); }
+            | BSQAssembly::CallNamespaceFunctionExpression => { return this.transformCallNamespaceFunctionExpression($expr); } 
+            | BSQAssembly::PostfixOp => { return this.transformPostfixOp($expr); }
+            | BSQAssembly::ConstructorStdExpression => { return this.transformConstructorStdExpression($expr); }
             | _ => { abort; }
         }
     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -44,7 +44,8 @@ namespace CPPTransformNameManager {
         return CPPAssembly::NamespaceDecl{ name, subns, entities, nsfuncs };
     }
 
-    recursive function getNamespaceDeclMapping(fullns: List<CString>, nsdecls: Map<CString, CPPAssembly::NamespaceDecl>, func_key: CPPAssembly::InvokeKey, func_val: CPPAssembly::NamespaceFunctionDecl): Map<CString, CPPAssembly::NamespaceDecl> {
+    %% If ns decl does not exist for name insert, otherwise continue recursing until fullns is empty
+    recursive function getNamespaceDeclMapping(fullns: List<CString>, nsdecls: Map<CString, CPPAssembly::NamespaceDecl>, insertion: fn(CPPAssembly::NamespaceDecl) -> CPPAssembly::NamespaceDecl): Map<CString, CPPAssembly::NamespaceDecl> {
         if(fullns.empty()) { %% Base case, we have recursed through all subdecls
             return nsdecls;
         }
@@ -60,54 +61,17 @@ namespace CPPTransformNameManager {
             cur_nsdecl = createNamespaceDecl(ns_name);
         }
 
-        %% See if we can insert our namespace function decl
-        var func: Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>;
-        if(remaining_ns_names.empty()) {
-            func = cur_nsdecl.nsfuncs.insert(func_key, func_val);
-        }
-        else{
-            func = cur_nsdecl.nsfuncs;
-        }
-
         %% Recursively process remaining names
-        let subns = getNamespaceDeclMapping[recursive](remaining_ns_names, cur_nsdecl.subns, func_key, func_val);
-        let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, subns, cur_nsdecl.entities, func }; %% Need to be cautious here
+        let subns = getNamespaceDeclMapping[recursive](remaining_ns_names, cur_nsdecl.subns, insertion);
+        let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, subns, cur_nsdecl.entities, cur_nsdecl.nsfuncs };
 
         %% We need to always update the nsdecls map as sub namespaces may change (this handles multiple nsdecls at same depth)
         if(!nsdecls.has(ns_name)) {
-            return nsdecls.insert(ns_name, updated_nsdecl);
+            return nsdecls.insert(ns_name, insertion(updated_nsdecl));
         }
         else {
             let tmp_map = nsdecls.delete(ns_name);
-            return tmp_map.insert(ns_name, updated_nsdecl);
-        }
-    }
-
-    %%
-    %% We will need to be able to handle a namespace with no func, only entities. This is possible adn valid code.
-    %% This likely means we do something similar to getNamespaceDeclMappign (prehaps make a bse method that recurses
-    %% until entityns is emtpty and generates necessary NamespaceDecl when needed as we recurse, then returns last mapping)
-    %%
-    recursive function insertEntityDecl(ens: List<CString>, nsdecls: Map<CString, CPPAssembly::NamespaceDecl>, e: CPPAssembly::EntityTypeDecl, etk: CPPAssembly::TypeKey): Map<CString, CPPAssembly::NamespaceDecl> {
-        if(ens.empty()) {
-            return nsdecls;
-        }
-
-        let ns_name = ens.front();
-        let remaining_ns_names = ens.popFront().1;
-
-        if(remaining_ns_names.empty()) {
-            %% This feels incredibly clunky
-            let tmp_entities = nsdecls.get(ns_name).entities.insert(etk, e);
-            let tmp_subns = nsdecls.get(ns_name).subns;
-            let tmp_funcs = nsdecls.get(ns_name).nsfuncs;
-            let tmp_map = nsdecls.delete(ns_name);
-            let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, tmp_subns, tmp_entities, tmp_funcs };
-
-            return tmp_map.insert(ns_name, updated_nsdecl);
-        }
-        else {
-            return insertEntityDecl[recursive](remaining_ns_names, nsdecls.get(ns_name).subns, e, etk);
+            return tmp_map.insert(ns_name, insertion(updated_nsdecl));
         }
     }
 }
@@ -495,14 +459,22 @@ entity CPPTransformer {
                 fn(acc, ikey) => {
                     let bsqdecl = bsqasm.nsfuncs.get(ikey);
                     let cppdecl = transformer.transformNamespaceFunctionDeclToCpp(bsqdecl);
-                    return CPPTransformNameManager::getNamespaceDeclMapping(bsqdecl.fullns, acc, cppdecl.ikey, cppdecl);
+                    return CPPTransformNameManager::getNamespaceDeclMapping(bsqdecl.fullns, acc,
+                        fn(decl) => { 
+                            let new_nsfuncs = decl.nsfuncs.insert(cppdecl.ikey, cppdecl);
+                            return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.entities, new_nsfuncs };
+                        });
         });
 
         let nsdecls_entities = bsqasm.entities.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
             transformer_nsdecls, fn(acc, tk, e) => {
                 let key = CPPTransformNameManager::convertTypeKey(tk);
                 let cppentity = transformer.transformEntityDeclToCpp(e);
-                return CPPTransformNameManager::insertEntityDecl(cppentity.fullns, acc, cppentity, key);
+                return CPPTransformNameManager::getNamespaceDeclMapping(cppentity.fullns, acc,
+                    fn(decl) => {
+                        let new_entities = decl.entities.insert(key, cppentity);
+                        return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, new_entities, decl.nsfuncs };
+                    });
         });
 
         let transformer_allfuncs = bsqasm.allfuncs.map<CPPAssembly::FunctionDecl>(fn(ikey) => {

--- a/src/bsqir/asm/body.bsq
+++ b/src/bsqir/asm/body.bsq
@@ -155,6 +155,7 @@ entity ConstructorTypeDeclStringExpression provides ConstructorPrimaryExpression
 
 entity ConstructorStdExpression provides ConstructorPrimaryExpression { 
     field shuffleinfo: List<(|Option<Nat>, Identifier, TypeSignature|)>;
+    field fullns: List<CString>;
     field invchecks: Bool;
 }
 

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -413,8 +413,16 @@ class BSQIREmitter {
             const iidx = si[0] !== -1 ? `some(${si[0]}n)` : "none";
             return `(|${iidx}, '${si[1]}'<BSQAssembly::Identifier>, ${this.emitTypeSignature(si[2])}|)`;
         });
+
+         // ConstructorStdExpression provides Expression (not AbstractDecl), so we need to emit fullns explicitly
+        let cstrns = exp.ctype.tkeystr.split('::').map(e => `'${e}'`);
         
-        return `BSQAssembly::ConstructorStdExpression{ ${cpee}, shuffleinfo=List<(|Option<Nat>, BSQAssembly::Identifier, BSQAssembly::TypeSignature|)>{${shuffleinfo}}, invchecks=${invchecks} }`;
+        // Last element is entity name, we cannot properly look this up as fullns is for resolving namespaces
+        if(cstrns.length >= 1) {
+            cstrns.pop();
+        }
+        const fmt_cstrns = `fullns = List<CString>{${cstrns.join(', ')}}`;
+        return `BSQAssembly::ConstructorStdExpression{ ${cpee}, shuffleinfo=List<(|Option<Nat>, BSQAssembly::Identifier, BSQAssembly::TypeSignature|)>{${shuffleinfo}}, ${fmt_cstrns}, invchecks=${invchecks} }`;
     }
 
     private emitConstructorPrimaryExpression(exp: ConstructorPrimaryExpression): string {

--- a/test/cppoutput/cons_exps/cons_entity.test.js
+++ b/test/cppoutput/cons_exps/cons_entity.test.js
@@ -1,0 +1,41 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate -- Entity Constructor", () => {
+    it("should exec positional", function () {
+        runMainCode('entity Foo { field f: Int; } public function main(): Int { return Foo{1i}.f; }', "1_i");
+        runMainCode('entity Foo { field f: Int; field g: Bool; } public function main(): Bool { return Foo{1i, false}.g; }', "false");
+    });
+
+    it("should exec nominal", function () {
+        runMainCode('entity Foo { field f: Int; } public function main(): Int { return Foo{f = 1i}.f; }', "1_i");
+        runMainCode('entity Foo { field f: Int; field g: Bool; } public function main(): Bool { return Foo{1i, g = true}.g; }', "true");
+        runMainCode('entity Foo { field f: Int; field g: Bool; } public function main(): Bool { return Foo{f=1i, g = true}.g; }', "true");
+    });
+
+    it("should exec default", function () {
+        runMainCode('entity Foo { field f: Int = 0i; } public function main(): Int { return Foo{}.f; }', "0_i");
+        runMainCode('entity Foo { field f: Int = 0i; } public function main(): Int { return Foo{5i}.f; }', "5_i");
+    });
+});
+
+/*
+describe ("Exec -- Entity w/ Invariant Constructor", () => {
+    it("should exec positional", function () {
+        runMainCode('entity Foo { field f: Int; invariant $f > 3i; } public function main(): Int { return Foo{4i}.f; }', "4i");
+        runMainCode('entity Foo { field f: Int; field g: Bool; invariant $g ==> $f > 3i; } public function main(): Bool { return Foo{1i, false}.g; }', "false");
+
+        runMainCode('entity Foo { field f: Int; field g: Bool; invariant !$g; invariant $f != 0i; } public function main(): Bool { return Foo{1i, false}.g; }', "false");
+    });
+
+    it("should fail inv", function () {
+        runMainCodeError("entity Foo { field f: Int; field g: Bool; invariant $g ==> $f > 3i; } public function main(): Bool { return Foo{1i, true}.g; }", "Error -- failed invariant @ test.bsq:3");
+    });
+
+    it("should exec default", function () {
+        runMainCode('entity Foo { field f: Int = 0i; invariant $f != 3i; } public function main(): Int { return Foo{5i}.f; }', "5i");
+    });
+});
+*/


### PR DESCRIPTION
We are now able to emit cpp code for simple entities with primitive fields. Constructor w/ default or named parameters and basic field access is supported. They do not emit any type information quite yet (or any methods, although these will be emitted as functions).

Some Bosque code like so:
```
declare namespace Main;

entity Bar {
    field x: Int;
    field y: Int;
    field z: Int;
}

namespace Foo {
    function foo(e: Bar): Int {
        return e.x + e.y + e.z;
    }
}

public function main(): Int {
    return Foo::foo( Bar{ 1i, 2i, 3i } );
}
```
Emits:
```
namespace Main {
    class Bar;
    __CoreCpp::Int foo(Bar e);
    __CoreCpp::Int main();
    class Bar{ 
    public:
        __CoreCpp::Int x;
        __CoreCpp::Int y;
        __CoreCpp::Int z;
    };
    namespace Foo {
        __CoreCpp::Int foo(Bar e);
        __CoreCpp::Int foo(Bar e) {
            return ((e.x + e.y) + e.z);
        }
    }
    __CoreCpp::Int foo(Bar e) {
        return ((e.x + e.y) + e.z);
    }
    __CoreCpp::Int main() {
        return Foo::foo(Bar{ 1_i, 2_i, 3_i });
    }
}

```