### PR TITLE
Cpp Emit Static Methods & TypeInfo

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -160,7 +160,7 @@ PostfixAccessFromName {
     field declaredInType: NominalTypeSignature;
     field ftype: TypeSignature;
 }
-| PostfixInvokeStatic { %% May only need args here...?
+| PostfixInvokeStatic { 
     field resolvedType: NominalTypeSignature;
     field resolvedTrgt: InvokeKey;
     field args: ArgumentList;

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -160,6 +160,11 @@ PostfixAccessFromName {
     field declaredInType: NominalTypeSignature;
     field ftype: TypeSignature;
 }
+| PostfixInvokeStatic { %% May only need args here...?
+    field resolvedType: NominalTypeSignature;
+    field resolvedTrgt: InvokeKey;
+    field args: ArgumentList;
+}
 ;
 
 entity PostfixOp provides Expression {

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -41,6 +41,7 @@ entity MemberFieldDecl provides AbstractCoreDecl {
 
 concept AbstractNominalTypeDecl provides AbstractDecl {
     field tkey: TypeKey;
+    field tinfo: TypeInfo;
 
     %% invariants, validates, methods, saturated, as well
 }
@@ -50,6 +51,15 @@ concept AbstractEntityTypeDecl provides AbstractNominalTypeDecl {
 
 entity EntityTypeDecl provides AbstractEntityTypeDecl{
     field fields: List<MemberFieldDecl>;
+}
+
+%% Info for the GC 
+entity TypeInfo {
+    field id: Nat;
+    field typesize: Nat;
+    field slotsize: Nat;
+    field ptrmask: CString;
+    field typekey: CPPAssembly::TypeKey;
 }
 
 entity ParameterDecl {

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -72,8 +72,6 @@ entity TypeInfo {
 }
 
 datatype MethodDecl provides AbstractInvokeDecl using {
-    %% Not quite sure what this does
-    %% field isThisRef: Bool;
 }
 of
 MethodDeclStatic { }
@@ -90,7 +88,6 @@ entity ParameterDecl {
     %% TODO: Support ref/rest param
 }
 
-%% May want to change this as it doesnt map super well to bsqir (but maps nice to how smtemit)
 entity NamespaceFunctionDecl provides AbstractInvokeDecl {
 }
 
@@ -115,10 +112,8 @@ entity Assembly {
     field nsdecls: Map<CString, NamespaceDecl>; %% Toplevel decls, traverse to find lower level decls
     field allfuncs: List<FunctionDecl>;
 
-    %% We will need to put static, abstract, override, virtual methods here then in NamespaceDecl
-    %% we just have a List<InvokeKey>, allows for very easy lookups and ns resolution 
-    %% (this helps us get the parameter list for constructors and stuff)
     field staticmethods: Map<InvokeKey, MethodDeclStatic>;
+    %% TODO: Abstract, Override, Virtual methods
 
     field allmethods: List<InvokeKey>;
     field typeinfos: Map<TypeKey, TypeInfo>;

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -117,6 +117,11 @@ entity NamespaceDecl {
 entity Assembly {
     field nsdecls: Map<CString, NamespaceDecl>; %% Toplevel decls, traverse to find lower level decls
     field allfuncs: List<FunctionDecl>;
+
+    %% We will need to put static, abstract, override, virtual methods here then in NamespaceDecl
+    %% we just have a List<InvokeKey>, allows for very easy lookups and ns resolution 
+    %% (this helps us get the parameter list for constructors and stuff)
+
     field allmethods: List<InvokeKey>;
     field typeinfos: Map<TypeKey, TypeInfo>;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -45,7 +45,7 @@ concept AbstractNominalTypeDecl provides AbstractDecl {
     %% invariants, validates, methods, saturated, as well
 }
 
-concept AbstractEntityTypeDecl provides AbstractNominalTypeDecl {
+concept AbstractEntityTypeDecl provides AbstractNoinalTypeDecl {
 }
 
 entity EntityTypeDecl provides AbstractEntityTypeDecl{
@@ -71,7 +71,6 @@ datatype MethodDecl provides AbstractDecl using {
     field params: List<ParameterDecl>;
     field resultType: TypeSignature;
     field body: BodyImplementation;
-    field declaredIn: TypeKey;
 }
 of
 MethodDeclStatic { }
@@ -110,7 +109,7 @@ entity NamespaceDecl {
     field subns: Map<CString, NamespaceDecl>;
     field entities: Map<TypeKey, EntityTypeDecl>; %% Will have to do forward decls too
     field nsfuncs: Map<InvokeKey, NamespaceFunctionDecl>;
-    field staticmethods: Map<InvokeKey, MethodDeclStatic>;
+    field staticmethods: List<InvokeKey>; %% Convienent for fwd decls
 }
 
 %% Will need expanding
@@ -121,6 +120,7 @@ entity Assembly {
     %% We will need to put static, abstract, override, virtual methods here then in NamespaceDecl
     %% we just have a List<InvokeKey>, allows for very easy lookups and ns resolution 
     %% (this helps us get the parameter list for constructors and stuff)
+    field staticmethods: Map<InvokeKey, MethodDeclStatic>;
 
     field allmethods: List<InvokeKey>;
     field typeinfos: Map<TypeKey, TypeInfo>;

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -50,6 +50,8 @@ concept AbstractEntityTypeDecl provides AbstractNominalTypeDecl {
 
 entity EntityTypeDecl provides AbstractEntityTypeDecl{
     field fields: List<MemberFieldDecl>;
+    field staticmethods: List<InvokeKey>;
+    %% Other method types too
 }
 
 %% Info for the GC 
@@ -60,6 +62,24 @@ entity TypeInfo {
     field ptrmask: CString;
     field typekey: CString;
 }
+
+datatype MethodDecl provides AbstractDecl using {
+    %% Not quite sure what this does
+    %% field isThisRef: Bool;
+    field name: CString;
+    field ikey: InvokeKey;
+    field params: List<ParameterDecl>;
+    field resultType: TypeSignature;
+    field body: BodyImplementation;
+
+
+}
+of
+MethodDeclStatic { }
+| MethodDeclAbstract {}
+| MethodDeclVirtual {}
+| MethodDeclOverride {}
+;
 
 entity ParameterDecl {
     field pname: Identifier;
@@ -91,11 +111,13 @@ entity NamespaceDecl {
     field subns: Map<CString, NamespaceDecl>;
     field entities: Map<TypeKey, EntityTypeDecl>; %% Will have to do forward decls too
     field nsfuncs: Map<InvokeKey, NamespaceFunctionDecl>;
+    field staticmethods: Map<InvokeKey, MethodDeclStatic>;
 }
 
 %% Will need expanding
 entity Assembly {
     field nsdecls: Map<CString, NamespaceDecl>; %% Toplevel decls, traverse to find lower level decls
     field allfuncs: List<FunctionDecl>;
+    field allmethods: List<InvokeKey>;
     field typeinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -45,7 +45,15 @@ concept AbstractNominalTypeDecl provides AbstractDecl {
     %% invariants, validates, methods, saturated, as well
 }
 
-concept AbstractEntityTypeDecl provides AbstractNoinalTypeDecl {
+concept AbstractInvokeDecl provides AbstractDecl {
+    field name: CString;
+    field ikey: InvokeKey;
+    field params: List<ParameterDecl>;
+    field resultType: TypeSignature;
+    field body: BodyImplementation;
+}
+
+concept AbstractEntityTypeDecl provides AbstractNominalTypeDecl {
 }
 
 entity EntityTypeDecl provides AbstractEntityTypeDecl{
@@ -63,14 +71,9 @@ entity TypeInfo {
     field typekey: CString;
 }
 
-datatype MethodDecl provides AbstractDecl using {
+datatype MethodDecl provides AbstractInvokeDecl using {
     %% Not quite sure what this does
     %% field isThisRef: Bool;
-    field name: CString;
-    field ikey: InvokeKey;
-    field params: List<ParameterDecl>;
-    field resultType: TypeSignature;
-    field body: BodyImplementation;
 }
 of
 MethodDeclStatic { }
@@ -88,12 +91,7 @@ entity ParameterDecl {
 }
 
 %% May want to change this as it doesnt map super well to bsqir (but maps nice to how smtemit)
-entity NamespaceFunctionDecl provides AbstractDecl {
-    field name: CString;
-    field ikey: InvokeKey;
-    field params: List<ParameterDecl>;
-    field resultType: TypeSignature;
-    field body: BodyImplementation;
+entity NamespaceFunctionDecl provides AbstractInvokeDecl {
 }
 
 %% This is not actively being used but MAY prove some use as the emitter expands so ill leave it 
@@ -109,7 +107,7 @@ entity NamespaceDecl {
     field subns: Map<CString, NamespaceDecl>;
     field entities: Map<TypeKey, EntityTypeDecl>; %% Will have to do forward decls too
     field nsfuncs: Map<InvokeKey, NamespaceFunctionDecl>;
-    field staticmethods: List<InvokeKey>; %% Convienent for fwd decls
+    field staticmethods: List<(|InvokeKey, TypeKey|)>; %% Convienent for fwd decls
 }
 
 %% Will need expanding

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -62,6 +62,12 @@ entity EntityTypeDecl provides AbstractEntityTypeDecl{
     %% Other method types too
 }
 
+enum Tag {
+    Value,
+    Ref,
+    Tagged
+}
+
 %% Info for the GC 
 entity TypeInfo {
     field id: Nat;
@@ -69,6 +75,7 @@ entity TypeInfo {
     field slotsize: Nat;
     field ptrmask: CString;
     field typekey: TypeKey;
+    field tag: Tag;
 }
 
 datatype MethodDecl provides AbstractInvokeDecl using {

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -71,8 +71,7 @@ datatype MethodDecl provides AbstractDecl using {
     field params: List<ParameterDecl>;
     field resultType: TypeSignature;
     field body: BodyImplementation;
-
-
+    field declaredIn: TypeKey;
 }
 of
 MethodDeclStatic { }
@@ -119,5 +118,5 @@ entity Assembly {
     field nsdecls: Map<CString, NamespaceDecl>; %% Toplevel decls, traverse to find lower level decls
     field allfuncs: List<FunctionDecl>;
     field allmethods: List<InvokeKey>;
-    field typeinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>;
+    field typeinfos: Map<TypeKey, TypeInfo>;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -41,8 +41,7 @@ entity MemberFieldDecl provides AbstractCoreDecl {
 
 concept AbstractNominalTypeDecl provides AbstractDecl {
     field tkey: TypeKey;
-    field tinfo: TypeInfo;
-
+ 
     %% invariants, validates, methods, saturated, as well
 }
 
@@ -59,7 +58,7 @@ entity TypeInfo {
     field typesize: Nat;
     field slotsize: Nat;
     field ptrmask: CString;
-    field typekey: CPPAssembly::TypeKey;
+    field typekey: CString;
 }
 
 entity ParameterDecl {
@@ -98,4 +97,5 @@ entity NamespaceDecl {
 entity Assembly {
     field nsdecls: Map<CString, NamespaceDecl>; %% Toplevel decls, traverse to find lower level decls
     field allfuncs: List<FunctionDecl>;
+    field typeinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -68,7 +68,7 @@ entity TypeInfo {
     field typesize: Nat;
     field slotsize: Nat;
     field ptrmask: CString;
-    field typekey: CString;
+    field typekey: TypeKey;
 }
 
 datatype MethodDecl provides AbstractInvokeDecl using {

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -6,6 +6,16 @@
 #include <csetjmp>
 #include <variant>
 
+// Note: This will be deleted when the GC is merged, only exists so emitted cpp still compiles
+struct TypeInfoBase 
+{
+    uint32_t type_id;
+    uint32_t type_size;
+    uint32_t slot_size;
+    const char* ptr_mask;
+    const char* typekey;
+};
+
 namespace __CoreCpp {
 
 #define MAX_BSQ_INT ((int64_t(1) << 62) - 1)

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -7,6 +7,13 @@
 #include <variant>
 
 // Note: This will be deleted when the GC is merged, only exists so emitted cpp still compiles
+struct FieldOffsetInfo 
+{
+    uint16_t id;
+    uint16_t type;
+    uint32_t byteoffset;
+};
+
 struct TypeInfoBase 
 {
     uint32_t type_id;
@@ -14,6 +21,7 @@ struct TypeInfoBase
     uint32_t slot_size;
     const char* ptr_mask;
     const char* typekey;
+    const FieldOffsetInfo* vtable; // Will need to add to gc
 };
 
 namespace __CoreCpp {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -278,9 +278,9 @@ recursive function emitLogicActionOrExpression(e: CPPAssembly::LogicActionOrExpr
     return CString::concat('(', CString::joinAll(' || ', args), ')');
 }
 
-function emitArgumentValue(av: Option<CPPAssembly::ArgumentValue>, i: Nat, func: CPPAssembly::NamespaceFunctionDecl, ctx: Context): CString {
+function emitArgumentValue(av: Option<CPPAssembly::ArgumentValue>, i: Nat, params: List<CPPAssembly::ParameterDecl>, ctx: Context): CString {
     if(av)@none {
-        let param = func.params.get(i).defaultval;
+        let param = params.get(i).defaultval;
         if(param)@none {
             abort; %% Should be impossible
         }
@@ -299,13 +299,13 @@ function emitArgumentValue(av: Option<CPPAssembly::ArgumentValue>, i: Nat, func:
     }
 }
 
-function resolveDefaultParams(al: List<CString>, func: CPPAssembly::NamespaceFunctionDecl): List<CString> {
+function resolveDefaultParams(al: List<CString>, params: List<CPPAssembly::ParameterDecl>): List<CString> {
     return al.map<CString>(fn(arg) => { 
         if(arg.startsWithString('$')) {
             let ident = arg.removePrefixString('$');
 
             %% This is a bit hacky but works for getting default val idx
-            let idx = func.params.mapIdx<Nat>(fn(param, ii) => {
+            let idx = params.mapIdx<Nat>(fn(param, ii) => {
                 if(emitIdentifier(param.pname) === ident) {
                     return ii;
                 }
@@ -318,10 +318,10 @@ function resolveDefaultParams(al: List<CString>, func: CPPAssembly::NamespaceFun
     });
 }
 
-function emitArgumentList(al: CPPAssembly::ArgumentList, func: CPPAssembly::NamespaceFunctionDecl, ctx: Context): CString {
-    let emit_al = al.args.mapIdx<CString>(fn(arg, ii) => emitArgumentValue(arg, ii, func, ctx));
+function emitArgumentList(al: CPPAssembly::ArgumentList, params: List<CPPAssembly::ParameterDecl>, ctx: Context): CString {
+    let emit_al = al.args.mapIdx<CString>(fn(arg, ii) => emitArgumentValue(arg, ii, params, ctx));
     
-    return CString::joinAll(', ', resolveDefaultParams[recursive](emit_al, func));
+    return CString::joinAll(', ', resolveDefaultParams[recursive](emit_al, params));
 }
 
 recursive function findNamespaceDecl(decls: Map<CString, CPPAssembly::NamespaceDecl>, fullns: List<CString>): CPPAssembly::NamespaceDecl {
@@ -346,7 +346,7 @@ function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFuncti
     let resolvedns = emitResolvedNamespace(ctx.fullns_list, e.ns.value); 
 
     let ident = emitInvokeKey(e.ikey, ctx);
-    let name = ident.removePrefixString(e.ns.value);
+    let name = ident.removePrefixString(resolvedns);
     
     var resolvedName: CString;
     if(name.startsWithString('::')) {
@@ -357,7 +357,7 @@ function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFuncti
     }
 
     let func = findNamespaceDecl(ctx.nsdecls, e.fullns).nsfuncs.get(e.ikey);
-    let args = emitArgumentList(e.args, func, ctx);
+    let args = emitArgumentList(e.args, func.params, ctx);
 
     if(resolvedns !== '') {
         return CString::concat(resolvedns, '::', resolvedName,'(', args, ')');
@@ -373,7 +373,18 @@ function emitPostfixAccessFromName(op: CPPAssembly::PostfixAccessFromName): CStr
 function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CString, ctx: Context): CString {
     let ik = emitInvokeKey(op.resolvedTrgt, ctx);
     let tk = emitTypeKey(op.resolvedType.tkeystr, ctx);
-    
+
+    %% this does NOT work for lookup namespace, would be better to get the method directly 
+    let nsdecl = findNamespaceDecl(ctx.nsdecls, ctx.fullns_list);
+    var params: CString;
+    if(nsdecl.staticmethods.has(op.resolvedTrgt)) {
+        let trgt = nsdecl.staticmethods.get(op.resolvedTrgt);
+        params = emitParameters(trgt.params, ctx);
+    }
+    else {
+        abort; %% TODO: Support methods in abstract nominal types other than static!
+    }
+
     %% Remove abstract nominal we were in
     var resolvedInvoke: CString;
     if(ik.startsWithString(tk)) {
@@ -390,7 +401,12 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CSt
         resolvedInvoke = ik;
     }
 
-    return CString::concat(resolvedInvoke, '(', expr, ')');
+    if(params === '') {
+        return CString::concat(resolvedInvoke, '(', expr, ')');
+    }
+    else {
+         return CString::concat(resolvedInvoke, '(', expr, ', ', params, ')');       
+    }
 }
 
 function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
@@ -559,7 +575,15 @@ function emitMethodDecl(m: CPPAssembly::MethodDecl, ctx: Context, indent: CStrin
         let this_type = emitResolvedNamespace(nctx.fullns_list, m.declaredIn.value); %% Find necessary ns resolution for the structure we are declared in
 
         let pre = CString::concat(indent, 'const ', rtype, ' ', name);
-        let params_impl = CString::concat('(const ', this_type, ' ', emitSpecialThis(), params, ') noexcept');
+        
+        var params_impl: CString;
+        if(params === '') {
+            params_impl = CString::concat('(const ', this_type, ' ', emitSpecialThis(), ') noexcept');
+        }
+        else {
+            let base = CString::concat('(const ', this_type, ' ');
+            params_impl = CString::concat(base, emitSpecialThis(), ', ', params, ') noexcept');           
+        }
 
         return CString::concat(pre, params_impl, ' {%n;', emitBodyImplementation(m.body, nctx, indent), indent, '}%n;');
     }
@@ -614,9 +638,15 @@ function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, ctx: Context, 
         let this_type = emitResolvedNamespace(nctx.fullns_list, m.declaredIn.value);
         let params = emitParameters(m.params, nctx);
         let first = CString::concat(indent, 'const ', rtype, ' ', pre, '(const ');
-        return CString::concat(first, this_type, ' ', emitSpecialThis(), params, ') noexcept;%n;');
-    }
 
+        if(params === '') {
+            return CString::concat(first, this_type, ' ', emitSpecialThis(), params, ') noexcept;%n;');
+        }
+        else {
+            let base = CString::concat(first, this_type, ' ');
+            return CString::concat(base, emitSpecialThis(), ', ', params, ') noexcept;%n;');           
+        }
+    }
     abort; %% TODO: Support other method types!
 }
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -41,7 +41,7 @@ function emitTypeSignature(ts: CPPAssembly::TypeSignature, ctx: Context): CStrin
     return emitResolvedNamespace(ctx.fullns_list, ts.tkeystr.value);    
 }
 
-%% We wont do this for now, gets weird with the interation wiht CStrings
+%% Temporary invalid string we replace just before emission (with our special unicode tᖺis)
 function emitSpecialThis(): CString {
     return '!!!';
 }
@@ -563,7 +563,6 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context):
     return CString::joinAll(', ', all_params);
 }
 
-%% Will need to make some changes in case of actually having parameters (needs a comma after special this if params, not if none)
 function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CString, ctx: Context, indent: CString): CString {
     let nctx = ctx.updateCurrentNamespace(m.declaredInNS, m.fullns);
     if(m)@<CPPAssembly::MethodDeclStatic> { %% Pass "this" ptr as first argument
@@ -625,11 +624,9 @@ function emitEntityForwardDeclaration(e: CPPAssembly::EntityTypeDecl, ctx: Conte
     return CString::concat(indent, 'struct ', emitResolvedNamespace(nctx.fullns_list, e.tkey.value), ';%n;');
 }
 
-%% Will need to make some changes in case of actually having parameters (needs a comma after special this if params, not if none)
 function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: CString): CString {
     let nctx = ctx.updateCurrentNamespace(m.declaredInNS, m.fullns);
 
-    %% Methods may all emit fwd decl the same, will keep as is incase they do not (once i get to other method types)
     if(m)@<CPPAssembly::MethodDeclStatic> {
         let pre = m.name;
         let rtype = emitTypeSignature(m.resultType, ctx);
@@ -648,7 +645,6 @@ function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CP
     abort; %% TODO: Support other method types!
 }
 
-%% I suspect we will need separate cases for entities, types, enums and such
 function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl, ctx: Context, ident: CString): CString {
     let nctx = ctx.updateCurrentNamespace(decl.declaredInNS, decl.fullns);
 
@@ -683,17 +679,16 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
         return CString::concat(acc, emitEntityForwardDeclaration(e, ctx, full_indent));
     });
 
-    %% Emit our function and entity forward decls (all that is supported for now)
+    %% Emit our method and func fwd decls
     let funcfwd_decls = nsdecl.nsfuncs.reduce<CString>(entityfwd_decls, fn(acc, ikey, decl) => {
         return CString::concat(acc, emitFunctionForwardDeclaration(decl, ctx, full_indent));
     });
 
-    %% Akward to add the this special first argument...
     let methodfwd_decls = nsdecl.staticmethods.reduce<CString>(funcfwd_decls, fn(acc, mtkey) => {
         return CString::concat(acc, emitMethodForwardDeclaration(ctx.asm.staticmethods.get(mtkey.0), mtkey.1, ctx, full_indent));
     });
 
-    %% All entities
+    %% All entities && their typeinfo
     let entities = nsdecl.entities.reduce<CString>(methodfwd_decls, fn(acc, tk, e) => {
         let typekey = tk.value;
         let emit_entity = emitEntityTypeDecl(e, typekey, ctx, full_indent);

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -369,9 +369,28 @@ function emitPostfixAccessFromName(op: CPPAssembly::PostfixAccessFromName): CStr
     return CString::concat('.', emitIdentifier(op.name));
 }
 
+%% Does not emit arguments yet
 function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CString, ctx: Context): CString {
+    let ik = emitInvokeKey(op.resolvedTrgt, ctx);
     let tk = emitTypeKey(op.resolvedType.tkeystr, ctx);
-    return CString::concat(tk, '(', expr, ', args go here', ')');
+    
+    %% Remove abstract nominal we were in
+    var resolvedInvoke: CString;
+    if(ik.startsWithString(tk)) {
+        let tmp = ik.removePrefixString(tk);
+        if(tmp.startsWithString('::')) {
+            resolvedInvoke = tmp.removePrefixString('::');
+        }
+        else {
+            resolvedInvoke = tmp;
+        }
+        
+    }
+    else {
+        resolvedInvoke = ik;
+    }
+
+    return CString::concat(resolvedInvoke, '(', expr, ')');
 }
 
 function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -43,8 +43,7 @@ function emitTypeSignature(ts: CPPAssembly::TypeSignature, ctx: Context): CStrin
 
 %% We wont do this for now, gets weird with the interation wiht CStrings
 function emitSpecialThis(): CString {
-    %% return "tᖺis";
-    return 'specialthis';
+    return '!!!';
 }
 
 function emitTypeKey(tk: CPPAssembly::TypeKey, ctx: Context): CString {
@@ -663,14 +662,14 @@ function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl
 function emitTypeInfo(info: CPPAssembly::TypeInfo, fullns: List<CString>, indent: CString): CString {
     let full_indent = CString::concat('    ', indent);
 
-    let resolved_name = CString::concat(emitResolvedNamespace(fullns, info.typekey), 'Type');
+    let resolved_name = CString::concat(emitResolvedNamespace(fullns, info.typekey.value), 'Type');
 
     let base = CString::concat(indent, 'TypeInfoBase ', resolved_name, ' = {%n;');
     let id = CString::concat(base, full_indent, '.type_id = ', info.id.toCString(), ',%n;');
     let typesize = CString::concat(id, full_indent, '.type_size = ', info.typesize.toCString(), ', %n;');
     let slotsize = CString::concat(typesize, full_indent, '.slot_size = ', info.slotsize.toCString(), ',%n;');
     let ptrmask = CString::concat(slotsize, full_indent, '.ptr_mask = "', info.ptrmask, '",%n;');
-    let typekey = CString::concat(ptrmask, full_indent, '.typekey = "', info.typekey, '"%n;');
+    let typekey = CString::concat(ptrmask, full_indent, '.typekey = "', info.typekey.value, '"%n;');
 
     return CString::concat(typekey, indent, '};%n;');
 }
@@ -718,7 +717,7 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     return CString::concat(funcs, indent, '}%n;');
 }
 
-function emitAssembly(asm: CPPAssembly::Assembly): CString {    
+function emitAssembly(asm: CPPAssembly::Assembly): String {    
     let ctx: Context = Context{ asm, CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''} }; %% No known namespace yet
     let ns_emission = asm.nsdecls.reduce<CString>('', fn(acc, nsname, nsdecl) => {
         return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, ''));
@@ -728,5 +727,9 @@ function emitAssembly(asm: CPPAssembly::Assembly): CString {
 
     %% For CCharBuf and Unicode... will need to emit builtin functions explicitly
 
-    return CString::join('%n;', ns_emission, '%n;');
+    let convert = String::fromCString(ns_emission);
+    let target = String::fromCString(emitSpecialThis());
+    let updated = convert.replaceAllStringOccurrences(target, "tᖺis");
+
+    return String::join("%n;", updated, "%n;");
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -41,6 +41,12 @@ function emitTypeSignature(ts: CPPAssembly::TypeSignature, ctx: Context): CStrin
     return emitResolvedNamespace(ctx.fullns_list, ts.tkeystr.value);    
 }
 
+%% We wont do this for now, gets weird with the interation wiht CStrings
+function emitSpecialThis(): CString {
+    %% return "tᖺis";
+    return 'specialthis';
+}
+
 function emitTypeKey(tk: CPPAssembly::TypeKey, ctx: Context): CString {
     return emitResolvedNamespace(ctx.fullns_list, tk.value); 
 }
@@ -50,11 +56,14 @@ function emitIdentifier(ident: CPPAssembly::Identifier): CString {
 }
 
 function emitVarIdentifier(vident: CPPAssembly::VarIdentifier): CString {
+    if(vident.value === 'this') {
+        return emitSpecialThis();
+    }
     return vident.value;
 }
 
-function emitInvokeKey(ik: CPPAssembly::InvokeKey): CString {
-    return ik.value;
+function emitInvokeKey(ik: CPPAssembly::InvokeKey, ctx: Context): CString {
+    return emitResolvedNamespace(ctx.fullns_list, ik.value); 
 }
 
 function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): CString {
@@ -336,7 +345,7 @@ recursive function findNamespaceDecl(decls: Map<CString, CPPAssembly::NamespaceD
 function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFunctionExpression, ctx: Context): CString { 
     let resolvedns = emitResolvedNamespace(ctx.fullns_list, e.ns.value); 
 
-    let ident = emitInvokeKey(e.ikey);
+    let ident = emitInvokeKey(e.ikey, ctx);
     let name = ident.removePrefixString(e.ns.value);
     
     var resolvedName: CString;
@@ -521,11 +530,27 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context):
     return CString::joinAll(', ', all_params);
 }
 
+function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredInType: CString, ctx: Context, indent: CString): CString {
+    let nctx = ctx.updateCurrentNamespace(m.declaredInNS, m.fullns);
+    if(m)@<CPPAssembly::MethodDeclStatic> { %% Pass "this" ptr as first argument
+        let name = m.name;
+        let params = emitParameters(m.params, nctx);
+        let rtype = emitTypeSignature(m.resultType, ctx);
+        let this_type = emitResolvedNamespace(nctx.fullns_list, declaredInType); %% Find necessary ns resolution for the structure we are declared in
+
+        let pre = CString::concat(indent, 'const ', rtype, ' ', name);
+        let params_impl = CString::concat('(const ', this_type, ' ', emitSpecialThis(), params, ') noexcept');
+
+        return CString::concat(pre, params_impl, ' {%n;', emitBodyImplementation(m.body, nctx, indent), indent, '}%n;');
+    }
+
+    abort; %% TODO: Need to support other method types!
+}
+
 function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ctx: Context, indent: CString): CString {
     let nctx = ctx.updateCurrentNamespace(func.declaredInNS, func.fullns);
 
     let name = func.name;
-    let nskey = emitNamespaceKey(func.declaredInNS);
     let params = emitParameters(func.params, nctx);
     let rtype = emitTypeSignature(func.resultType, ctx); 
 
@@ -556,6 +581,21 @@ function emitEntityTypeDecl(e: CPPAssembly::EntityTypeDecl, tk: CString, ctx: Co
 function emitEntityForwardDeclaration(e: CPPAssembly::EntityTypeDecl, ctx: Context, indent: CString): CString {
     let nctx = ctx.updateCurrentNamespace(e.declaredInNS, e.fullns);
     return CString::concat(indent, 'struct ', emitResolvedNamespace(nctx.fullns_list, e.tkey.value), ';%n;');
+}
+
+function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, ctx: Context, indent: CString): CString {
+    let nctx = ctx.updateCurrentNamespace(m.declaredInNS, m.fullns);
+
+    %% Methods may all emit fwd decl the same, will keep as is incase they do not (once i get to other method types)
+    if(m)@<CPPAssembly::MethodDeclStatic> {
+        let pre = m.name;
+        let rtype = emitTypeSignature(m.resultType, ctx); 
+        let params = emitParameters(m.params, nctx);
+        let first = CString::concat(rtype, ' ', pre );
+        return CString::concat(indent, 'const ', first, '( ', params, ') noexcept;%n;');
+    }
+
+    abort; %% TODO: Support other method types!
 }
 
 %% I suspect we will need separate cases for entities, types, enums and such
@@ -598,14 +638,27 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
         return CString::concat(acc, emitFunctionForwardDeclaration(decl, ctx, full_indent));
     });
 
+    %% Akward to add the this special first argument...
+    let methodfwd_decls = nsdecl.staticmethods.reduce<CString>(funcfwd_decls, fn(acc, ikey, decl) => {
+        return CString::concat(acc, emitMethodForwardDeclaration(decl, ctx, full_indent));
+    });
+
     %% All entities
-    let entities = nsdecl.entities.reduce<CString>(funcfwd_decls, fn(acc, tk, e) => {
+    let entities = nsdecl.entities.reduce<CString>(methodfwd_decls, fn(acc, tk, e) => {
         let typekey = tk.value;
         let emit_entity = emitEntityTypeDecl(e, typekey, ctx, full_indent);
         let entity_tinfo = emitTypeInfo(typeinfos.get(tk), e.fullns, full_indent);
-        return CString::concat(acc, indent, entity_tinfo, emit_entity);
+        let entity_staticmethods = e.staticmethods.reduce<CString>('', fn(acc, m) => { 
+            return CString::concat(acc, emitMethodDecl(nsdecl.staticmethods.get(m), e.tkey.value, ctx, full_indent));
+        });
+        return CString::concat(acc, indent, entity_tinfo, emit_entity, entity_staticmethods);
     });
 
+%*
+    let methods = nsdecl.staticmethods.reduce<CString>(entities, fn(acc, ikey, decl) => {
+        return CString::concat(acc, emitMethodDecl(decl, ctx, full_indent));
+    });
+*%
     %% Emit sub-namespace declarations
     let subns = nsdecl.subns.reduce<CString>(entities, fn(acc, name, decl) => {
         return CString::concat(acc, emitNamespaceDecl[recursive](decl, ctx, typeinfos, full_indent));

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -37,8 +37,18 @@ entity Context {
     }
 }
 
-function emitTypeSignature(ts: CPPAssembly::TypeSignature, ctx: Context): CString {
-    return emitResolvedNamespace(ctx.fullns_list, ts.tkeystr.value);    
+%%
+%% TODO: THe mehtods below likely need to be split up into their unique cases.
+%%
+
+%% Could remove these two and just call emitTypeKey... but I suspect we will eventually need to handle
+%% lambda and elist explicitly (so fornow these are fine)
+function emitTypeSignatureBase(ts: CPPAssembly::TypeSignature, ctx: Context): CString {
+    return emitTypeKeyBase(ts.tkeystr, ctx);    
+}
+
+function emitTypeSignatureParamFieldType(ts: CPPAssembly::TypeSignature, ctx: Context): CString {
+    return emitTypeKeyParamField(ts.tkeystr, ctx);
 }
 
 %% Temporary invalid string we replace just before emission (with our special unicode tᖺis)
@@ -50,7 +60,7 @@ function emitTypeKeyBase(tk: CPPAssembly::TypeKey, ctx: Context): CString {
     return emitResolvedNamespace(ctx.fullns_list, tk.value); 
 }
 
-function emitTypeKeyField(tk: CPPAssembly::TypeKey, ctx: Context): CString {
+function emitTypeKeyParamField(tk: CPPAssembly::TypeKey, ctx: Context): CString {
     let resolved = emitResolvedNamespace(ctx.fullns_list, tk.value);
 
     if(!ctx.asm.typeinfos.has(tk)) {
@@ -121,7 +131,6 @@ function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression
 }
 
 function emitReturnSingleStatement(ret: CPPAssembly::ReturnSingleStatement, ctx: Context, indent: CString): CString {
-    %% let rtype = emitTypeSignature(ret.rtype);
     let exp = emitExpression(ret.value, ctx);
 
     let full_indent: CString = CString::concat(indent, '    ');
@@ -446,6 +455,10 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
     return CString::joinAll('', ops);
 }
 
+%%
+%% TODO: Once the GC is integrated we will need to call our special GC allocate on ref type objects instead of the default
+%% constructor like we do now. Ref type object constructors will not work as is currently.
+%%
 function emitConstructorStdExpression(e: CPPAssembly::ConstructorStdExpression, ctx: Context): CString {
     %% Eventually might want to rework emitArgumentList to support constructors too 
     let emitargs =  CString::joinAll(', ', e.args.args.mapIdx<CString>(fn(av, ii) => {
@@ -471,7 +484,11 @@ function emitConstructorStdExpression(e: CPPAssembly::ConstructorStdExpression, 
     }));
 
     let resolved_type = emitResolvedNamespace(ctx.fullns_list, e.ctype.tkeystr.value);
-    return CString::concat(resolved_type, '{ ', emitargs, ' }');
+
+    if(ctx.asm.typeinfos.get(e.ctype.tkeystr).tag === CPPAssembly::Tag#Ref) {
+        return CString::concat('new ', resolved_type, '{ ', emitargs, ' }'); %% We use new solely to keep the code compiling before GC integration
+    }
+    return CString::concat(resolved_type, '{ ', emitargs, ' }'); 
 }
 
 function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
@@ -493,7 +510,7 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
 
 function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitializationStatement, ctx: Context, indent: CString): CString {
     let name = emitIdentifier(stmt.name);
-    let stype = emitTypeSignature(stmt.vtype, ctx);
+    let stype = emitTypeSignatureParamFieldType(stmt.vtype, ctx);
     let exp = emitExpression(stmt.exp, ctx);
 
     let full_indent: CString = CString::concat(indent, '    ', stype); %% List constructor size max 6
@@ -575,7 +592,7 @@ function emitBodyImplementation(body: CPPAssembly::BodyImplementation, ctx: Cont
 
 function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context): CString {
     let all_params = params.map<CString>(fn(param) => {
-        let ptype = emitTypeSignature(param.ptype, ctx);
+        let ptype = emitTypeSignatureParamFieldType(param.ptype, ctx);
         let resolved_ptype = emitResolvedNamespace(ctx.fullns_list, ptype);
         let pident = emitIdentifier(param.pname);
         return CString::concat(resolved_ptype, ' ', pident);
@@ -584,22 +601,32 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context):
     return CString::joinAll(', ', all_params);
 }
 
-function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CString, ctx: Context, indent: CString): CString {
+%% Determine whether to emit this param as const this* or this
+function emitThisType(tk: CPPAssembly::TypeKey, ctx: Context): CString {
+    let resolved_type = emitResolvedNamespace(ctx.fullns_list, tk.value);
+    
+    if(ctx.asm.typeinfos.get(tk).tag === CPPAssembly::Tag#Ref) {
+        return CString::concat('const ', resolved_type, '*');
+    }
+    return resolved_type;
+}
+
+function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: CString): CString {
     let nctx = ctx.updateCurrentNamespace(m.declaredInNS, m.fullns);
     if(m)@<CPPAssembly::MethodDeclStatic> { %% Pass "this" ptr as first argument
         let name = m.name;
         let params = emitParameters(m.params, nctx);
-        let rtype = emitTypeSignature(m.resultType, ctx);
-        let this_type = emitResolvedNamespace(nctx.fullns_list, declaredIn); %% Find necessary ns resolution for the structure we are declared in
+        let rtype = emitTypeSignatureBase(m.resultType, ctx);
+        let this_type = emitThisType(declaredIn, nctx);
 
         let pre = CString::concat(indent, 'const ', rtype, ' ', name);
         
         var params_impl: CString;
         if(params === '') {
-            params_impl = CString::concat('(const ', this_type, ' ', emitSpecialThis(), ') noexcept');
+            params_impl = CString::concat('(', this_type, ' ', emitSpecialThis(), ') noexcept');
         }
         else {
-            let base = CString::concat('(const ', this_type, ' ');
+            let base = CString::concat('(', this_type, ' ');
             params_impl = CString::concat(base, emitSpecialThis(), ', ', params, ') noexcept');           
         }
 
@@ -614,7 +641,7 @@ function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ctx
 
     let name = func.name;
     let params = emitParameters(func.params, nctx);
-    let rtype = emitTypeSignature(func.resultType, ctx); 
+    let rtype = emitTypeSignatureBase(func.resultType, ctx); 
 
     let pre: CString = CString::concat(indent, rtype, ' ', name );
     let params_impl: CString = CString::concat('(', params, ') noexcept ');
@@ -624,8 +651,8 @@ function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ctx
 
 function emitMemberFieldDecl(member: CPPAssembly::MemberFieldDecl, ctx: Context, indent: CString): CString {
     let name = emitIdentifier(member.name);
-    let mtype = emitTypeKeyField(member.declaredType.tkeystr, ctx);
-    return CString::concat(indent, 'const ', mtype, ' ', name, ';%n;');
+    let mtype = emitTypeSignatureParamFieldType(member.declaredType, ctx);
+    return CString::concat(indent, mtype, ' ', name, ';%n;');
 }
 
 function emitEntityTypeDecl(e: CPPAssembly::EntityTypeDecl, tk: CString, ctx: Context, indent: CString): CString {
@@ -650,10 +677,10 @@ function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CP
 
     if(m)@<CPPAssembly::MethodDeclStatic> {
         let pre = m.name;
-        let rtype = emitTypeSignature(m.resultType, ctx);
-        let this_type = emitTypeKeyBase(declaredIn, nctx); 
+        let rtype = emitTypeSignatureBase(m.resultType, ctx);
+        let this_type = emitThisType(declaredIn, ctx);
         let params = emitParameters(m.params, nctx);
-        let first = CString::concat(indent, 'const ', rtype, ' ', pre, '(const ');
+        let first = CString::concat(indent, 'const ', rtype, ' ', pre, '(');
 
         if(params === '') {
             return CString::concat(first, this_type, ' ', emitSpecialThis(), params, ') noexcept;%n;');
@@ -670,7 +697,7 @@ function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl
     let nctx = ctx.updateCurrentNamespace(decl.declaredInNS, decl.fullns);
 
     let pre = decl.name;
-    let rtype = emitTypeSignature(decl.resultType, ctx); 
+    let rtype = emitTypeSignatureBase(decl.resultType, ctx); 
     let params = emitParameters(decl.params, nctx);
     let first = CString::concat(ident, rtype, ' ', pre );
     return CString::concat(first, '(', params, ') noexcept;%n;');
@@ -715,7 +742,7 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
         let emit_entity = emitEntityTypeDecl(e, typekey, ctx, full_indent);
         let entity_tinfo = emitTypeInfo(ctx.asm.typeinfos.get(tk), e.fullns, full_indent);
         let entity_staticmethods = e.staticmethods.reduce<CString>('', fn(acc, m) => { 
-            return CString::concat(acc, emitMethodDecl(ctx.asm.staticmethods.get(m), typekey, ctx, full_indent));
+            return CString::concat(acc, emitMethodDecl(ctx.asm.staticmethods.get(m), tk, ctx, full_indent));
         });
         return CString::concat(acc, indent, entity_tinfo, emit_entity, entity_staticmethods);
     });

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -46,8 +46,24 @@ function emitSpecialThis(): CString {
     return '!!!';
 }
 
-function emitTypeKey(tk: CPPAssembly::TypeKey, ctx: Context): CString {
+function emitTypeKeyBase(tk: CPPAssembly::TypeKey, ctx: Context): CString {
     return emitResolvedNamespace(ctx.fullns_list, tk.value); 
+}
+
+function emitTypeKeyField(tk: CPPAssembly::TypeKey, ctx: Context): CString {
+    let resolved = emitResolvedNamespace(ctx.fullns_list, tk.value);
+
+    if(!ctx.asm.typeinfos.has(tk)) {
+        abort;
+    }
+
+    let tinfo = ctx.asm.typeinfos.get(tk);
+
+    switch(tinfo.tag) {
+        CPPAssembly::Tag#Value => { return resolved; }
+        | CPPAssembly::Tag#Ref => { return CString::concat(resolved, '*'); }
+        | CPPAssembly::Tag#Tagged => { abort; } %% Not fully confident on how to handle this quite yet
+    }
 }
 
 function emitIdentifier(ident: CPPAssembly::Identifier): CString {
@@ -364,13 +380,20 @@ function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFuncti
     return CString::concat(resolvedName, '(', args, ')');
 }
 
-function emitPostfixAccessFromName(op: CPPAssembly::PostfixAccessFromName): CString {
-    return CString::concat('.', emitIdentifier(op.name));
+function emitPostfixAccessFromName(op: CPPAssembly::PostfixAccessFromName, ctx: Context): CString {
+    let ident = emitIdentifier(op.name);
+
+    let op_tinfo = ctx.asm.typeinfos.get(op.declaredInType.tkeystr);
+    switch(op_tinfo.tag) {
+        CPPAssembly::Tag#Value => { return CString::concat('.', ident); }
+        | CPPAssembly::Tag#Ref => { return CString::concat('->', ident); }
+        | CPPAssembly::Tag#Tagged => { abort; } %% TODO: Need to handle virtual lookups (and add our little vtable to backend that emits)
+    }
 }
 
 function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CString, ctx: Context): CString {
     let ik = emitInvokeKey(op.resolvedTrgt, ctx);
-    let tk = emitTypeKey(op.resolvedType.tkeystr, ctx);
+    let tk = emitTypeKeyBase(op.resolvedType.tkeystr, ctx);
 
     var args: CString;
     if(ctx.asm.staticmethods.has(op.resolvedTrgt)) {
@@ -410,9 +433,9 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
     let ops = pop.ops.mapIdx<CString>(fn(op, ii) => {
         if(op)@<CPPAssembly::PostfixAccessFromName> {
             if (ii == 0n) {
-                return CString::concat(rootExp, emitPostfixAccessFromName($op));
+                return CString::concat(rootExp, emitPostfixAccessFromName($op, ctx));
             }
-            return emitPostfixAccessFromName($op);
+            return emitPostfixAccessFromName($op, ctx);
         }
         if(op)@<CPPAssembly::PostfixInvokeStatic> {
             return emitPostfixInvokeStatic($op, rootExp, ctx);
@@ -601,7 +624,7 @@ function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ctx
 
 function emitMemberFieldDecl(member: CPPAssembly::MemberFieldDecl, ctx: Context, indent: CString): CString {
     let name = emitIdentifier(member.name);
-    let mtype = emitTypeSignature(member.declaredType, ctx);
+    let mtype = emitTypeKeyField(member.declaredType.tkeystr, ctx);
     return CString::concat(indent, 'const ', mtype, ' ', name, ';%n;');
 }
 
@@ -628,7 +651,7 @@ function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CP
     if(m)@<CPPAssembly::MethodDeclStatic> {
         let pre = m.name;
         let rtype = emitTypeSignature(m.resultType, ctx);
-        let this_type = emitTypeKey(declaredIn, nctx); 
+        let this_type = emitTypeKeyBase(declaredIn, nctx); 
         let params = emitParameters(m.params, nctx);
         let first = CString::concat(indent, 'const ', rtype, ' ', pre, '(const ');
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -703,19 +703,61 @@ function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl
     return CString::concat(first, '(', params, ') noexcept;%n;');
 }
 
-function emitTypeInfo(info: CPPAssembly::TypeInfo, fullns: List<CString>, indent: CString): CString {
+%%
+%% TODO: Need to add lookup methods for these vtables and give this some thought. A lot of this code is repetitive or could be
+%% cleaned up pretty signifigantly. We currently emit a vtable entry for all fields, not just those who are derived. (this may need changed)
+%%
+
+function generateVTableEntry(entry: CPPAssembly::MemberFieldDecl, resolved_name: CString, enum_name: CString, idx: Nat, ctx: Context, indent: CString): CString {
+    let tinfo = ctx.asm.typeinfos.get(entry.declaredType.tkeystr);
+
+    let id = tinfo.id.toCString();
+    let entrytype = CString::concat(enum_name, '::', resolved_name, '_', emitIdentifier(entry.name));
+    let byteoffset = (idx * 8n).toCString(); %% Woudlnt be a bad idea to make these 8 byte alignment a const
+
+    let base = CString::concat('{ ', id, ', ', entrytype, ', ', byteoffset);
+    return CString::concat(indent, base, ' }');
+}
+
+function generateVTable(e: CPPAssembly::EntityTypeDecl, fullns: List<CString>, ctx: Context, indent: CString): CString {
+    let full_indent = CString::concat('    ', indent);
+    
+    let resolved_name = CString::concat(emitResolvedNamespace(fullns, e.tkey.value));
+    let enum_name = CString::concat(resolved_name, '_entries');
+    let vtable_name = CString::concat(resolved_name, '_vtable');
+
+    let base = CString::concat('const FieldOffsetInfo ', vtable_name, '[] = ', '{%n;');
+    let field_names = e.fields.mapIdx<CString>(fn(f_entry, ii) => generateVTableEntry(f_entry, resolved_name, enum_name, ii, ctx, full_indent));
+    return CString::concat(indent, base, CString::joinAll(',%n;', field_names), '%n;', indent, '};%n;'); 
+}
+
+%% Might need to be a bit careful with the naming here, perhaps some funny unicode magic again
+function generateEntriesEnum(e: CPPAssembly::EntityTypeDecl, fullns: List<CString>, indent: CString): CString {
+    let full_indent = CString::concat('    ', indent);
+    
+    let resolved_name = CString::concat(emitResolvedNamespace(fullns, e.tkey.value));
+    let enum_name = CString::concat(resolved_name, '_entries');
+
+    let base = CString::concat('enum ', enum_name, ' {%n;');
+    let field_names = e.fields.map<CString>(fn(f_entry) => CString::concat(full_indent, resolved_name, '_', emitIdentifier(f_entry.name)));
+    return CString::concat(indent, base, CString::joinAll(',%n;', field_names), '%n;', indent, '};%n;');
+}
+
+function emitTypeInfo(info: CPPAssembly::TypeInfo, fullns: List<CString>, e: CPPAssembly::EntityTypeDecl, indent: CString): CString {
     let full_indent = CString::concat('    ', indent);
 
-    let resolved_name = CString::concat(emitResolvedNamespace(fullns, info.typekey.value), 'Type');
+    let resolved_name = emitResolvedNamespace(fullns, info.typekey.value);
+    let tinfo_name = CString::concat(resolved_name, 'Type');
 
-    let base = CString::concat(indent, 'TypeInfoBase ', resolved_name, ' = {%n;');
+    let base = CString::concat(indent, 'TypeInfoBase ', tinfo_name, ' = {%n;');
     let id = CString::concat(base, full_indent, '.type_id = ', info.id.toCString(), ',%n;');
     let typesize = CString::concat(id, full_indent, '.type_size = ', info.typesize.toCString(), ', %n;');
     let slotsize = CString::concat(typesize, full_indent, '.slot_size = ', info.slotsize.toCString(), ',%n;');
     let ptrmask = CString::concat(slotsize, full_indent, '.ptr_mask = "', info.ptrmask, '",%n;');
-    let typekey = CString::concat(ptrmask, full_indent, '.typekey = "', info.typekey.value, '"%n;');
+    let typekey = CString::concat(ptrmask, full_indent, '.typekey = "', info.typekey.value, '",%n;');
+    let vtable = CString::concat(typekey, full_indent, '.vtable = ', CString::concat(resolved_name, '_vtable'), '%n;');
 
-    return CString::concat(typekey, indent, '};%n;');
+    return CString::concat(vtable, indent, '};%n;');
 }
 
 recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: CString): CString {
@@ -739,12 +781,15 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     %% All entities && their typeinfo
     let entities = nsdecl.entities.reduce<CString>(methodfwd_decls, fn(acc, tk, e) => {
         let typekey = tk.value;
+        let entities_enum = generateEntriesEnum(e, e.fullns, full_indent);
+        let vtable = generateVTable(e, e.fullns, ctx, full_indent);
         let emit_entity = emitEntityTypeDecl(e, typekey, ctx, full_indent);
-        let entity_tinfo = emitTypeInfo(ctx.asm.typeinfos.get(tk), e.fullns, full_indent);
+        let entity_tinfo = emitTypeInfo(ctx.asm.typeinfos.get(tk), e.fullns, e, full_indent);
         let entity_staticmethods = e.staticmethods.reduce<CString>('', fn(acc, m) => { 
             return CString::concat(acc, emitMethodDecl(ctx.asm.staticmethods.get(m), tk, ctx, full_indent));
         });
-        return CString::concat(acc, indent, entity_tinfo, emit_entity, entity_staticmethods);
+        let res = CString::concat(entities_enum, vtable, entity_tinfo, emit_entity, entity_staticmethods);
+        return CString::concat(acc, indent, res);
     });
 
     %% Emit sub-namespace declarations

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -530,13 +530,14 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context):
     return CString::joinAll(', ', all_params);
 }
 
-function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredInType: CString, ctx: Context, indent: CString): CString {
+%% Will need to make some changes in case of actually having parameters (needs a comma after special this if params, not if none)
+function emitMethodDecl(m: CPPAssembly::MethodDecl, ctx: Context, indent: CString): CString {
     let nctx = ctx.updateCurrentNamespace(m.declaredInNS, m.fullns);
     if(m)@<CPPAssembly::MethodDeclStatic> { %% Pass "this" ptr as first argument
         let name = m.name;
         let params = emitParameters(m.params, nctx);
         let rtype = emitTypeSignature(m.resultType, ctx);
-        let this_type = emitResolvedNamespace(nctx.fullns_list, declaredInType); %% Find necessary ns resolution for the structure we are declared in
+        let this_type = emitResolvedNamespace(nctx.fullns_list, m.declaredIn.value); %% Find necessary ns resolution for the structure we are declared in
 
         let pre = CString::concat(indent, 'const ', rtype, ' ', name);
         let params_impl = CString::concat('(const ', this_type, ' ', emitSpecialThis(), params, ') noexcept');
@@ -563,7 +564,7 @@ function emitNamespaceFunctionDecl(func: CPPAssembly::NamespaceFunctionDecl, ctx
 function emitMemberFieldDecl(member: CPPAssembly::MemberFieldDecl, ctx: Context, indent: CString): CString {
     let name = emitIdentifier(member.name);
     let mtype = emitTypeSignature(member.declaredType, ctx);
-    return CString::concat(indent, 'const ',mtype, ' ', name, ';%n;');
+    return CString::concat(indent, 'const ', mtype, ' ', name, ';%n;');
 }
 
 function emitEntityTypeDecl(e: CPPAssembly::EntityTypeDecl, tk: CString, ctx: Context, indent: CString): CString {
@@ -583,16 +584,18 @@ function emitEntityForwardDeclaration(e: CPPAssembly::EntityTypeDecl, ctx: Conte
     return CString::concat(indent, 'struct ', emitResolvedNamespace(nctx.fullns_list, e.tkey.value), ';%n;');
 }
 
+%% Will need to make some changes in case of actually having parameters (needs a comma after special this if params, not if none)
 function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, ctx: Context, indent: CString): CString {
     let nctx = ctx.updateCurrentNamespace(m.declaredInNS, m.fullns);
 
     %% Methods may all emit fwd decl the same, will keep as is incase they do not (once i get to other method types)
     if(m)@<CPPAssembly::MethodDeclStatic> {
         let pre = m.name;
-        let rtype = emitTypeSignature(m.resultType, ctx); 
+        let rtype = emitTypeSignature(m.resultType, ctx);
+        let this_type = emitResolvedNamespace(nctx.fullns_list, m.declaredIn.value);
         let params = emitParameters(m.params, nctx);
-        let first = CString::concat(rtype, ' ', pre );
-        return CString::concat(indent, 'const ', first, '( ', params, ') noexcept;%n;');
+        let first = CString::concat(indent, 'const ', rtype, ' ', pre, '(const ');
+        return CString::concat(first, this_type, ' ', emitSpecialThis(), params, ') noexcept;%n;');
     }
 
     abort; %% TODO: Support other method types!
@@ -649,16 +652,11 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
         let emit_entity = emitEntityTypeDecl(e, typekey, ctx, full_indent);
         let entity_tinfo = emitTypeInfo(typeinfos.get(tk), e.fullns, full_indent);
         let entity_staticmethods = e.staticmethods.reduce<CString>('', fn(acc, m) => { 
-            return CString::concat(acc, emitMethodDecl(nsdecl.staticmethods.get(m), e.tkey.value, ctx, full_indent));
+            return CString::concat(acc, emitMethodDecl(nsdecl.staticmethods.get(m), ctx, full_indent));
         });
         return CString::concat(acc, indent, entity_tinfo, emit_entity, entity_staticmethods);
     });
 
-%*
-    let methods = nsdecl.staticmethods.reduce<CString>(entities, fn(acc, ikey, decl) => {
-        return CString::concat(acc, emitMethodDecl(decl, ctx, full_indent));
-    });
-*%
     %% Emit sub-namespace declarations
     let subns = nsdecl.subns.reduce<CString>(entities, fn(acc, name, decl) => {
         return CString::concat(acc, emitNamespaceDecl[recursive](decl, ctx, typeinfos, full_indent));

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -553,10 +553,12 @@ function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl
     return CString::concat(first, '(', params, ') noexcept;%n;');
 }
 
-function emitTypeInfo(info: CPPAssembly::TypeInfo, indent: CString): CString {
+function emitTypeInfo(info: CPPAssembly::TypeInfo, fullns: List<CString>, indent: CString): CString {
     let full_indent = CString::concat('    ', indent);
 
-    let base = CString::concat(indent, 'TypeInfoBase ', info.typekey, ' = {%n;');
+    let resolved_name = CString::concat(emitResolvedNamespace(fullns, info.typekey), 'Type');
+
+    let base = CString::concat(indent, 'TypeInfoBase ', resolved_name, ' = {%n;');
     let id = CString::concat(base, full_indent, '.type_id = ', info.id.toCString(), ',%n;');
     let typesize = CString::concat(id, full_indent, '.type_size = ', info.typesize.toCString(), ', %n;');
     let slotsize = CString::concat(typesize, full_indent, '.slot_size = ', info.slotsize.toCString(), ',%n;');
@@ -566,7 +568,7 @@ function emitTypeInfo(info: CPPAssembly::TypeInfo, indent: CString): CString {
     return CString::concat(typekey, indent, '};%n;');
 }
 
-recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: CString): CString {
+recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, typeinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, indent: CString): CString {
     %% Emit namespace 
     let ns = CString::concat(indent, 'namespace ', nsdecl.nsname, ' {%n;');
     let full_indent = CString::concat('    ', indent);
@@ -584,13 +586,13 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     let entities = nsdecl.entities.reduce<CString>(funcfwd_decls, fn(acc, tk, e) => {
         let typekey = tk.value;
         let emit_entity = emitEntityTypeDecl(e, typekey, ctx, full_indent);
-
-        return CString::concat(acc, indent, emit_entity);
+        let entity_tinfo = emitTypeInfo(typeinfos.get(tk), e.fullns, full_indent);
+        return CString::concat(acc, indent, entity_tinfo, emit_entity);
     });
 
     %% Emit sub-namespace declarations
     let subns = nsdecl.subns.reduce<CString>(entities, fn(acc, name, decl) => {
-        return CString::concat(acc, emitNamespaceDecl[recursive](decl, ctx, full_indent));
+        return CString::concat(acc, emitNamespaceDecl[recursive](decl, ctx, typeinfos, full_indent));
     });
 
     %% Emit functions in current namespace
@@ -601,14 +603,10 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     return CString::concat(funcs, indent, '}%n;');
 }
 
-function emitAssembly(asm: CPPAssembly::Assembly): CString {
-    let typeinfos = asm.typeinfos.reduce<CString>('', fn(acc, tkey, tinfo) => {
-        return CString::concat(acc, emitTypeInfo(tinfo, ''));
-    });
-    
+function emitAssembly(asm: CPPAssembly::Assembly): CString {    
     let ctx: Context = Context{CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''}, asm.nsdecls}; %% No known namespace yet
-    let ns_emission = asm.nsdecls.reduce<CString>(typeinfos, fn(acc, nsname, nsdecl) => {
-        return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, ''));
+    let ns_emission = asm.nsdecls.reduce<CString>('', fn(acc, nsname, nsdecl) => {
+        return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, asm.typeinfos, ''));
     });
 
     %% TODO: Other non namespace functions

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -38,9 +38,11 @@ entity Context {
 }
 
 function emitTypeSignature(ts: CPPAssembly::TypeSignature, ctx: Context): CString {
-    let resolved_typesig = emitResolvedNamespace(ctx.fullns_list, ts.tkeystr.value);
-    
-    return resolved_typesig;
+    return emitResolvedNamespace(ctx.fullns_list, ts.tkeystr.value);    
+}
+
+function emitTypeKey(tk: CPPAssembly::TypeKey, ctx: Context): CString {
+    return emitResolvedNamespace(ctx.fullns_list, tk.value); 
 }
 
 function emitIdentifier(ident: CPPAssembly::Identifier): CString {
@@ -354,17 +356,31 @@ function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFuncti
     return CString::concat(resolvedName, '(', args, ')');
 }
 
-function emitPostfixOpImpl(op: CPPAssembly::PostfixOperation): CString {
-    return CString::concat( '.', emitIdentifier(op@<CPPAssembly::PostfixAccessFromName>.name));
+function emitPostfixAccessFromName(op: CPPAssembly::PostfixAccessFromName): CString {
+    return CString::concat('.', emitIdentifier(op.name));
+}
+
+function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CString, ctx: Context): CString {
+    let tk = emitTypeKey(op.resolvedType.tkeystr, ctx);
+    return CString::concat(tk, '(', expr, ', args go here', ')');
 }
 
 function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
     let rootExp = emitExpression(pop.rootExp, ctx);
-    let ops = pop.ops.map<CString>(fn(op) => {
-        return emitPostfixOpImpl(op); 
+    let ops = pop.ops.mapIdx<CString>(fn(op, ii) => {
+        if(op)@<CPPAssembly::PostfixAccessFromName> {
+            if (ii == 0n) {
+                return CString::concat(rootExp, emitPostfixAccessFromName($op));
+            }
+            return emitPostfixAccessFromName($op);
+        }
+        if(op)@<CPPAssembly::PostfixInvokeStatic> {
+            return emitPostfixInvokeStatic($op, rootExp, ctx);
+        }
+        abort; %% TODO: Not implemented
     });
 
-    return CString::concat(rootExp, CString::joinAll(', ', ops));
+    return CString::joinAll('', ops);
 }
 
 function emitConstructorStdExpression(e: CPPAssembly::ConstructorStdExpression, ctx: Context): CString {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -368,12 +368,10 @@ function emitPostfixAccessFromName(op: CPPAssembly::PostfixAccessFromName): CStr
     return CString::concat('.', emitIdentifier(op.name));
 }
 
-%% Does not emit arguments yet
 function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CString, ctx: Context): CString {
     let ik = emitInvokeKey(op.resolvedTrgt, ctx);
     let tk = emitTypeKey(op.resolvedType.tkeystr, ctx);
 
-    %% TODO: Need to figure out why this method isnt found in the asm...
     var args: CString;
     if(ctx.asm.staticmethods.has(op.resolvedTrgt)) {
         let trgt = ctx.asm.staticmethods.get(op.resolvedTrgt);

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -375,10 +375,10 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CSt
     let tk = emitTypeKey(op.resolvedType.tkeystr, ctx);
 
     %% TODO: Need to figure out why this method isnt found in the asm...
-    var params: CString;
+    var args: CString;
     if(ctx.asm.staticmethods.has(op.resolvedTrgt)) {
         let trgt = ctx.asm.staticmethods.get(op.resolvedTrgt);
-        params = emitParameters(trgt.params, ctx);
+        args = emitArgumentList(op.args, trgt.params, ctx);
     }
     else {
         abort; %% TODO: Support methods in abstract nominal types other than static!
@@ -400,11 +400,11 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CSt
         resolvedInvoke = ik;
     }
 
-    if(params === '') {
+    if(args === '') {
         return CString::concat(resolvedInvoke, '(', expr, ')');
     }
     else {
-         return CString::concat(resolvedInvoke, '(', expr, ', ', params, ')');       
+         return CString::concat(resolvedInvoke, '(', expr, ', ', args, ')');       
     }
 }
 
@@ -627,14 +627,14 @@ function emitEntityForwardDeclaration(e: CPPAssembly::EntityTypeDecl, ctx: Conte
 }
 
 %% Will need to make some changes in case of actually having parameters (needs a comma after special this if params, not if none)
-function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, ctx: Context, indent: CString): CString {
+function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: CString): CString {
     let nctx = ctx.updateCurrentNamespace(m.declaredInNS, m.fullns);
 
     %% Methods may all emit fwd decl the same, will keep as is incase they do not (once i get to other method types)
     if(m)@<CPPAssembly::MethodDeclStatic> {
         let pre = m.name;
         let rtype = emitTypeSignature(m.resultType, ctx);
-        let this_type = m.ikey.value; 
+        let this_type = emitTypeKey(declaredIn, nctx); 
         let params = emitParameters(m.params, nctx);
         let first = CString::concat(indent, 'const ', rtype, ' ', pre, '(const ');
 
@@ -690,8 +690,8 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     });
 
     %% Akward to add the this special first argument...
-    let methodfwd_decls = nsdecl.staticmethods.reduce<CString>(funcfwd_decls, fn(acc, ikey) => {
-        return CString::concat(acc, emitMethodForwardDeclaration(ctx.asm.staticmethods.get(ikey), ctx, full_indent));
+    let methodfwd_decls = nsdecl.staticmethods.reduce<CString>(funcfwd_decls, fn(acc, mtkey) => {
+        return CString::concat(acc, emitMethodForwardDeclaration(ctx.asm.staticmethods.get(mtkey.0), mtkey.1, ctx, full_indent));
     });
 
     %% All entities

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -553,6 +553,21 @@ function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl
     return CString::concat(first, '(', params, ') noexcept;%n;');
 }
 
+function emitTypeInfo(info: CPPAssembly::TypeInfo, ns: List<CString>, indent: CString): CString {
+    let full_indent = CString::concat('    ', indent);
+
+    let resolved_typename = CString::concat(emitResolvedNamespace(ns, info.typekey.value), 'Type');
+
+    let base = CString::concat(indent, 'TypeInfoBase ', resolved_typename, ' = {%n;');
+    let id = CString::concat(base, full_indent, '.type_id = ', info.id.toCString(), ',%n;');
+    let typesize = CString::concat(id, full_indent, '.type_size = ', info.typesize.toCString(), ', %n;');
+    let slotsize = CString::concat(typesize, full_indent, '.slot_size = ', info.slotsize.toCString(), ',%n;');
+    let ptrmask = CString::concat(slotsize, full_indent, '.ptr_mask = "', info.ptrmask, '",%n;');
+    let typekey = CString::concat(ptrmask, full_indent, '.typekey = "', info.typekey.value, '"%n;');
+
+    return CString::concat(typekey, indent, '};%n;');
+}
+
 recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: CString): CString {
     %% Emit namespace 
     let ns = CString::concat(indent, 'namespace ', nsdecl.nsname, ' {%n;');
@@ -571,8 +586,9 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     let entities = nsdecl.entities.reduce<CString>(funcfwd_decls, fn(acc, tk, e) => {
         let typekey = tk.value;
         let emit_entity = emitEntityTypeDecl(e, typekey, ctx, full_indent);
+        let tinfo = emitTypeInfo(e.tinfo, e.fullns, full_indent);
 
-        return CString::concat(acc, indent, emit_entity);
+        return CString::concat(acc, indent, tinfo, emit_entity);
     });
 
     %% Emit sub-namespace declarations

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -553,17 +553,15 @@ function emitFunctionForwardDeclaration(decl: CPPAssembly::NamespaceFunctionDecl
     return CString::concat(first, '(', params, ') noexcept;%n;');
 }
 
-function emitTypeInfo(info: CPPAssembly::TypeInfo, ns: List<CString>, indent: CString): CString {
+function emitTypeInfo(info: CPPAssembly::TypeInfo, indent: CString): CString {
     let full_indent = CString::concat('    ', indent);
 
-    let resolved_typename = CString::concat(emitResolvedNamespace(ns, info.typekey.value), 'Type');
-
-    let base = CString::concat(indent, 'TypeInfoBase ', resolved_typename, ' = {%n;');
+    let base = CString::concat(indent, 'TypeInfoBase ', info.typekey, ' = {%n;');
     let id = CString::concat(base, full_indent, '.type_id = ', info.id.toCString(), ',%n;');
     let typesize = CString::concat(id, full_indent, '.type_size = ', info.typesize.toCString(), ', %n;');
     let slotsize = CString::concat(typesize, full_indent, '.slot_size = ', info.slotsize.toCString(), ',%n;');
     let ptrmask = CString::concat(slotsize, full_indent, '.ptr_mask = "', info.ptrmask, '",%n;');
-    let typekey = CString::concat(ptrmask, full_indent, '.typekey = "', info.typekey.value, '"%n;');
+    let typekey = CString::concat(ptrmask, full_indent, '.typekey = "', info.typekey, '"%n;');
 
     return CString::concat(typekey, indent, '};%n;');
 }
@@ -586,9 +584,8 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     let entities = nsdecl.entities.reduce<CString>(funcfwd_decls, fn(acc, tk, e) => {
         let typekey = tk.value;
         let emit_entity = emitEntityTypeDecl(e, typekey, ctx, full_indent);
-        let tinfo = emitTypeInfo(e.tinfo, e.fullns, full_indent);
 
-        return CString::concat(acc, indent, tinfo, emit_entity);
+        return CString::concat(acc, indent, emit_entity);
     });
 
     %% Emit sub-namespace declarations
@@ -605,8 +602,12 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {
+    let typeinfos = asm.typeinfos.reduce<CString>('', fn(acc, tkey, tinfo) => {
+        return CString::concat(acc, emitTypeInfo(tinfo, ''));
+    });
+    
     let ctx: Context = Context{CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''}, asm.nsdecls}; %% No known namespace yet
-    let ns_emission = asm.nsdecls.reduce<CString>('', fn(acc, nsname, nsdecl) => {
+    let ns_emission = asm.nsdecls.reduce<CString>(typeinfos, fn(acc, nsname, nsdecl) => {
         return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, ''));
     });
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -28,12 +28,12 @@ namespace UnicodeCharBuffer {
 }
 
 entity Context {
+    field asm: CPPAssembly::Assembly;
     field fullns_key: CPPAssembly::NamespaceKey; %% Main::Foo::Bar::...
     field fullns_list: List<CString>; %% ['Main', 'Foo', 'Bar', ...]
-    field nsdecls: Map<CString, CPPAssembly::NamespaceDecl>;
 
     method updateCurrentNamespace(new_ns: CPPAssembly::NamespaceKey, new_nsname: List<CString>): Context {
-        return Context{ new_ns, new_nsname, this.nsdecls };
+        return Context{ this.asm, new_ns, new_nsname };
     }
 }
 
@@ -356,7 +356,7 @@ function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFuncti
         resolvedName = name;
     }
 
-    let func = findNamespaceDecl(ctx.nsdecls, e.fullns).nsfuncs.get(e.ikey);
+    let func = findNamespaceDecl(ctx.asm.nsdecls, e.fullns).nsfuncs.get(e.ikey);
     let args = emitArgumentList(e.args, func.params, ctx);
 
     if(resolvedns !== '') {
@@ -374,11 +374,10 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CSt
     let ik = emitInvokeKey(op.resolvedTrgt, ctx);
     let tk = emitTypeKey(op.resolvedType.tkeystr, ctx);
 
-    %% this does NOT work for lookup namespace, would be better to get the method directly 
-    let nsdecl = findNamespaceDecl(ctx.nsdecls, ctx.fullns_list);
+    %% TODO: Need to figure out why this method isnt found in the asm...
     var params: CString;
-    if(nsdecl.staticmethods.has(op.resolvedTrgt)) {
-        let trgt = nsdecl.staticmethods.get(op.resolvedTrgt);
+    if(ctx.asm.staticmethods.has(op.resolvedTrgt)) {
+        let trgt = ctx.asm.staticmethods.get(op.resolvedTrgt);
         params = emitParameters(trgt.params, ctx);
     }
     else {
@@ -431,7 +430,7 @@ function emitConstructorStdExpression(e: CPPAssembly::ConstructorStdExpression, 
     %% Eventually might want to rework emitArgumentList to support constructors too 
     let emitargs =  CString::joinAll(', ', e.args.args.mapIdx<CString>(fn(av, ii) => {
         if(av)@none {
-            let ns_entity = findNamespaceDecl(ctx.nsdecls, e.fullns).entities.get(e.ctype.tkeystr);
+            let ns_entity = findNamespaceDecl(ctx.asm.nsdecls, e.fullns).entities.get(e.ctype.tkeystr);
             let member_defval = ns_entity.fields.get(ii).defaultval;
             if(member_defval)@none {
                 abort; %% Default value detected in transform, yet none provided for emission
@@ -566,13 +565,13 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context):
 }
 
 %% Will need to make some changes in case of actually having parameters (needs a comma after special this if params, not if none)
-function emitMethodDecl(m: CPPAssembly::MethodDecl, ctx: Context, indent: CString): CString {
+function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CString, ctx: Context, indent: CString): CString {
     let nctx = ctx.updateCurrentNamespace(m.declaredInNS, m.fullns);
     if(m)@<CPPAssembly::MethodDeclStatic> { %% Pass "this" ptr as first argument
         let name = m.name;
         let params = emitParameters(m.params, nctx);
         let rtype = emitTypeSignature(m.resultType, ctx);
-        let this_type = emitResolvedNamespace(nctx.fullns_list, m.declaredIn.value); %% Find necessary ns resolution for the structure we are declared in
+        let this_type = emitResolvedNamespace(nctx.fullns_list, declaredIn); %% Find necessary ns resolution for the structure we are declared in
 
         let pre = CString::concat(indent, 'const ', rtype, ' ', name);
         
@@ -635,7 +634,7 @@ function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, ctx: Context, 
     if(m)@<CPPAssembly::MethodDeclStatic> {
         let pre = m.name;
         let rtype = emitTypeSignature(m.resultType, ctx);
-        let this_type = emitResolvedNamespace(nctx.fullns_list, m.declaredIn.value);
+        let this_type = m.ikey.value; 
         let params = emitParameters(m.params, nctx);
         let first = CString::concat(indent, 'const ', rtype, ' ', pre, '(const ');
 
@@ -676,7 +675,7 @@ function emitTypeInfo(info: CPPAssembly::TypeInfo, fullns: List<CString>, indent
     return CString::concat(typekey, indent, '};%n;');
 }
 
-recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, typeinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, indent: CString): CString {
+recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: CString): CString {
     %% Emit namespace 
     let ns = CString::concat(indent, 'namespace ', nsdecl.nsname, ' {%n;');
     let full_indent = CString::concat('    ', indent);
@@ -691,24 +690,24 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     });
 
     %% Akward to add the this special first argument...
-    let methodfwd_decls = nsdecl.staticmethods.reduce<CString>(funcfwd_decls, fn(acc, ikey, decl) => {
-        return CString::concat(acc, emitMethodForwardDeclaration(decl, ctx, full_indent));
+    let methodfwd_decls = nsdecl.staticmethods.reduce<CString>(funcfwd_decls, fn(acc, ikey) => {
+        return CString::concat(acc, emitMethodForwardDeclaration(ctx.asm.staticmethods.get(ikey), ctx, full_indent));
     });
 
     %% All entities
     let entities = nsdecl.entities.reduce<CString>(methodfwd_decls, fn(acc, tk, e) => {
         let typekey = tk.value;
         let emit_entity = emitEntityTypeDecl(e, typekey, ctx, full_indent);
-        let entity_tinfo = emitTypeInfo(typeinfos.get(tk), e.fullns, full_indent);
+        let entity_tinfo = emitTypeInfo(ctx.asm.typeinfos.get(tk), e.fullns, full_indent);
         let entity_staticmethods = e.staticmethods.reduce<CString>('', fn(acc, m) => { 
-            return CString::concat(acc, emitMethodDecl(nsdecl.staticmethods.get(m), ctx, full_indent));
+            return CString::concat(acc, emitMethodDecl(ctx.asm.staticmethods.get(m), typekey, ctx, full_indent));
         });
         return CString::concat(acc, indent, entity_tinfo, emit_entity, entity_staticmethods);
     });
 
     %% Emit sub-namespace declarations
     let subns = nsdecl.subns.reduce<CString>(entities, fn(acc, name, decl) => {
-        return CString::concat(acc, emitNamespaceDecl[recursive](decl, ctx, typeinfos, full_indent));
+        return CString::concat(acc, emitNamespaceDecl[recursive](decl, ctx, full_indent));
     });
 
     %% Emit functions in current namespace
@@ -720,9 +719,9 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): CString {    
-    let ctx: Context = Context{CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''}, asm.nsdecls}; %% No known namespace yet
+    let ctx: Context = Context{ asm, CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''} }; %% No known namespace yet
     let ns_emission = asm.nsdecls.reduce<CString>('', fn(acc, nsname, nsdecl) => {
-        return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, asm.typeinfos, ''));
+        return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, ''));
     });
 
     %% TODO: Other non namespace functions

--- a/src/backend/cpp/transformer/cppprocessor.bsq
+++ b/src/backend/cpp/transformer/cppprocessor.bsq
@@ -4,7 +4,7 @@ declare namespace CPPEmitter {
 }
 
 %% Our API for emitting cpp
-public function main(asm: BSQAssembly::Assembly): CString {
+public function main(asm: BSQAssembly::Assembly): String {
     let tasm = CPPEmitter::CPPTransformer::convertBsqAsmToCpp(asm);
     let cppstr = CPPEmitter::emitAssembly(tasm);
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -98,8 +98,8 @@ namespace CPPTransformNameManager {
     }
 
     recursive function repeatCString(str: CString, n: Nat, acc: CString): CString {
-        if(n > 0) {
-            return repeatCString[recursive](str, n-1, CString::concat(acc, str));
+        if(n > 0n) {
+            return repeatCString[recursive](str, n - 1n, CString::concat(acc, str));
         }
         return acc;
     }
@@ -506,9 +506,9 @@ entity CPPTransformer {
                         if(tinfo.0.tag === CPPAssembly::Tag#Ref) {
                             return CPPAssembly::TypeInfo{ acc.id, acc.typesize + 8n, acc.slotsize + 1n, CString::concat(acc.ptrmask, '1'), acc.typekey, acc.tag };
                         }
-                        return CPPAssembly::TypeInfo{ acc.id, acc.typesize + 8n, acc.slotsize + 1n, CString::concat(acc.ptrmask, tinfo.0.ptrmask), acc.typekey, acc.tag };
+                        return CPPAssembly::TypeInfo{ acc.id, acc.typesize + tinfo.0.typesize, acc.slotsize + tinfo.0.slotsize, CString::concat(acc.ptrmask, tinfo.0.ptrmask), acc.typekey, acc.tag };
                     }
-                    %% Value type 
+                    %% Primitive type 
                     return CPPAssembly::TypeInfo{ acc.id, acc.typesize + tinfo.0.typesize, acc.slotsize + tinfo.0.slotsize, CString::concat(acc.ptrmask, tinfo.0.ptrmask), acc.typekey, acc.tag };
                 });
             }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -250,8 +250,14 @@ entity CPPTransformer {
 
             return CPPAssembly::PostfixAccessFromName{ baseType, name, declaredInType, ftype };
         }
+        if(op)@<BSQAssembly::PostfixInvokeStatic> { %% Invoke for static methods
+            let resolvedType = CPPAssembly::NominalTypeSignature{ CPPTransformNameManager::convertTypeKey($op.resolvedType.tkeystr) };
+            let resolvedTrgt = CPPTransformNameManager::convertInvokeKey($op.resolvedTrgt);
+            let args = this.transformArgumentInfo($op.argsinfo);
 
-        abort;
+            return CPPAssembly::PostfixInvokeStatic{ baseType, resolvedType, resolvedTrgt, args };
+        }
+        abort; %% TODO: Not implemented
     }
 
     method transformPostfixOp(pop: BSQAssembly::PostfixOp): CPPAssembly::PostfixOp {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -41,7 +41,7 @@ namespace CPPTransformNameManager {
         let subns = Map<CString, CPPAssembly::NamespaceDecl>{};
         let nsfuncs = Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>{};
         let entities = Map<CPPAssembly::TypeKey, CPPAssembly::EntityTypeDecl>{};
-        let staticmethods = Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclStatic>{};
+        let staticmethods = List<CPPAssembly::InvokeKey>{};
         return CPPAssembly::NamespaceDecl{ name, subns, entities, nsfuncs, staticmethods };
     }
 
@@ -409,7 +409,7 @@ entity CPPTransformer {
     %% I think we will need to keep these as their own separate entities (not converting methods to functions in the transformer)
     %% since we need to do some speical work on them maybe. I also dont like all the repition here (basically same method as funcdecl)
     %%
-    method transformStaticMethodDecl(m: BSQAssembly::MethodDeclStatic, declaredIn: CPPAssembly::TypeKey): CPPAssembly::MethodDeclStatic {
+    method transformStaticMethodDecl(m: BSQAssembly::MethodDeclStatic): CPPAssembly::MethodDeclStatic {
         let name = m.name.value;
         let nskey = CPPTransformNameManager::convertNamespaceKey(m.declaredInNS);
         let fullns = m.fullns;
@@ -418,7 +418,7 @@ entity CPPTransformer {
         let res = CPPTransformNameManager::convertTypeSignature(m.resultType);
         let body = this.transformBodyToCpp(m.body);
 
-        return CPPAssembly::MethodDeclStatic{ nskey, fullns, name, ikey, params, res, body, declaredIn };
+        return CPPAssembly::MethodDeclStatic{ nskey, fullns, name, ikey, params, res, body };
     }
 
     method transformNamespaceFunctionDeclToCpp(decl: BSQAssembly::NamespaceFunctionDecl): CPPAssembly::NamespaceFunctionDecl {
@@ -526,16 +526,10 @@ entity CPPTransformer {
             transformer_nsdecls, fn(acc, it, e) => {
                 let key = CPPTransformNameManager::convertTypeKey(it);
                 let cppentity = transformer.transformEntityDeclToCpp(e);
-                let cppstaticmethods = bsqasm.staticmethods.reduce<Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclStatic>>(
-                    Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclStatic>{},
-                    fn(acc, ikey, m) => acc.insert(CPPTransformNameManager::convertInvokeKey(ikey), transformer.transformStaticMethodDecl(m, key)));
-                
-                %% TODO: Support other method types!
-
                 let ns_insertion = CPPTransformNameManager::getNamespaceDeclMapping(cppentity.fullns, acc,
                     fn(decl) => {
                         let new_entities = decl.entities.insert(key, cppentity);
-                        return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, new_entities, decl.nsfuncs, cppstaticmethods };
+                        return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, new_entities, decl.nsfuncs, cppentity.staticmethods };
                     });
                 return ns_insertion;
         });
@@ -550,6 +544,11 @@ entity CPPTransformer {
             else {
                 abort; %% We will need to eventually support non-ns funcs
             }
+        });
+
+        let transformer_staticmethods = bsqasm.staticmethods.reduce<Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclStatic>>(
+            Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclStatic>{}, fn(acc, ikey, decl) => {
+                return acc.insert(CPPTransformNameManager::convertInvokeKey(ikey), transformer.transformStaticMethodDecl(decl));
         });
 
         let transformer_allmethods = bsqasm.allmethods.map<CPPAssembly::InvokeKey>(fn(ikey) => {
@@ -568,6 +567,7 @@ entity CPPTransformer {
         return CPPAssembly::Assembly {
             nsdecls = nsdecls_entities,
             allfuncs = transformer_allfuncs,
+            staticmethods = transformer_staticmethods,
             allmethods = transformer_allmethods, %% Might need to do someting like the funcs, being able to get the ns is nice
             typeinfos = generated_typeinfos
         };

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -450,23 +450,26 @@ entity CPPTransformer {
         }
         elif(asm.isPrimtitiveType(typekey)) {
             switch(typekey) {
-                'Int'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 0n, 8n, 1n, '0', 'Int' }; }
-                | 'Nat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 1n, 8n, 1n, '0', 'Nat' }; }
-                | 'BigInt'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 2n, 16n, 2n, '00', 'BigInt' }; }
-                | 'BigNat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 3n, 16n, 2n, '00', 'BigNat' }; }
-                | 'Float'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 4n, 8n, 1n, '0', 'Float' }; }
-                | 'Bool'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 5n, 8n, 1n, '0', 'Bool' }; }
-                | 'None'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 6n, 0n, 0n, '', 'None' }; }
+                'Int'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 0n, 8n, 1n, '0', cpptkey }; }
+                | 'Nat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 1n, 8n, 1n, '0', cpptkey }; }
+                | 'BigInt'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 2n, 16n, 2n, '00', cpptkey }; }
+                | 'BigNat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 3n, 16n, 2n, '00', cpptkey }; }
+                | 'Float'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 4n, 8n, 1n, '0', cpptkey }; }
+                | 'Bool'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 5n, 8n, 1n, '0', cpptkey }; }
+                | 'None'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 6n, 0n, 0n, '', cpptkey }; }
                 | _ => { abort; } %% Not supported by cpp emitter yet!
             }
         }
-        %% I think this could be weird. If we happen to have an entity as a field inside another entity we should put a 1 in ptrmask field...
         elif(asm.isNominalTypeConcrete(typekey)) {
             %% We can't compare tkey like primtives, so check if container has our tkey
-            if(asm.entities.has(typekey)) {
+            if(asm.entities.has(typekey)) { %% TODO: add a method
                 let m_entity = asm.entities.get(typekey);
                 let fields_tinfo = m_entity.fields.map<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(fn(f_tkey) => this.generateTypeInfo[recursive](f_tkey.declaredType.tkeystr, tinfos, asm) );
-                matchedType = fields_tinfo.reduce<CPPAssembly::TypeInfo>(CPPAssembly::TypeInfo{ 7n, 0n, 0n, '', m_entity.tkey.value }, fn(acc, tinfo) => {
+                matchedType = fields_tinfo.reduce<CPPAssembly::TypeInfo>(CPPAssembly::TypeInfo{ 7n, 0n, 0n, '', CPPTransformNameManager::convertTypeKey(m_entity.tkey) }, fn(acc, tinfo) => {
+                    let bsqtkey = BSQAssembly::TypeKey::from(tinfo.0.typekey.value);
+                    if(asm.isNominalTypeConcrete(bsqtkey) && !asm.isPrimtitiveType(bsqtkey)) { %% Pointer to other Concrete Nominal (non primitive) type
+                        return CPPAssembly::TypeInfo{ acc.id, acc.typesize + 8n, acc.slotsize + 1n, CString::concat(acc.ptrmask, '1'), acc.typekey }; 
+                    }
                     return CPPAssembly::TypeInfo{ acc.id, acc.typesize + tinfo.0.typesize, acc.slotsize + tinfo.0.slotsize, CString::concat(acc.ptrmask, tinfo.0.ptrmask), acc.typekey };
                 });
             }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -429,27 +429,51 @@ entity CPPTransformer {
         });
     }
 
-    method generateTypeInfo(e: BSQAssembly::EntityTypeDecl, i: Nat): CPPAssembly::TypeInfo {
-        let id: Nat = i;
-        let typesize: Nat = e.fields.size();
-        let slotsize: Nat = typesize * 8n; %% Everything in the GC is 8 byte aligned 
-        let ptrmask: CString = e.fields.reduce<CString>('', fn(acc, f) => {
-            %% I am thinking once we support entities having other entities as fields, we need to store these as ptrs ('1' instead of '0')
-            return CString::concat(acc, '0');
-        }); %% Ignoring strings for now
-        let typekey: CPPAssembly::TypeKey = CPPTransformNameManager::convertTypeKey(e.tkey);
+    method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, asm: BSQAssembly::Assembly): CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> { 
+        let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);
 
-        return CPPAssembly::TypeInfo{ id, typesize, slotsize, ptrmask, typekey };
+        var matchedType: CPPAssembly::TypeInfo;
+        if(tinfos.has(cpptkey)) {
+            return tinfos.get(cpptkey), tinfos;
+        }
+        elif(asm.isPrimtitiveType(typekey)) {
+            switch(typekey) {
+                'Int'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 0n, 8n, 1n, '0', 'Int' }; }
+                | 'Nat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 1n, 8n, 1n, '0', 'Nat' }; }
+                | 'BigInt'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 2n, 16n, 2n, '00', 'BigInt' }; }
+                | 'BigNat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 3n, 16n, 2n, '00', 'BigNat' }; }
+                | 'Float'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 4n, 8n, 1n, '0', 'Float' }; }
+                | 'Bool'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 5n, 8n, 1n, '0', 'Bool' }; }
+                | 'None'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 6n, 0n, 0n, '', 'None' }; }
+                | _ => { abort; } %% Not supported by cpp emitter yet!
+            }
+        }
+        elif(asm.isNominalTypeConcrete(typekey)) {
+            %% We can't compare tkey like primtives, so check if container has our tkey
+            if(asm.entities.has(typekey)) {
+                let m_entity = asm.entities.get(typekey);
+                let fields_tinfo = m_entity.fields.map<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(fn(f_tkey) => this.generateTypeInfo[recursive](f_tkey.declaredType.tkeystr, tinfos, asm) );
+                matchedType = fields_tinfo.reduce<CPPAssembly::TypeInfo>(CPPAssembly::TypeInfo{ 7n, 0n, 0n, '', m_entity.tkey.value }, fn(acc, tinfo) => {
+                    return CPPAssembly::TypeInfo{ acc.id, acc.typesize + tinfo.0.typesize, acc.slotsize + tinfo.0.slotsize, CString::concat(acc.ptrmask, tinfo.0.ptrmask), acc.typekey };
+                });
+            }
+            else {
+                abort; %% TODO: Add support for other types
+            }
+        }
+        else {
+            abort; %% Type is not known or generic!
+        }
+
+        return matchedType, tinfos.insert(CPPTransformNameManager::convertTypeKey(typekey), matchedType);
     }
 
-    method transformEntityDeclToCpp(e: BSQAssembly::EntityTypeDecl, i: Nat): CPPAssembly::EntityTypeDecl {
+    method transformEntityDeclToCpp(e: BSQAssembly::EntityTypeDecl): CPPAssembly::EntityTypeDecl {
         let declaredInNS = CPPTransformNameManager::convertNamespaceKey(e.declaredInNS);
         let tkey = CPPTransformNameManager::convertTypeKey(e.tkey); 
-        let tinfo = this.generateTypeInfo(e, i);
-
         let fields = this.transformMemberFieldDecl(e.fields);
 
-        return CPPAssembly::EntityTypeDecl{ declaredInNS, e.fullns, tkey, tinfo, fields };
+        return CPPAssembly::EntityTypeDecl{ declaredInNS, e.fullns, tkey, fields };
     }
 
     %*
@@ -475,16 +499,16 @@ entity CPPTransformer {
                         });
         });
 
-        let nsdecls_entities = bsqasm.entities.reduce<(|Nat, Map<CString, CPPAssembly::NamespaceDecl>|)>(
-            (|0n, transformer_nsdecls|), fn(acc, it, e) => {
+        let nsdecls_entities = bsqasm.entities.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
+            transformer_nsdecls, fn(acc, it, e) => {
                 let key = CPPTransformNameManager::convertTypeKey(it);
-                let cppentity = transformer.transformEntityDeclToCpp(e, acc.0);
-                let ns_insertion = CPPTransformNameManager::getNamespaceDeclMapping(cppentity.fullns, acc.1,
+                let cppentity = transformer.transformEntityDeclToCpp(e);
+                let ns_insertion = CPPTransformNameManager::getNamespaceDeclMapping(cppentity.fullns, acc,
                     fn(decl) => {
                         let new_entities = decl.entities.insert(key, cppentity);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, new_entities, decl.nsfuncs };
                     });
-                return (|acc.0 + 1n, ns_insertion|);
+                return ns_insertion;
         });
 
         let transformer_allfuncs = bsqasm.allfuncs.map<CPPAssembly::FunctionDecl>(fn(ikey) => {
@@ -499,9 +523,19 @@ entity CPPTransformer {
             }
         });
 
+        %% Will need to also handle abstract types
+        let generated_typeinfos = bsqasm.allconcretetypes.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>>(
+            Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>{}, fn(acc, tkey) => {
+                if(bsqasm.isPrimtitiveType(tkey)) {
+                    return acc; %% GC doesnt need primitive type info
+                }
+                return transformer.generateTypeInfo(tkey, acc, bsqasm).1;
+            });
+
         return CPPAssembly::Assembly {
-            nsdecls = nsdecls_entities.1,
-            allfuncs = transformer_allfuncs
+            nsdecls = nsdecls_entities,
+            allfuncs = transformer_allfuncs,
+            typeinfos = generated_typeinfos
         };
     }
 }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -41,7 +41,7 @@ namespace CPPTransformNameManager {
         let subns = Map<CString, CPPAssembly::NamespaceDecl>{};
         let nsfuncs = Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>{};
         let entities = Map<CPPAssembly::TypeKey, CPPAssembly::EntityTypeDecl>{};
-        let staticmethods = List<CPPAssembly::InvokeKey>{};
+        let staticmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>{};
         return CPPAssembly::NamespaceDecl{ name, subns, entities, nsfuncs, staticmethods };
     }
 
@@ -405,32 +405,22 @@ entity CPPTransformer {
         }
     }
 
-    %%
-    %% I think we will need to keep these as their own separate entities (not converting methods to functions in the transformer)
-    %% since we need to do some speical work on them maybe. I also dont like all the repition here (basically same method as funcdecl)
-    %%
-    method transformStaticMethodDecl(m: BSQAssembly::MethodDeclStatic): CPPAssembly::MethodDeclStatic {
-        let name = m.name.value;
-        let nskey = CPPTransformNameManager::convertNamespaceKey(m.declaredInNS);
-        let fullns = m.fullns;
-        let ikey = CPPTransformNameManager::convertInvokeKey(m.ikey);
-        let params = this.transformParameterDecl(m.params);
-        let res = CPPTransformNameManager::convertTypeSignature(m.resultType);
-        let body = this.transformBodyToCpp(m.body);
+    method transformAbstractInvokeDecl(decl: BSQAssembly::AbstractInvokeDecl): (|CPPAssembly::NamespaceKey, List<CString>, CString, CPPAssembly::InvokeKey,
+        List<CPPAssembly::ParameterDecl>, CPPAssembly::TypeSignature, CPPAssembly::BodyImplementation|) {
+        return
+            (|CPPTransformNameManager::convertNamespaceKey(decl.declaredInNS), decl.fullns, decl.name.value, 
+            CPPTransformNameManager::convertInvokeKey(decl.ikey), this.transformParameterDecl(decl.params),
+            CPPTransformNameManager::convertTypeSignature(decl.resultType), this.transformBodyToCpp(decl.body)|);
+    }
 
-        return CPPAssembly::MethodDeclStatic{ nskey, fullns, name, ikey, params, res, body };
+    method transformStaticMethodDecl(m: BSQAssembly::MethodDeclStatic): CPPAssembly::MethodDeclStatic {
+        let base = this.transformAbstractInvokeDecl(m);
+        return CPPAssembly::MethodDeclStatic{ base.0, base.1, base.2, base.3, base.4, base.5, base.6 };
     }
 
     method transformNamespaceFunctionDeclToCpp(decl: BSQAssembly::NamespaceFunctionDecl): CPPAssembly::NamespaceFunctionDecl {
-        let name = decl.name.value;
-        let nskey = CPPTransformNameManager::convertNamespaceKey(decl.declaredInNS);
-        let fullns = decl.fullns;
-        let ikey = CPPTransformNameManager::convertInvokeKey(decl.ikey);
-        let params = this.transformParameterDecl(decl.params);
-        let res = CPPTransformNameManager::convertTypeSignature(decl.resultType);
-        let body = this.transformBodyToCpp(decl.body);
-
-        return CPPAssembly::NamespaceFunctionDecl{nskey, fullns, name, ikey, params, res, body};
+        let base = this.transformAbstractInvokeDecl(decl);
+        return CPPAssembly::NamespaceFunctionDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6 };
     }   
 
     method transformMemberFieldDecl(fields: List<BSQAssembly::MemberFieldDecl>): List<CPPAssembly::MemberFieldDecl> {
@@ -470,6 +460,7 @@ entity CPPTransformer {
                 | _ => { abort; } %% Not supported by cpp emitter yet!
             }
         }
+        %% I think this could be weird. If we happen to have an entity as a field inside another entity we should put a 1 in ptrmask field...
         elif(asm.isNominalTypeConcrete(typekey)) {
             %% We can't compare tkey like primtives, so check if container has our tkey
             if(asm.entities.has(typekey)) {
@@ -526,10 +517,11 @@ entity CPPTransformer {
             transformer_nsdecls, fn(acc, it, e) => {
                 let key = CPPTransformNameManager::convertTypeKey(it);
                 let cppentity = transformer.transformEntityDeclToCpp(e);
+                let cppstaticmethods = cppentity.staticmethods.map<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>(fn(m) => (|m, cppentity.tkey|));
                 let ns_insertion = CPPTransformNameManager::getNamespaceDeclMapping(cppentity.fullns, acc,
                     fn(decl) => {
                         let new_entities = decl.entities.insert(key, cppentity);
-                        return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, new_entities, decl.nsfuncs, cppentity.staticmethods };
+                        return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, new_entities, decl.nsfuncs, cppstaticmethods };
                     });
                 return ns_insertion;
         });

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -10,26 +10,35 @@ namespace CPPTransformNameManager {
         return CPPAssembly::InvokeKey::from(ikey.value);
     }
 
-    %% This is mega broken. Will fix when I am not tired.... :)
     function convertTypeKey(tk: BSQAssembly::TypeKey): CPPAssembly::TypeKey {
-        switch(tk) {
-            'None'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('None'); }
-            | 'Bool'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('bool'); }
-            | 'Nat'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('__CoreCpp::Nat'); }
-            | 'Int'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('__CoreCpp::Int'); }
-            | 'BigNat'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('__CoreCpp::BigNat'); }
-            | 'BigInt'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('__CoreCpp::BigInt'); }
-            | 'Float'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('__CoreCpp::Float'); }
-            | _ => { return CPPAssembly::TypeKey::from(''); } 
+        switch(tk.value) {
+            'None' => { return CPPAssembly::TypeKey::from('None'); }
+            | 'Bool' => { return CPPAssembly::TypeKey::from('bool'); }
+            | 'Nat' => { return CPPAssembly::TypeKey::from('__CoreCpp::Nat'); }
+            | 'Int' => { return CPPAssembly::TypeKey::from('__CoreCpp::Int'); }
+            | 'BigNat' => { return CPPAssembly::TypeKey::from('__CoreCpp::BigNat'); }
+            | 'BigInt' => { return CPPAssembly::TypeKey::from('__CoreCpp::BigInt'); }
+            | 'Float' => { return CPPAssembly::TypeKey::from('__CoreCpp::Float'); }
+            | _ => { return CPPAssembly::TypeKey::from(tk.value); } 
+        }
+    }
+
+    %% Necessary when generating typeinfos for containers
+    function revertTypeKey(tk: CPPAssembly::TypeKey): BSQAssembly::TypeKey {
+        switch(tk.value) {
+            'None' => { return BSQAssembly::TypeKey::from('None'); }
+            | 'bool' => { return BSQAssembly::TypeKey::from('Bool'); }
+            | '__CoreCpp::Nat' => { return BSQAssembly::TypeKey::from('Nat'); }
+            | '__CoreCpp::Int' => { return BSQAssembly::TypeKey::from('Int'); }
+            | '__CoreCpp::BigNat' => { return BSQAssembly::TypeKey::from('BigNat'); }
+            | '__CoreCpp::BigInt' => { return BSQAssembly::TypeKey::from('BigInt'); }
+            | '__CoreCpp::Float' => { return BSQAssembly::TypeKey::from('Float'); }
+            | _ => { return BSQAssembly::TypeKey::from(tk.value); }
         }
     }
 
     function convertTypeSignature(tsig: BSQAssembly::TypeSignature): CPPAssembly::TypeSignature {
-        let tk = convertTypeKey(tsig.tkeystr); 
-        if(tk.value === '') { %% EhhhhhhhI dont relaly like returning '' here
-            return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from(tsig.tkeystr.value) };
-        }
-
+        let tk = convertTypeKey(tsig.tkeystr);
         return CPPAssembly::NominalTypeSignature{ tk };
     }
 
@@ -78,6 +87,14 @@ namespace CPPTransformNameManager {
             let tmp_map = nsdecls.delete(ns_name);
             return tmp_map.insert(ns_name, insertion(updated_nsdecl));
         }
+    }
+
+    function shouldBeRef(fields: List<BSQAssembly::MemberFieldDecl>, asm: BSQAssembly::Assembly): Bool {
+        let fieldsPrimitive = fields.reduce<Bool>(true, fn(acc, f) => acc && asm.isPrimtitiveType(f.declaredType.tkeystr));
+        if(fields.size() > 4n || !fieldsPrimitive) {
+            return true;
+        }
+        return false;
     }
 }
 
@@ -474,17 +491,24 @@ entity CPPTransformer {
                 let m_entity = asm.entities.get(typekey);
                 let fields_tinfo = m_entity.fields.map<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(fn(f_tkey) => this.generateTypeInfo[recursive](f_tkey.declaredType.tkeystr, tinfos, asm) );
 
-                %%
-                %% Here we need to do some sorta lookup to determine whether we need to do the silly first slot is type info and determineing refernce 
-                %% type stuff wiht the check that we are less that K=4 fields to become emitted as a refernce type. Not sure if this is done here, 
-                %% but we need to check the context in which our type is being used. If ref, the emission for decl is same as for value. If param needs
-                %% to be const foo*, if cpnstructor, needs to be foo*
-                %%
+                %% TODO: Add support for tagged types. If isNominalTypeConcept is true, then we find the field with largest nbumber of sub fiuelds and 
+                %% emit corresponding zeros as blank space. First slot is a 2 meaning its typeinfo
 
-                matchedType = fields_tinfo.reduce<CPPAssembly::TypeInfo>(CPPAssembly::TypeInfo{ 7n, 0n, 0n, '', CPPTransformNameManager::convertTypeKey(m_entity.tkey), CPPAssembly::Tag#Value }, fn(acc, tinfo) => {
-                    let bsqtkey = BSQAssembly::TypeKey::from(tinfo.0.typekey.value);
+                let isRef = CPPTransformNameManager::shouldBeRef(m_entity.fields, asm);
+                let tag = if(isRef) then CPPAssembly::Tag#Ref else CPPAssembly::Tag#Value;
+
+                matchedType = fields_tinfo.reduce<CPPAssembly::TypeInfo>(CPPAssembly::TypeInfo{ 7n, 0n, 0n, '', CPPTransformNameManager::convertTypeKey(m_entity.tkey), tag }, fn(acc, tinfo) => {
+                    let bsqtkey = CPPTransformNameManager::revertTypeKey(tinfo.0.typekey);
                     if(asm.isNominalTypeConcrete(bsqtkey) && !asm.isPrimtitiveType(bsqtkey)) { %% Pointer to other Concrete Nominal (non primitive) type
-                        return CPPAssembly::TypeInfo{ acc.id, acc.typesize + 8n, acc.slotsize + 1n, CString::concat(acc.ptrmask, '1'), acc.typekey, acc.tag }; 
+                        if(tinfo.0.tag === CPPAssembly::Tag#Ref) {
+                            return CPPAssembly::TypeInfo{ acc.id, acc.typesize + 8n, acc.slotsize + 1n, CString::concat(acc.ptrmask, '1'), acc.typekey, acc.tag };
+                        }
+                        elif(tinfo.0.tag === CPPAssembly::Tag#Value) {
+                            return CPPAssembly::TypeInfo{ acc.id, acc.typesize + 8n, acc.slotsize + 1n, CString::concat(acc.ptrmask, tinfo.0.ptrmask), acc.typekey, acc.tag };
+                        }
+                        else {
+                            abort; %% TODO: Add support for concept! (maybe not here, we need to check isNominalConcept whatever first)
+                        }
                     }
                     return CPPAssembly::TypeInfo{ acc.id, acc.typesize + tinfo.0.typesize, acc.slotsize + tinfo.0.slotsize, CString::concat(acc.ptrmask, tinfo.0.ptrmask), acc.typekey, acc.tag };
                 });

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -10,23 +10,27 @@ namespace CPPTransformNameManager {
         return CPPAssembly::InvokeKey::from(ikey.value);
     }
 
+    %% This is mega broken. Will fix when I am not tired.... :)
     function convertTypeKey(tk: BSQAssembly::TypeKey): CPPAssembly::TypeKey {
-        return CPPAssembly::TypeKey::from(tk.value);
+        switch(tk) {
+            'None'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('None'); }
+            | 'Bool'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('bool'); }
+            | 'Nat'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('__CoreCpp::Nat'); }
+            | 'Int'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('__CoreCpp::Int'); }
+            | 'BigNat'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('__CoreCpp::BigNat'); }
+            | 'BigInt'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('__CoreCpp::BigInt'); }
+            | 'Float'<BSQAssembly::TypeKey> => { return CPPAssembly::TypeKey::from('__CoreCpp::Float'); }
+            | _ => { return CPPAssembly::TypeKey::from(''); } 
+        }
     }
 
     function convertTypeSignature(tsig: BSQAssembly::TypeSignature): CPPAssembly::TypeSignature {
-        let tk = CPPAssembly::TypeKey::from(tsig.tkeystr.value);
-
-        %% We will want to eventually not use nominal type signature always, i think itll be obvious when to not use
-        switch(tk.value) {
-            'Int' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::Int') }; }
-            | 'BigInt' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::BigInt') }; }
-            | 'Nat' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::Nat') }; }
-            | 'BigNat' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::BigNat') }; }
-            | 'Float' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::Float') }; }
-            | 'Bool' => { return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('bool') }; }
-            | _ => { return CPPAssembly::NominalTypeSignature{ tk }; }
+        let tk = convertTypeKey(tsig.tkeystr); 
+        if(tk.value === '') { %% EhhhhhhhI dont relaly like returning '' here
+            return CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from(tsig.tkeystr.value) };
         }
+
+        return CPPAssembly::NominalTypeSignature{ tk };
     }
 
     function convertIdentifier(ident: BSQAssembly::Identifier): CPPAssembly::Identifier {
@@ -441,6 +445,10 @@ entity CPPTransformer {
         });
     }
 
+    %%
+    %% We will need to dynamicall determine whether we have a ref, value, or tagged type (abstract) and adjust accordingly.
+    %%
+
     method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, asm: BSQAssembly::Assembly): CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> { 
         let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);
 
@@ -450,13 +458,13 @@ entity CPPTransformer {
         }
         elif(asm.isPrimtitiveType(typekey)) {
             switch(typekey) {
-                'Int'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 0n, 8n, 1n, '0', cpptkey }; }
-                | 'Nat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 1n, 8n, 1n, '0', cpptkey }; }
-                | 'BigInt'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 2n, 16n, 2n, '00', cpptkey }; }
-                | 'BigNat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 3n, 16n, 2n, '00', cpptkey }; }
-                | 'Float'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 4n, 8n, 1n, '0', cpptkey }; }
-                | 'Bool'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 5n, 8n, 1n, '0', cpptkey }; }
-                | 'None'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 6n, 0n, 0n, '', cpptkey }; }
+                'None'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 6n, 0n, 0n, '', cpptkey, CPPAssembly::Tag#Value }; }
+                | 'Bool'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 5n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                | 'Nat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 1n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                | 'Int'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 0n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                | 'Nat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 1n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                | 'BigInt'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 2n, 16n, 2n, '00', cpptkey, CPPAssembly::Tag#Value }; }
+                | 'Float'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 4n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
                 | _ => { abort; } %% Not supported by cpp emitter yet!
             }
         }
@@ -465,13 +473,20 @@ entity CPPTransformer {
             if(asm.entities.has(typekey)) {
                 let m_entity = asm.entities.get(typekey);
                 let fields_tinfo = m_entity.fields.map<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(fn(f_tkey) => this.generateTypeInfo[recursive](f_tkey.declaredType.tkeystr, tinfos, asm) );
-                
-                matchedType = fields_tinfo.reduce<CPPAssembly::TypeInfo>(CPPAssembly::TypeInfo{ 7n, 0n, 0n, '', CPPTransformNameManager::convertTypeKey(m_entity.tkey) }, fn(acc, tinfo) => {
+
+                %%
+                %% Here we need to do some sorta lookup to determine whether we need to do the silly first slot is type info and determineing refernce 
+                %% type stuff wiht the check that we are less that K=4 fields to become emitted as a refernce type. Not sure if this is done here, 
+                %% but we need to check the context in which our type is being used. If ref, the emission for decl is same as for value. If param needs
+                %% to be const foo*, if cpnstructor, needs to be foo*
+                %%
+
+                matchedType = fields_tinfo.reduce<CPPAssembly::TypeInfo>(CPPAssembly::TypeInfo{ 7n, 0n, 0n, '', CPPTransformNameManager::convertTypeKey(m_entity.tkey), CPPAssembly::Tag#Value }, fn(acc, tinfo) => {
                     let bsqtkey = BSQAssembly::TypeKey::from(tinfo.0.typekey.value);
                     if(asm.isNominalTypeConcrete(bsqtkey) && !asm.isPrimtitiveType(bsqtkey)) { %% Pointer to other Concrete Nominal (non primitive) type
-                        return CPPAssembly::TypeInfo{ acc.id, acc.typesize + 8n, acc.slotsize + 1n, CString::concat(acc.ptrmask, '1'), acc.typekey }; 
+                        return CPPAssembly::TypeInfo{ acc.id, acc.typesize + 8n, acc.slotsize + 1n, CString::concat(acc.ptrmask, '1'), acc.typekey, acc.tag }; 
                     }
-                    return CPPAssembly::TypeInfo{ acc.id, acc.typesize + tinfo.0.typesize, acc.slotsize + tinfo.0.slotsize, CString::concat(acc.ptrmask, tinfo.0.ptrmask), acc.typekey };
+                    return CPPAssembly::TypeInfo{ acc.id, acc.typesize + tinfo.0.typesize, acc.slotsize + tinfo.0.slotsize, CString::concat(acc.ptrmask, tinfo.0.ptrmask), acc.typekey, acc.tag };
                 });
             }
             else {
@@ -554,9 +569,6 @@ entity CPPTransformer {
         %% Will need to also handle abstract types
         let generated_typeinfos = bsqasm.allconcretetypes.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>>(
             Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>{}, fn(acc, tkey) => {
-                if(bsqasm.isPrimtitiveType(tkey)) {
-                    return acc; %% GC doesnt need primitive type info
-                }
                 return transformer.generateTypeInfo(tkey, acc, bsqasm).1;
             });
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -409,7 +409,7 @@ entity CPPTransformer {
     %% I think we will need to keep these as their own separate entities (not converting methods to functions in the transformer)
     %% since we need to do some speical work on them maybe. I also dont like all the repition here (basically same method as funcdecl)
     %%
-    method transformStaticMethodDecl(m: BSQAssembly::MethodDeclStatic): CPPAssembly::MethodDeclStatic {
+    method transformStaticMethodDecl(m: BSQAssembly::MethodDeclStatic, declaredIn: CPPAssembly::TypeKey): CPPAssembly::MethodDeclStatic {
         let name = m.name.value;
         let nskey = CPPTransformNameManager::convertNamespaceKey(m.declaredInNS);
         let fullns = m.fullns;
@@ -418,15 +418,7 @@ entity CPPTransformer {
         let res = CPPTransformNameManager::convertTypeSignature(m.resultType);
         let body = this.transformBodyToCpp(m.body);
 
-        return CPPAssembly::MethodDeclStatic{ nskey, fullns, name, ikey, params, res, body };
-    }
-
-    method transformMethodDeclToCpp(m: BSQAssembly::MethodDecl): CPPAssembly::MethodDecl {
-        if(m)@<BSQAssembly::MethodDeclStatic> {
-            return this.transformStaticMethodDecl($m);
-        }
-
-        abort; %% TODO: Not implemented
+        return CPPAssembly::MethodDeclStatic{ nskey, fullns, name, ikey, params, res, body, declaredIn };
     }
 
     method transformNamespaceFunctionDeclToCpp(decl: BSQAssembly::NamespaceFunctionDecl): CPPAssembly::NamespaceFunctionDecl {
@@ -534,22 +526,16 @@ entity CPPTransformer {
             transformer_nsdecls, fn(acc, it, e) => {
                 let key = CPPTransformNameManager::convertTypeKey(it);
                 let cppentity = transformer.transformEntityDeclToCpp(e);
+                let cppstaticmethods = bsqasm.staticmethods.reduce<Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclStatic>>(
+                    Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclStatic>{},
+                    fn(acc, ikey, m) => acc.insert(CPPTransformNameManager::convertInvokeKey(ikey), transformer.transformStaticMethodDecl(m, key)));
+                
+                %% TODO: Support other method types!
+
                 let ns_insertion = CPPTransformNameManager::getNamespaceDeclMapping(cppentity.fullns, acc,
                     fn(decl) => {
                         let new_entities = decl.entities.insert(key, cppentity);
-                        return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, new_entities, decl.nsfuncs, decl.staticmethods };
-                    });
-                return ns_insertion;
-        });
-
-        let nsdecls_staticmethods = bsqasm.staticmethods.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            nsdecls_entities, fn(acc, it, m) => {
-                let ikey = CPPTransformNameManager::convertInvokeKey(it);
-                let cppmethod = transformer.transformStaticMethodDecl(m);
-                let ns_insertion = CPPTransformNameManager::getNamespaceDeclMapping(cppmethod.fullns, acc,
-                    fn(decl) => {
-                        let new_staticmethods = decl.staticmethods.insert(ikey, cppmethod);
-                        return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.entities, decl.nsfuncs, new_staticmethods };
+                        return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, new_entities, decl.nsfuncs, cppstaticmethods };
                     });
                 return ns_insertion;
         });
@@ -580,7 +566,7 @@ entity CPPTransformer {
             });
 
         return CPPAssembly::Assembly {
-            nsdecls = nsdecls_staticmethods,
+            nsdecls = nsdecls_entities,
             allfuncs = transformer_allfuncs,
             allmethods = transformer_allmethods, %% Might need to do someting like the funcs, being able to get the ns is nice
             typeinfos = generated_typeinfos

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -429,13 +429,27 @@ entity CPPTransformer {
         });
     }
 
-    method transformEntityDeclToCpp(e: BSQAssembly::EntityTypeDecl): CPPAssembly::EntityTypeDecl {
+    method generateTypeInfo(e: BSQAssembly::EntityTypeDecl, i: Nat): CPPAssembly::TypeInfo {
+        let id: Nat = i;
+        let typesize: Nat = e.fields.size();
+        let slotsize: Nat = typesize * 8n; %% Everything in the GC is 8 byte aligned 
+        let ptrmask: CString = e.fields.reduce<CString>('', fn(acc, f) => {
+            %% I am thinking once we support entities having other entities as fields, we need to store these as ptrs ('1' instead of '0')
+            return CString::concat(acc, '0');
+        }); %% Ignoring strings for now
+        let typekey: CPPAssembly::TypeKey = CPPTransformNameManager::convertTypeKey(e.tkey);
+
+        return CPPAssembly::TypeInfo{ id, typesize, slotsize, ptrmask, typekey };
+    }
+
+    method transformEntityDeclToCpp(e: BSQAssembly::EntityTypeDecl, i: Nat): CPPAssembly::EntityTypeDecl {
         let declaredInNS = CPPTransformNameManager::convertNamespaceKey(e.declaredInNS);
-        let tkey = CPPTransformNameManager::convertTypeKey(e.tkey);
-        
+        let tkey = CPPTransformNameManager::convertTypeKey(e.tkey); 
+        let tinfo = this.generateTypeInfo(e, i);
+
         let fields = this.transformMemberFieldDecl(e.fields);
 
-        return CPPAssembly::EntityTypeDecl{ declaredInNS, e.fullns, tkey, fields };
+        return CPPAssembly::EntityTypeDecl{ declaredInNS, e.fullns, tkey, tinfo, fields };
     }
 
     %*
@@ -461,15 +475,16 @@ entity CPPTransformer {
                         });
         });
 
-        let nsdecls_entities = bsqasm.entities.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            transformer_nsdecls, fn(acc, tk, e) => {
-                let key = CPPTransformNameManager::convertTypeKey(tk);
-                let cppentity = transformer.transformEntityDeclToCpp(e);
-                return CPPTransformNameManager::getNamespaceDeclMapping(cppentity.fullns, acc,
+        let nsdecls_entities = bsqasm.entities.reduce<(|Nat, Map<CString, CPPAssembly::NamespaceDecl>|)>(
+            (|0n, transformer_nsdecls|), fn(acc, it, e) => {
+                let key = CPPTransformNameManager::convertTypeKey(it);
+                let cppentity = transformer.transformEntityDeclToCpp(e, acc.0);
+                let ns_insertion = CPPTransformNameManager::getNamespaceDeclMapping(cppentity.fullns, acc.1,
                     fn(decl) => {
                         let new_entities = decl.entities.insert(key, cppentity);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, new_entities, decl.nsfuncs };
                     });
+                return (|acc.0 + 1n, ns_insertion|);
         });
 
         let transformer_allfuncs = bsqasm.allfuncs.map<CPPAssembly::FunctionDecl>(fn(ikey) => {
@@ -485,7 +500,7 @@ entity CPPTransformer {
         });
 
         return CPPAssembly::Assembly {
-            nsdecls = nsdecls_entities,
+            nsdecls = nsdecls_entities.1,
             allfuncs = transformer_allfuncs
         };
     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -41,7 +41,8 @@ namespace CPPTransformNameManager {
         let subns = Map<CString, CPPAssembly::NamespaceDecl>{};
         let nsfuncs = Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>{};
         let entities = Map<CPPAssembly::TypeKey, CPPAssembly::EntityTypeDecl>{};
-        return CPPAssembly::NamespaceDecl{ name, subns, entities, nsfuncs };
+        let staticmethods = Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclStatic>{};
+        return CPPAssembly::NamespaceDecl{ name, subns, entities, nsfuncs, staticmethods };
     }
 
     %% If ns decl does not exist for name insert, otherwise continue recursing until fullns is empty
@@ -63,7 +64,7 @@ namespace CPPTransformNameManager {
 
         %% Recursively process remaining names
         let subns = getNamespaceDeclMapping[recursive](remaining_ns_names, cur_nsdecl.subns, insertion);
-        let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, subns, cur_nsdecl.entities, cur_nsdecl.nsfuncs };
+        let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, subns, cur_nsdecl.entities, cur_nsdecl.nsfuncs, cur_nsdecl.staticmethods };
 
         %% We need to always update the nsdecls map as sub namespaces may change (this handles multiple nsdecls at same depth)
         if(!nsdecls.has(ns_name)) {
@@ -404,6 +405,30 @@ entity CPPTransformer {
         }
     }
 
+    %%
+    %% I think we will need to keep these as their own separate entities (not converting methods to functions in the transformer)
+    %% since we need to do some speical work on them maybe. I also dont like all the repition here (basically same method as funcdecl)
+    %%
+    method transformStaticMethodDecl(m: BSQAssembly::MethodDeclStatic): CPPAssembly::MethodDeclStatic {
+        let name = m.name.value;
+        let nskey = CPPTransformNameManager::convertNamespaceKey(m.declaredInNS);
+        let fullns = m.fullns;
+        let ikey = CPPTransformNameManager::convertInvokeKey(m.ikey);
+        let params = this.transformParameterDecl(m.params);
+        let res = CPPTransformNameManager::convertTypeSignature(m.resultType);
+        let body = this.transformBodyToCpp(m.body);
+
+        return CPPAssembly::MethodDeclStatic{ nskey, fullns, name, ikey, params, res, body };
+    }
+
+    method transformMethodDeclToCpp(m: BSQAssembly::MethodDecl): CPPAssembly::MethodDecl {
+        if(m)@<BSQAssembly::MethodDeclStatic> {
+            return this.transformStaticMethodDecl($m);
+        }
+
+        abort; %% TODO: Not implemented
+    }
+
     method transformNamespaceFunctionDeclToCpp(decl: BSQAssembly::NamespaceFunctionDecl): CPPAssembly::NamespaceFunctionDecl {
         let name = decl.name.value;
         let nskey = CPPTransformNameManager::convertNamespaceKey(decl.declaredInNS);
@@ -411,7 +436,6 @@ entity CPPTransformer {
         let ikey = CPPTransformNameManager::convertInvokeKey(decl.ikey);
         let params = this.transformParameterDecl(decl.params);
         let res = CPPTransformNameManager::convertTypeSignature(decl.resultType);
-
         let body = this.transformBodyToCpp(decl.body);
 
         return CPPAssembly::NamespaceFunctionDecl{nskey, fullns, name, ikey, params, res, body};
@@ -478,8 +502,9 @@ entity CPPTransformer {
         let declaredInNS = CPPTransformNameManager::convertNamespaceKey(e.declaredInNS);
         let tkey = CPPTransformNameManager::convertTypeKey(e.tkey); 
         let fields = this.transformMemberFieldDecl(e.fields);
+        let staticmethods = e.staticmethods.map<CPPAssembly::InvokeKey>(fn(m) => CPPTransformNameManager::convertInvokeKey(m));
 
-        return CPPAssembly::EntityTypeDecl{ declaredInNS, e.fullns, tkey, fields };
+        return CPPAssembly::EntityTypeDecl{ declaredInNS, e.fullns, tkey, fields, staticmethods };
     }
 
     %*
@@ -501,7 +526,7 @@ entity CPPTransformer {
                     return CPPTransformNameManager::getNamespaceDeclMapping(bsqdecl.fullns, acc,
                         fn(decl) => { 
                             let new_nsfuncs = decl.nsfuncs.insert(cppdecl.ikey, cppdecl);
-                            return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.entities, new_nsfuncs };
+                            return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.entities, new_nsfuncs, decl.staticmethods };
                         });
         });
 
@@ -512,7 +537,19 @@ entity CPPTransformer {
                 let ns_insertion = CPPTransformNameManager::getNamespaceDeclMapping(cppentity.fullns, acc,
                     fn(decl) => {
                         let new_entities = decl.entities.insert(key, cppentity);
-                        return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, new_entities, decl.nsfuncs };
+                        return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, new_entities, decl.nsfuncs, decl.staticmethods };
+                    });
+                return ns_insertion;
+        });
+
+        let nsdecls_staticmethods = bsqasm.staticmethods.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
+            nsdecls_entities, fn(acc, it, m) => {
+                let ikey = CPPTransformNameManager::convertInvokeKey(it);
+                let cppmethod = transformer.transformStaticMethodDecl(m);
+                let ns_insertion = CPPTransformNameManager::getNamespaceDeclMapping(cppmethod.fullns, acc,
+                    fn(decl) => {
+                        let new_staticmethods = decl.staticmethods.insert(ikey, cppmethod);
+                        return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.entities, decl.nsfuncs, new_staticmethods };
                     });
                 return ns_insertion;
         });
@@ -529,6 +566,10 @@ entity CPPTransformer {
             }
         });
 
+        let transformer_allmethods = bsqasm.allmethods.map<CPPAssembly::InvokeKey>(fn(ikey) => {
+            return CPPTransformNameManager::convertInvokeKey(ikey);
+        });
+
         %% Will need to also handle abstract types
         let generated_typeinfos = bsqasm.allconcretetypes.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>>(
             Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>{}, fn(acc, tkey) => {
@@ -539,8 +580,9 @@ entity CPPTransformer {
             });
 
         return CPPAssembly::Assembly {
-            nsdecls = nsdecls_entities,
+            nsdecls = nsdecls_staticmethods,
             allfuncs = transformer_allfuncs,
+            allmethods = transformer_allmethods, %% Might need to do someting like the funcs, being able to get the ns is nice
             typeinfos = generated_typeinfos
         };
     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -96,6 +96,13 @@ namespace CPPTransformNameManager {
         }
         return false;
     }
+
+    recursive function repeatCString(str: CString, n: Nat, acc: CString): CString {
+        if(n > 0) {
+            return repeatCString[recursive](str, n-1, CString::concat(acc, str));
+        }
+        return acc;
+    }
 }
 
 entity CPPTransformer {
@@ -462,11 +469,7 @@ entity CPPTransformer {
         });
     }
 
-    %%
-    %% We will need to dynamicall determine whether we have a ref, value, or tagged type (abstract) and adjust accordingly.
-    %%
-
-    method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, asm: BSQAssembly::Assembly): CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> { 
+    recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, asm: BSQAssembly::Assembly): CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> { 
         let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);
 
         var matchedType: CPPAssembly::TypeInfo;
@@ -479,7 +482,7 @@ entity CPPTransformer {
                 | 'Bool'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 5n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
                 | 'Nat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 1n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
                 | 'Int'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 0n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
-                | 'Nat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 1n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                | 'BigNat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 1n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
                 | 'BigInt'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 2n, 16n, 2n, '00', cpptkey, CPPAssembly::Tag#Value }; }
                 | 'Float'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 4n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
                 | _ => { abort; } %% Not supported by cpp emitter yet!
@@ -503,22 +506,39 @@ entity CPPTransformer {
                         if(tinfo.0.tag === CPPAssembly::Tag#Ref) {
                             return CPPAssembly::TypeInfo{ acc.id, acc.typesize + 8n, acc.slotsize + 1n, CString::concat(acc.ptrmask, '1'), acc.typekey, acc.tag };
                         }
-                        elif(tinfo.0.tag === CPPAssembly::Tag#Value) {
-                            return CPPAssembly::TypeInfo{ acc.id, acc.typesize + 8n, acc.slotsize + 1n, CString::concat(acc.ptrmask, tinfo.0.ptrmask), acc.typekey, acc.tag };
-                        }
-                        else {
-                            abort; %% TODO: Add support for concept! (maybe not here, we need to check isNominalConcept whatever first)
-                        }
+                        return CPPAssembly::TypeInfo{ acc.id, acc.typesize + 8n, acc.slotsize + 1n, CString::concat(acc.ptrmask, tinfo.0.ptrmask), acc.typekey, acc.tag };
                     }
+                    %% Value type 
                     return CPPAssembly::TypeInfo{ acc.id, acc.typesize + tinfo.0.typesize, acc.slotsize + tinfo.0.slotsize, CString::concat(acc.ptrmask, tinfo.0.ptrmask), acc.typekey, acc.tag };
                 });
             }
             else {
-                abort; %% TODO: Add support for other types
+                abort; %% TODO: Type not supported for typeinfo emission!
             }
         }
+        elif(asm.isNominalTypeConcept(typekey)) {
+            var maxFieldCount: Nat;
+            if(asm.concepts.has(typekey)) {
+                maxFieldCount = asm.concepts.reduce<Nat>(0n, fn(acc, c, e) => {
+                    let size = e.fields.size();
+                    return if(acc < size) then size else acc;
+                });
+            }
+            elif(asm.pconcepts.has(typekey)) {
+                abort; %% TODO: Add support for primtive concepts 
+            }
+            else {
+                abort; %% Not a concept
+            }
+            
+            %% ptrmask == '2' means it is storing type info
+            %% To prevent dataloss we fill the rest of slots with zeros, where the number of 
+            %% zeros represents the maximum number of possible fields in subtypes
+            let ptr_mask = CPPTransformNameManager::repeatCString('0', maxFieldCount, '2');
+            matchedType = CPPAssembly::TypeInfo{ 8n, 8n + (maxFieldCount * 8n), maxFieldCount + 1n, ptr_mask, CPPTransformNameManager::convertTypeKey(typekey), CPPAssembly::Tag#Tagged }; 
+        }
         else {
-            abort; %% Type is not known or generic!
+            abort; %% TODO: Type not supported for generating typeinfo!
         }
 
         return matchedType, tinfos.insert(CPPTransformNameManager::convertTypeKey(typekey), matchedType);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -462,9 +462,10 @@ entity CPPTransformer {
         }
         elif(asm.isNominalTypeConcrete(typekey)) {
             %% We can't compare tkey like primtives, so check if container has our tkey
-            if(asm.entities.has(typekey)) { %% TODO: add a method
+            if(asm.entities.has(typekey)) {
                 let m_entity = asm.entities.get(typekey);
                 let fields_tinfo = m_entity.fields.map<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(fn(f_tkey) => this.generateTypeInfo[recursive](f_tkey.declaredType.tkeystr, tinfos, asm) );
+                
                 matchedType = fields_tinfo.reduce<CPPAssembly::TypeInfo>(CPPAssembly::TypeInfo{ 7n, 0n, 0n, '', CPPTransformNameManager::convertTypeKey(m_entity.tkey) }, fn(acc, tinfo) => {
                     let bsqtkey = BSQAssembly::TypeKey::from(tinfo.0.typekey.value);
                     if(asm.isNominalTypeConcrete(bsqtkey) && !asm.isPrimtitiveType(bsqtkey)) { %% Pointer to other Concrete Nominal (non primitive) type

--- a/src/bsqir/asm/assembly.bsq
+++ b/src/bsqir/asm/assembly.bsq
@@ -367,6 +367,10 @@ entity Assembly {
         return this.lookupNominalTypeDeclaration(tkey)?<AbstractEntityTypeDecl>;
     }
 
+    method isPrimtitiveType(tkey: TypeKey): Bool {
+        return this.lookupNominalTypeDeclaration(tkey)?<PrimitiveEntityTypeDecl>;
+    }
+
     method isNominalTypeConcept(tkey: TypeKey): Bool {
         return this.lookupNominalTypeDeclaration(tkey)?<AbstractConceptTypeDecl>;
     }

--- a/src/cmd/analyzecpp.ts
+++ b/src/cmd/analyzecpp.ts
@@ -9,7 +9,7 @@ import * as path from "path";
 import { fileURLToPath } from 'url';
 import { PackageConfig } from "../frontend/build_decls.js";
 import { execSync } from "child_process";
-import { validateCStringLiteral } from "@bosque/jsbrex";
+import { validateStringLiteral } from "@bosque/jsbrex";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -81,7 +81,7 @@ function runCPPEmit(outname: string): string {
         Status.error("Failed to write bsqir info file!\n");
     }
 
-    return validateCStringLiteral(res.slice(1, -2));
+    return validateStringLiteral(res.slice(1, -2));
 }
 
 function buildBSQONAssembly(assembly: Assembly, rootasm: string, outname: string) {

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -1673,7 +1673,6 @@ class BSQIREmitter {
         }
     }
 
-    // We will assume for now all methods are static
     private emitMethodDecl(ns: FullyQualifiedNamespace, rcvrtype: [NominalTypeSignature, TemplateNameMapper | undefined], mdecl: MethodDecl, optmapping: TemplateNameMapper | undefined, fmt: BsqonCodeFormatter): string {
         const omap = this.mapper;
         if(optmapping !== undefined) {
@@ -1691,7 +1690,6 @@ class BSQIREmitter {
         const isThisRef = fmt.indent(`isThisRef=${mdecl.isThisRef}`); 
         fmt.indentPop();
 
-        // Not actually sure if this is quite correct, maybe we just emit always static?
         if(rcvrtype[1] === undefined && optmapping === undefined) {
             ret = `'${ikey}'<BSQAssembly::InvokeKey>`;
             this.allmethods.push(ret); 
@@ -1701,7 +1699,6 @@ class BSQIREmitter {
             assert(false, "Not Implemented -- Abstract, Virtual, and Override methods");
         }
 
-        // Need to figure out what this does
         this.mapper = omap;
 
         return ret;

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -621,12 +621,12 @@ class BSQIREmitter {
         const rtrgt = (this.tproc(exp.resolvedTrgt as TypeSignature) as NominalTypeSignature);
         const rdecl = exp.resolvedMethod as MethodDecl;
 
-        const tkey = EmitNameManager.generateTypeKey(rtrgt);
+        const tsig = this.emitTypeSignature(rtrgt);
         const ikey = EmitNameManager.generateTypeInvokeKey(rtrgt, exp.name);
 
         const arginfo = this.emitInvokeArgumentInfo(exp.name, rdecl.recursive, exp.args, exp.shuffleinfo, exp.resttype, exp.restinfo);
 
-        return `BSQAssembly::PostfixInvokeStatic{ ${opbase}, resolvedType='${tkey}'<BSQAssembly::TypeKey>, resolvedTrgt='${ikey}'<BSQAssembly::InvokeKey>, arginfo=${arginfo} }`;
+        return `BSQAssembly::PostfixInvokeStatic{ ${opbase}, resolvedType=${tsig}, resolvedTrgt='${ikey}'<BSQAssembly::InvokeKey>, argsinfo=${arginfo} }`;
     }
 
     private emitVirtualPostfixInvoke(exp: PostfixInvoke): string {
@@ -1673,18 +1673,33 @@ class BSQIREmitter {
         }
     }
 
+    // We will assume for now all methods are static
     private emitMethodDecl(ns: FullyQualifiedNamespace, rcvrtype: [NominalTypeSignature, TemplateNameMapper | undefined], mdecl: MethodDecl, optmapping: TemplateNameMapper | undefined, fmt: BsqonCodeFormatter): string {
         const omap = this.mapper;
         if(optmapping !== undefined) {
             this.mapper = TemplateNameMapper.tryMerge(rcvrtype[1], optmapping);
         }
 
-        //TODO: handle emit here...
+        fmt.indentPush();
+        let ret: string = "";
+        const nskey = EmitNameManager.generateNamespaceKey(ns);
+        const ikey = EmitNameManager.generateNamespaceInvokeKey(ns, mdecl.name);          
+        const ibase = this.emitExplicitInvokeDecl(mdecl, nskey, ikey, fmt);
+        const isThisRef = fmt.indent(`isThisRef=${mdecl.isThisRef}`); 
+        fmt.indentPop();
 
+        // Not actually sure if this is quite correct, maybe we just emit always static?
+        if(rcvrtype[1] === undefined && optmapping === undefined) {
+            ret = `'${ikey}'<BSQAssembly::InvokeKey>`;
+            this.allmethods.push(ret); 
+            this.staticmethods.push(`'${ikey}'<BSQAssembly::InvokeKey> => BSQAssembly::MethodDeclStatic{ ${ibase}, ${fmt.nl()}${isThisRef}${fmt.nl() + fmt.indent("}")}`);
+        }
+
+        // Need to figure out what this does
         this.mapper = omap;
 
-        assert(false, "Not implemented -- emitMethodDecl");
-    }
+        return ret;
+     }
 
     private emitMethodDecls(ns: FullyQualifiedNamespace, rcvr: [NominalTypeSignature, TemplateNameMapper | undefined], mdecls: [MethodDecl, MethodInstantiationInfo | undefined][], fmt: BsqonCodeFormatter): [string[], string[], string[], string[]] {
         let decls: string[] = [];
@@ -1711,7 +1726,7 @@ class BSQIREmitter {
         //TODO: need to split these up based on the kind of method (abstract, virtual, override, static)
         //
 
-        return [decls, [], [], []];
+        return [[], [], [], decls];
     }
 
     private emitConstMemberDecls(ns: FullyQualifiedNamespace, declInType: NominalTypeSignature, decls: ConstMemberDecl[]) {

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -1682,8 +1682,11 @@ class BSQIREmitter {
 
         fmt.indentPush();
         let ret: string = "";
+
+        const declaredIn = rcvrtype[0].tkeystr;
         const nskey = EmitNameManager.generateNamespaceKey(ns);
-        const ikey = EmitNameManager.generateNamespaceInvokeKey(ns, mdecl.name);          
+        const ikey = `${declaredIn}::${mdecl.name}`; // Avoids ns flattening
+
         const ibase = this.emitExplicitInvokeDecl(mdecl, nskey, ikey, fmt);
         const isThisRef = fmt.indent(`isThisRef=${mdecl.isThisRef}`); 
         fmt.indentPop();

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -1694,6 +1694,9 @@ class BSQIREmitter {
             this.allmethods.push(ret); 
             this.staticmethods.push(`'${ikey}'<BSQAssembly::InvokeKey> => BSQAssembly::MethodDeclStatic{ ${ibase}, ${fmt.nl()}${isThisRef}${fmt.nl() + fmt.indent("}")}`);
         }
+        else {
+            assert(false, "Not Implemented -- Abstract, Virtual, and Override methods");
+        }
 
         // Need to figure out what this does
         this.mapper = omap;

--- a/test/cppoutput/cppemit_nf.ts
+++ b/test/cppoutput/cppemit_nf.ts
@@ -29,7 +29,7 @@ const bsq_min_bigint: string = "-85070591730234615865843651857942052863";
 
 import { tmpdir } from 'node:os';
 import { BSQIREmitter } from "../../src/frontend/bsqir_emit.js";
-import { validateCStringLiteral } from "@bosque/jsbrex";
+import { validateStringLiteral } from "@bosque/jsbrex";
 
 function buildMainCode(assembly: Assembly, outname: string): string | undefined {
     const iim = InstantiationPropagator.computeInstantiations(assembly, "Main");
@@ -53,7 +53,7 @@ function buildMainCode(assembly: Assembly, outname: string): string | undefined 
         return undefined;
     }
 
-    return validateCStringLiteral(res.slice(1, -2));
+    return validateStringLiteral(res.slice(1, -2));
 }
 
 function generateCPPFile(cpp: string, outdir: string): boolean {    

--- a/test/cppoutput/mcall_exps/simple_resolved.test.js
+++ b/test/cppoutput/mcall_exps/simple_resolved.test.js
@@ -5,13 +5,13 @@ import { describe, it } from "node:test";
 
 describe ("Exec -- entity methods", () => {
     it("should exec simple entity methods", function () {
-        runMainCode('entity Foo { field f: Int; method foo(): Int { return this.f; }} public function main(): Int { return Foo{3i}.foo(); }', "3i"); 
-        runMainCode('entity Foo { field f: Int; method foo(): Int { return this.f; }} public function main(): Int { let x = Foo{3i}; return x.foo(); }', "3i"); 
+        runMainCode('entity Foo { field f: Int; method foo(): Int { return this.f; }} public function main(): Int { return Foo{3i}.foo(); }', "3_i"); 
+        runMainCode('entity Foo { field f: Int; method foo(): Int { return this.f; }} public function main(): Int { let x = Foo{3i}; return x.foo(); }', "3_i"); 
     });
 
     it("should exec simple entity methods with args", function () {
-        runMainCode('entity Foo { field f: Int; method foo(x: Int): Int { return this.f + x; }} public function main(): Int { return Foo{3i}.foo(1i); }', "4i"); 
-        runMainCode('entity Foo { field f: Int; method foo(x: Int = 1i): Int { return this.f + x; }} public function main(): Int { let x = Foo{3i}; return x.foo(); }', "4i"); 
+        runMainCode('entity Foo { field f: Int; method foo(x: Int): Int { return this.f + x; }} public function main(): Int { return Foo{3i}.foo(1i); }', "4_i"); 
+        runMainCode('entity Foo { field f: Int; method foo(x: Int = 1i): Int { return this.f + x; }} public function main(): Int { let x = Foo{3i}; return x.foo(); }', "4_i"); 
     });
 
 /*

--- a/test/cppoutput/mcall_exps/simple_resolved.test.js
+++ b/test/cppoutput/mcall_exps/simple_resolved.test.js
@@ -1,0 +1,37 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";
+
+describe ("Exec -- entity methods", () => {
+    it("should exec simple entity methods", function () {
+        runMainCode('entity Foo { field f: Int; method foo(): Int { return this.f; }} public function main(): Int { return Foo{3i}.foo(); }', "3i"); 
+        runMainCode('entity Foo { field f: Int; method foo(): Int { return this.f; }} public function main(): Int { let x = Foo{3i}; return x.foo(); }', "3i"); 
+    });
+
+    it("should exec simple entity methods with args", function () {
+        runMainCode('entity Foo { field f: Int; method foo(x: Int): Int { return this.f + x; }} public function main(): Int { return Foo{3i}.foo(1i); }', "4i"); 
+        runMainCode('entity Foo { field f: Int; method foo(x: Int = 1i): Int { return this.f + x; }} public function main(): Int { let x = Foo{3i}; return x.foo(); }', "4i"); 
+    });
+
+/*
+    it("should exec simple entity methods with template", function () {
+        runMainCode('entity Foo { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} public function main(): Bool { let x = Foo{3i}; return x.foo<Nat>(); }', "false"); 
+        runMainCode('entity Foo { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} public function main(): Bool { let x = Foo{3i}; return x.foo<Int>(); }', "true"); 
+    });
+
+    it("should exec simple entity methods with type template", function () {
+        runMainCode('entity Foo<T> { field f: T; method foo(x: T): T { return if (true) then x else this.f; }} public function main(): Int { let x = Foo<Int>{3i}; return x.foo(2i); }', "2i"); 
+    });
+
+    it("should exec simple entity methods with both template", function () {
+        runMainCode('entity Foo<T> { field f: T; method foo<U>(): Bool { return this.f?<U>; }} public function main(): Bool { let x = Foo<Int>{3i}; return x.foo<Nat>(); }', "false"); 
+        runMainCode('entity Foo<T> { field f: T; method foo<U>(): Bool { return this.f?<U>; }} public function main(): Bool { let x = Foo<Int>{3i}; return x.foo<Int>(); }', "true"); 
+    });
+
+    it("should exec simple entity methods with both template and more", function () {
+        runMainCode('entity Foo<T> { field f: T; method foo<U>(u: U): U { return if (this.f)@<U> then $_ else u; }} public function main(): Nat { let x = Foo<Int>{3i}; return x.foo<Nat>(3n); }', "3n"); 
+        runMainCode('entity Foo<T> { field f: T; method foo<U>(t: T): T { return if (t)<U> then t else this.f; }} public function main(): Int { let x = Foo<Int>{3i}; return x.foo<Int>(3i); }', "3i"); 
+    });
+*/
+});

--- a/test/cppoutput/mcall_exps/simple_resolved.test.js
+++ b/test/cppoutput/mcall_exps/simple_resolved.test.js
@@ -14,6 +14,10 @@ describe ("Exec -- entity methods", () => {
         runMainCode('entity Foo { field f: Int; method foo(x: Int = 1i): Int { return this.f + x; }} public function main(): Int { let x = Foo{3i}; return x.foo(); }', "4_i"); 
     });
 
+    it("should exec simple entity methods with named args", function () {
+        runMainCode('entity Foo { field f: Int; method foo(x: Int, y: Int): Int { return this.f + x + y; }} public function main(): Int { return Foo{3i}.foo(x=1i,y=2i); }', "6_i"); 
+    });
+
 /*
     it("should exec simple entity methods with template", function () {
         runMainCode('entity Foo { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} public function main(): Bool { let x = Foo{3i}; return x.foo<Nat>(); }', "false"); 


### PR DESCRIPTION
We are now able to emit cpp code for static methods and these use a special unicode `this` to avoid any naming conflicts. We also emit the corresponding typeinfo with our entity emission.

For example, this Bosque code:
```
entity Foo { 
    field f: Int; 
    field o: Int;
    method foo(x: Int, y: Int = 1i): Int { 
        return this.f + this.o + x + y; 
    }
} 

public function main(): Int { 
    return Foo{3i, 2i}.foo(3i); 
}
```

Emits:
```
namespace Main {
    struct Foo;
    __CoreCpp::Int main() noexcept;
    const __CoreCpp::Int foo(const Foo tᖺis, __CoreCpp::Int x, __CoreCpp::Int y) noexcept;
    TypeInfoBase FooType = {
        .type_id = 7,
        .type_size = 16, 
        .slot_size = 2,
        .ptr_mask = "00",
        .typekey = "Main::Foo"
    };
    struct Foo{ 
        const __CoreCpp::Int f;
        const __CoreCpp::Int o;
    };
    const __CoreCpp::Int foo(const Foo tᖺis, __CoreCpp::Int x, __CoreCpp::Int y) noexcept {
        return (((tᖺis.f + tᖺis.o) + x) + y);
    }
    __CoreCpp::Int main() noexcept  {
        return foo(Foo{ 3_i, 2_i }, 3_i, 1_i);
    }
}
```