### PR TITLE
Cpp Emit Non-Binding ITests and Option<T>

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -36,7 +36,6 @@ ITestType { field ttype: TypeSignature; }
 | ITestFail { }
 ;
 
-
 datatype ArgumentValue using {
     field exp: Expression;
 }
@@ -205,6 +204,9 @@ PostfixAccessFromName {
     field resolvedType: NominalTypeSignature;
     field resolvedTrgt: InvokeKey;
     field args: ArgumentList;
+}
+| PostfixIsTest {
+    field ttest: ITest;
 }
 ;
 

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -127,6 +127,9 @@ entity AccessVariableExpression provides Expression {
     field layouttype: TypeSignature;
 }
 
+entity LiteralNoneExpression provides Expression {
+}
+
 entity LiteralSimpleExpression provides Expression {
     field value: CString;
 }
@@ -210,6 +213,21 @@ concept ConstructorPrimaryExpression provides ConstructorExpression {
 entity ConstructorStdExpression provides ConstructorPrimaryExpression {
     field fullns: List<CString>;
 }
+
+datatype ConstructorPrimarySpecialConstructableExpression provides ConstructorPrimaryExpression 
+of
+ConstructorPrimarySpecialSomeExpression {
+    field ofttype: TypeSignature;
+}
+| ConstructorPrimarySpecialOkExpression { %% TODO: Not Implemented
+    field ofttype: TypeSignature;
+    field ofetype: TypeSignature;
+}
+| ConstructorPrimarySpecialFailExpression { %% TODO: Not Implemented
+    field ofttype: TypeSignature;
+    field ofetype: TypeSignature;
+}
+;
 
 datatype PostfixOperation using {
     field baseType: TypeSignature;

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -50,16 +50,36 @@ entity ArgumentList {
     field args: List<Option<ArgumentValue>>; %% if none get default val in emitter
 }
 
-entity IfStatement provides Statement {
+datatype IfStatement provides Statement using {
     field cond: Expression;
     field trueBlock: BlockStatement;
 }
+of
+IfSimpleStatement { }
+| IfTestStatement {
+    field itest: ITest;
+}
+| IfBinderStatement { %% TODO: Not implemented
+    field itest: ITest;
+    field binder: BinderInfo;
+}
+;
 
-entity IfElseStatement provides Statement {
+datatype IfElseStatement provides Statement using {
     field cond: Expression;
     field trueBlock: BlockStatement;
     field falseBlock: BlockStatement;
 }
+of
+IfElseSimpleStatement { }
+| IfElseTestStatement { 
+    field itest: ITest;
+}
+| IfElseBinderStatement {
+    field itest: ITest;
+    field binder: BinderInfo;
+}
+;
 
 entity IfElifElseStatement provides Statement {
     field ifcond: Expression;

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -242,6 +242,9 @@ entity Assembly {
 
     %% Let's work with type id's for the time being
     method areTypesSame(t1: TypeSignature, t2: TypeSignature): Bool {
-        return t1.tkeystr === t2.tkeystr;
+        if(!this.typeinfos.has(t1.tkeystr) || ! this.typeinfos.has(t2.tkeystr)) {
+            abort; %% No typeinfo found for TypeSignature!
+        }
+        return this.typeinfos.get(t1.tkeystr).id == this.typeinfos.get(t2.tkeystr).id;
     }
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -77,6 +77,12 @@ entity EntityTypeDecl provides AbstractEntityTypeDecl{
     field fields: List<MemberFieldDecl>;
 }
 
+datatype ConstructableTypeDecl provides AbstractEntityTypeDecl
+of
+SomeTypeDecl { field oftype: TypeSignature; }
+| MapEntryTypeDecl { field ktype: NominalTypeSignature; field vtype: TypeSignature; }
+; %% TODO: Other ConstructableTypeDecls!
+
 entity PrimitiveEntityTypeDecl provides AbstractEntityTypeDecl {
 }
 

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -77,12 +77,19 @@ entity EntityTypeDecl provides AbstractEntityTypeDecl{
     field fields: List<MemberFieldDecl>;
 }
 
+entity PrimitiveEntityTypeDecl provides AbstractEntityTypeDecl {
+}
+
 entity DatatypeMemberEntityTypeDecl provides AbstractEntityTypeDecl {
     field fields: List<MemberFieldDecl>;
     field parentTypeDecl: NominalTypeSignature;
 }
 
-entity DatatypeTypeDecl provides AbstractNominalTypeDecl {
+concept AbstractConceptTypeDecl provides AbstractNominalTypeDecl {
+    field subtypes: List<TypeKey>;
+}
+
+entity DatatypeTypeDecl provides AbstractConceptTypeDecl {
     field fields: List<MemberFieldDecl>;
     field associatedMemberEntityDecls: List<NominalTypeSignature>;
 }
@@ -168,10 +175,37 @@ entity Assembly {
     field overmethods: Map<InvokeKey, MethodDeclOverride>;
 
     field entities: Map<TypeKey, EntityTypeDecl>;
+    field primitives: Map<TypeKey, PrimitiveEntityTypeDecl>;
     field datamembers: Map<TypeKey, DatatypeMemberEntityTypeDecl>;
 
     field datatypes: Map<TypeKey, DatatypeTypeDecl>;
 
     field allmethods: List<InvokeKey>;
     field typeinfos: Map<TypeKey, TypeInfo>;
+
+    method lookupNominalTypeDeclaration(tkey: TypeKey): AbstractNominalTypeDecl {
+        if(this.entities.has(tkey)) {
+            return this.entities.get(tkey);
+        }
+        elif(this.primitives.has(tkey)) {
+            return this.primitives.get(tkey);
+        }
+        elif(this.datamembers.has(tkey)) {
+            return this.datamembers.get(tkey);
+        }
+        elif(this.datatypes.has(tkey)) {
+            return this.datatypes.get(tkey);
+        }
+        else {
+            abort; %% Non suported typekey!
+        }
+    }
+
+    method isNominalTypeConcrete(tkey: TypeKey): Bool {
+        return this.lookupNominalTypeDeclaration(tkey)?<AbstractEntityTypeDecl>;
+    }
+
+    method areTypesSame(t1: TypeSignature, t2: TypeSignature): Bool {
+        return t1.tkeystr === t2.tkeystr;
+    }
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -12,7 +12,7 @@ type NamespaceKey = CString of CPPAssembly::namespaceKeyRE; %%Core is implicit h
 const basicNominalTypeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}'::')?[_a-zA-Z0-9'::']+('<'.+'>')?/c;
 const nominalTypeKeyRE: CRegex = /(${CPPAssembly::basicNominalTypeKeyRE})/c; %% Will need to handle special scoped type key?
 
-const typeKeyRE: CRegex = /${CPPAssembly::nominalTypeKeyRE}/c;
+const typeKeyRE: CRegex = /${CPPAssembly::nominalTypeKeyRE}?/c;
 type TypeKey = CString of CPPAssembly::typeKeyRE;
 
 %% Optional '<' * '>' allows support for resolved templates on functions or methods
@@ -240,6 +240,7 @@ entity Assembly {
         return this.lookupNominalTypeDeclaration(tkey)?<AbstractEntityTypeDecl>;
     }
 
+    %% Let's work with type id's for the time being
     method areTypesSame(t1: TypeSignature, t2: TypeSignature): Bool {
         return t1.tkeystr === t2.tkeystr;
     }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -184,6 +184,8 @@ entity NamespaceDecl {
 
     field datatypes: List<TypeKey>;
 
+    field pconcepts: List<TypeKey>;
+
     field staticmethods: List<(|InvokeKey, TypeKey|)>; %% Tuple is convient for fwd decls here
     field virtmethods: List<(|InvokeKey, TypeKey|)>;
     field absmethods: List<(|InvokeKey, TypeKey|)>;
@@ -238,6 +240,10 @@ entity Assembly {
 
     method isNominalTypeConcrete(tkey: TypeKey): Bool {
         return this.lookupNominalTypeDeclaration(tkey)?<AbstractEntityTypeDecl>;
+    }
+
+    method isPrimtitiveType(tkey: TypeKey): Bool {
+        return this.primitives.has(tkey);
     }
 
     %% Let's work with type id's for the time being

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -89,6 +89,29 @@ concept AbstractConceptTypeDecl provides AbstractNominalTypeDecl {
     field subtypes: List<TypeKey>;
 }
 
+datatype PrimitiveConceptTypeDecl provides AbstractConceptTypeDecl 
+of
+OptionTypeDecl { 
+    field oftype: TypeSignature; 
+    field someType: TypeSignature;
+}
+| ResultTypeDecl { %% TODO: Not implemented!
+    field ttype: TypeSignature; 
+    field etype: TypeSignature;
+
+    field okType: TypeSignature;
+    field failType: TypeSignature;
+}
+| APIResultTypeDecl { %% TODO: Not Implemented!
+    field ttype: TypeSignature;
+
+    field errorType: TypeSignature;
+    field failedType: TypeSignature;
+    field rejectedType: TypeSignature;
+    field successType: TypeSignature;
+}
+;
+
 entity DatatypeTypeDecl provides AbstractConceptTypeDecl {
     field fields: List<MemberFieldDecl>;
     field associatedMemberEntityDecls: List<NominalTypeSignature>;
@@ -174,11 +197,14 @@ entity Assembly {
     field absmethods: Map<InvokeKey, MethodDeclAbstract>;
     field overmethods: Map<InvokeKey, MethodDeclOverride>;
 
-    field entities: Map<TypeKey, EntityTypeDecl>;
     field primitives: Map<TypeKey, PrimitiveEntityTypeDecl>;
+
+    field entities: Map<TypeKey, EntityTypeDecl>;
     field datamembers: Map<TypeKey, DatatypeMemberEntityTypeDecl>;
 
     field datatypes: Map<TypeKey, DatatypeTypeDecl>;
+
+    field pconcepts: Map<TypeKey, PrimitiveConceptTypeDecl>; %% Note: Currently only supports option
 
     field allmethods: List<InvokeKey>;
     field typeinfos: Map<TypeKey, TypeInfo>;
@@ -195,6 +221,9 @@ entity Assembly {
         }
         elif(this.datatypes.has(tkey)) {
             return this.datatypes.get(tkey);
+        }
+        elif(this.pconcepts.has(tkey)) {
+            return this.pconcepts.get(tkey);
         }
         else {
             abort; %% Non suported typekey!

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -6,6 +6,8 @@
 #include <csetjmp>
 #include <variant>
 
+namespace __CoreCpp {
+
 // Note: This will be deleted when the GC is merged, only exists so emitted cpp still compiles
 struct FieldOffsetInfo 
 {
@@ -24,7 +26,13 @@ struct TypeInfoBase
     const FieldOffsetInfo* vtable; // Will need to add to gc
 };
 
-namespace __CoreCpp {
+template <size_t K>
+class Boxed {
+    TypeInfoBase* typeinfo;
+    uint8_t data[K];
+};
+
+typedef uint64_t None;
 
 #define MAX_BSQ_INT ((int64_t(1) << 62) - 1)
 #define MIN_BSQ_INT (-(int64_t(1) << 62) + 1) 
@@ -396,9 +404,6 @@ public:
     friend constexpr bool operator!=(const Float& lhs, const Float& rhs) noexcept { return !(lhs == rhs); }
     friend constexpr bool operator<=(const Float& lhs, const Float& rhs) noexcept { return !(lhs > rhs); }
     friend constexpr bool operator>=(const Float& lhs, const Float& rhs) noexcept { return !(lhs < rhs); }
-};
-
-class None {
 };
 
 // Useful for keeping track of path in tree iteration

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -28,8 +28,14 @@ struct TypeInfoBase
 
 template <size_t K>
 class Boxed {
+public:
+    Boxed(TypeInfoBase* ti, uint64_t* data): typeinfo(ti) {
+        for(size_t i = 0; i < K; i++) {
+            this->data[i] = data[i];
+        }
+    }
     TypeInfoBase* typeinfo;
-    uint8_t data[K];
+    uint64_t data[K];
 };
 
 typedef uint64_t None;

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -398,6 +398,9 @@ public:
     friend constexpr bool operator>=(const Float& lhs, const Float& rhs) noexcept { return !(lhs < rhs); }
 };
 
+class None {
+};
+
 // Useful for keeping track of path in tree iteration
 struct PathStack {
     uint64_t bits;

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -44,7 +44,6 @@ entity Context {
 %% Could remove these two and just call emitTypeKey... but I suspect we will eventually need to handle
 %% lambda and elist explicitly (so fornow these are fine)
 function emitTypeSignatureBase(ts: CPPAssembly::TypeSignature, ctx: Context): CString {
-    %% Core becomes implicit in the ir so we have to add it. Perhaps could modify the ir itself to avoid this? dont want to break any other stuff tho
     return if(ctx.asm.pconcepts.has(ts.tkeystr)) then emitTypeKeyBase(CPPAssembly::TypeKey::from(CString::concat('Core::', ts.tkeystr.value)), ctx) 
         else emitTypeKeyBase(ts.tkeystr, ctx);    
 }
@@ -525,12 +524,6 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
     return CString::joinAll('', ops);
 }
 
-%%
-%% We should try to forcefully create the constructor for Option<T> where the tinfo pointer points to Some<T>,
-%% but the actual constructor is not Some<T>{...} but rather Option<T>{&Some<T>Type, ...}
-%%
-
-%% Needs to call constructor for our Boxed<K> type, not too sure how to construct the args
 function emitConstructorPrimarySpecialSomeExpression(cpsse: CPPAssembly::ConstructorPrimarySpecialSomeExpression, ctx: Context): CString {
     let t = getSpecialTemplates();
     let ttype = if(ctx.asm.isPrimtitiveType(cpsse.ofttype.tkeystr) && cpsse.ofttype.tkeystr.value !== 'bool') 
@@ -539,7 +532,7 @@ function emitConstructorPrimarySpecialSomeExpression(cpsse: CPPAssembly::Constru
     let widenedtype = CString::concat('Core::Option', t.0, ttype, t.2);
     let tinfoptr = CString::concat('&', ttype, 'Type, ');
 
-    %% This is quite naieve as we only support one argument and it does not map well to using the getter here
+    %% TODO: Support variable sized args! 
     if(cpsse.args.args.size() == 0n) {
         abort;
     }
@@ -1034,16 +1027,18 @@ function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, 
 }
 
 function emitPrimtiveConceptTypeDecl(pc: CPPAssembly::PrimitiveConceptTypeDecl, ctx: Context, indent: CString): CString {
+    let full_indent = CString::concat('    ', indent);
     let tkey = emitTypeKeyBase(pc.tkey, ctx);
-    let def = CString::concat('class ', emitTypeKeyBase(pc.tkey, ctx));
+    let def = CString::concat(indent, 'class ', emitTypeKeyBase(pc.tkey, ctx), ' : public ');
     if(!ctx.asm.typeinfos.has(pc.tkey)) {
         abort;
     }
     let k = ctx.asm.typeinfos.get(pc.tkey).slotsize - 1n; %% Slot size includes '2' ptr to typeinfo, so we ignore
     let boxed = CString::concat('__CoreCpp::Boxed', '<', k.toCString(), '>'); 
-    
-    let constructor = CString::concat('public:%n;', indent, tkey, '(__CoreCpp::TypeInfoBase* ti, uint64_t* data) : ', boxed, '(ti, data) {}%n;');
-    return CString::concat(def, ' : public ', boxed, '{%n;', constructor, '};%n;');
+
+    let base = CString::concat(indent, 'public:%n;'); 
+    let constructor = CString::concat(base, full_indent, tkey, '(__CoreCpp::TypeInfoBase* ti, uint64_t* data) : ', boxed, '(ti, data) {}%n;');
+    return CString::concat(def, boxed, '{%n;', constructor, indent, '};%n;');
 }
 
 function emitForwardDeclarationBody(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: CString): CString {    
@@ -1136,7 +1131,7 @@ function emitAssembly(asm: CPPAssembly::Assembly): String {
     });
 
     %%
-    %% We COULD get a bit spicy and emit pconcepts where T is a primitive here...
+    %% We could get a bit spicy and emit pconcepts where T is a primitive here...
     %%
 
     let ns_emission = asm.nsdecls.reduce<CString>(primitive_typeinfos, fn(acc, nsname, nsdecl) => {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -70,7 +70,7 @@ function emitSpecialTemplate(name: CString): CString {
 }
 
 function emitTypeKeyBase(tk: CPPAssembly::TypeKey, ctx: Context): CString {
-    return emitResolvedNamespace(ctx.fullns_list, tk.value); 
+    return emitResolvedNamespace(ctx.fullns_list, emitSpecialTemplate(tk.value)); 
 }
 
 function emitTypeKeyParamField(tk: CPPAssembly::TypeKey, ctx: Context): CString {
@@ -138,8 +138,8 @@ function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression):
     }
 }
 
-%% Not fully confident on this. I could see it interacting weirdly with our ITests...
-function emitLiteralNoneExpression(exp: CPPAssembly::LiteralNoneExpression): CString {
+%% TODO: Still call the Option<T> constructor, but pass in nones typeinfo and __CoreCpp::None as data
+function emitLiteralNoneExpression(): CString {
     return '__CoreCpp::None';
 }
 
@@ -465,10 +465,15 @@ function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSi
     }
 }
 
+function emitITestSome(it: CPPAssembly::ITestSome, baseType: CPPAssembly::TypeSignature, ctx: Context): CString {
+    return '';
+}
+
 function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, ctx: Context): CString {
     match(it)@ {
         CPPAssembly::ITestType => { return emitITestType($it, baseType, ctx); }
-        | _ => { abort; }
+        | CPPAssembly::ITestSome => { return emitITestSome($it, baseType, ctx); }
+        | _ => { abort; } %% TODO: Not Implemented!
     }
 }
 
@@ -493,15 +498,33 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
     return if(res.containsString('!false!')) then 'false' else if(res.containsString('!true!')) then 'true' else res;
 }
 
-function emitConstructorPrimarySpecialConstructableExpression(exp: CPPAssembly::ConstructorPrimarySpecialConstructableExpression, ctx: Context): CString {
-    %%
-    %% Not 100% confident on this, but I suspect we wont need to generate a special type for Option<T>. We likely can just
-    %% do a resolution of the contained types (i.e. what the Some<T> holds or if none) and directly emit this value.
-    %% I have not tested this yet, but I suspect it could be decent.
-    %%
-    
-    abort;
+%%
+%% We should try to forcefully create the constructor for Option<T> where the tinfo pointer points to Some<T>,
+%% but the actual constructor is not Some<T>{...} but rather Option<T>{&Some<T>Type, ...}
+%%
+
+%% Needs to call constructor for our Boxed<K> type, not too sure how to construct the args
+function emitConstructorPrimarySpecialSomeExpression(cpsse: CPPAssembly::ConstructorPrimarySpecialSomeExpression, ctx: Context): CString {
+    let tkey = emitTypeKeyBase(cpsse.ctype.tkeystr, ctx);
+    let tinfoptr = CString::concat('&', tkey, 'Type');
+    return CString::concat(tkey, '{', tinfoptr, '}');
 }
+
+function emitConstructorPrimarySpecialOkExpression(cpsoe: CPPAssembly::ConstructorPrimarySpecialOkExpression, ctx: Context): CString {
+    abort; %% TODO: Not implemented!
+}
+
+function emitConstructorPrimarySpecialFailExpression(cpsfe: CPPAssembly::ConstructorPrimarySpecialFailExpression, ctx: Context): CString {
+    abort; %% TODO: Not Implemented!
+}
+
+function emitConstructorPrimarySpecialConstructableExpression(exp: CPPAssembly::ConstructorPrimarySpecialConstructableExpression, ctx: Context): CString {    
+    match(exp)@ {
+        CPPAssembly::ConstructorPrimarySpecialSomeExpression => { return emitConstructorPrimarySpecialSomeExpression($exp, ctx); }
+        | CPPAssembly::ConstructorPrimarySpecialOkExpression => { return emitConstructorPrimarySpecialOkExpression($exp, ctx); }
+        | CPPAssembly::ConstructorPrimarySpecialFailExpression => { return emitConstructorPrimarySpecialFailExpression($exp, ctx); }
+    }
+ }
 
 %%
 %% TODO: Once the GC is integrated we will need to call our special GC allocate on ref type objects instead of the default
@@ -559,7 +582,7 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
         | CPPAssembly::BinLogicExpression => { return emitBinLogicExpression[recursive]($e, ctx); }
         | CPPAssembly::LogicActionAndExpression => { return emitLogicActionAndExpression[recursive]($e, ctx); }
         | CPPAssembly::LogicActionOrExpression => { return emitLogicActionOrExpression[recursive]($e, ctx); }
-        | CPPAssembly::LiteralNoneExpression => { return emitLiteralNoneExpression($e); }
+        | CPPAssembly::LiteralNoneExpression => { return emitLiteralNoneExpression(); }
         | CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($e); }
         | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e); }
         | CPPAssembly::CallNamespaceFunctionExpression => { return emitCallNamespaceFunctionExpression($e, ctx); }
@@ -805,7 +828,6 @@ function emitDatatypeMemberEntityDecl(dm: CPPAssembly::DatatypeMemberEntityTypeD
     let resolved_tk = emitResolvedNamespace(nctx.fullns_list, dm.tkey.value); 
     let specialName = emitSpecialTemplate(resolved_tk);
 
-
     let fields = dm.saturatedBFieldInfo.reduce<CString>(CString::concat(indent, 'struct ', specialName, '{ %n;'), 
         fn(acc, entry) => {
             return CString::concat(acc, emitSaturatedFieldInfo(entry, nctx, CString::concat('    ', indent)));
@@ -888,7 +910,7 @@ function generateVTable(ant: CPPAssembly::AbstractNominalTypeDecl, fields: List<
     let enum_name = CString::concat(specialName, '_entries');
     let vtable_name = CString::concat(specialName, '_vtable');
 
-    let base = CString::concat('const FieldOffsetInfo ', vtable_name, '[] = ', '{%n;');
+    let base = CString::concat('const __CoreCpp::FieldOffsetInfo ', vtable_name, '[] = ', '{%n;');
     let field_names = fields.mapIdx<CString>(fn(f_entry, ii) => generateVTableEntry(f_entry, specialName, enum_name, ii, ctx, full_indent));
     return CString::concat(indent, base, CString::joinAll(',%n;', field_names), '%n;', indent, '};%n;'); 
 }
@@ -907,7 +929,7 @@ function generateEntriesEnum(ant: CPPAssembly::AbstractNominalTypeDecl, fields: 
     return CString::concat(indent, base, CString::joinAll(',%n;', field_names), '%n;', indent, '};%n;');
 }
 
-function emitTypeInfo(info: CPPAssembly::TypeInfo, ant: CPPAssembly::AbstractNominalTypeDecl, indent: CString): CString {
+function emitTypeInfo(info: CPPAssembly::TypeInfo, ant: CPPAssembly::AbstractNominalTypeDecl, hasfields: Bool, indent: CString): CString {
     let full_indent = CString::concat('    ', indent);
 
     let resolved_name = emitResolvedNamespace(ant.fullns, info.typekey.value);
@@ -915,13 +937,14 @@ function emitTypeInfo(info: CPPAssembly::TypeInfo, ant: CPPAssembly::AbstractNom
 
     let tinfo_name = CString::concat(specialName, 'Type');
 
-    let base = CString::concat(indent, 'TypeInfoBase ', tinfo_name, ' = {%n;');
+    let base = CString::concat(indent, '__CoreCpp::TypeInfoBase ', tinfo_name, ' = {%n;');
     let id = CString::concat(base, full_indent, '.type_id = ', info.id.toCString(), ',%n;');
     let typesize = CString::concat(id, full_indent, '.type_size = ', info.typesize.toCString(), ', %n;');
     let slotsize = CString::concat(typesize, full_indent, '.slot_size = ', info.slotsize.toCString(), ',%n;');
     let ptrmask = CString::concat(slotsize, full_indent, '.ptr_mask = "', info.ptrmask, '",%n;');
     let typekey = CString::concat(ptrmask, full_indent, '.typekey = "', info.typekey.value, '",%n;');
-    let vtable = CString::concat(typekey, full_indent, '.vtable = ', CString::concat(specialName, '_vtable'), '%n;');
+    let vtable = if(hasfields) then CString::concat(typekey, full_indent, '.vtable = ', CString::concat(specialName, '_vtable'), '%n;')
+        else CString::concat(typekey, full_indent, '.vtable = nullptr%n;');
 
     return CString::concat(vtable, indent, '};%n;');
 }
@@ -929,12 +952,19 @@ function emitTypeInfo(info: CPPAssembly::TypeInfo, ant: CPPAssembly::AbstractNom
 function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, fields: List<CPPAssembly::MemberFieldDecl>, body: CString, ctx: Context, indent: CString): CString {
     let ant_enum = generateEntriesEnum(ant, fields, indent);
     let vtable = generateVTable(ant, fields, ctx, indent);
-    let tinfo = emitTypeInfo(ctx.asm.typeinfos.get(ant.tkey), ant, indent);
+    let tinfo = emitTypeInfo(ctx.asm.typeinfos.get(ant.tkey), ant, false, indent);
     let staticmethods = ant.staticmethods.reduce<CString>('', fn(acc, m) => { 
         return CString::concat(acc, emitMethodDecl(ctx.asm.staticmethods.get(m), ant.tkey, ctx, indent));
     });
     
     return CString::concat(ant_enum, vtable, tinfo, body, staticmethods);
+}
+
+function emitPrimtiveConceptTypeDecl(pc: CPPAssembly::PrimitiveConceptTypeDecl, ctx: Context, indent: CString): CString {
+    let tkey = CString::concat('class ', emitTypeKeyBase(pc.tkey, ctx));
+    let k = ctx.asm.typeinfos.get(pc.tkey).slotsize;
+
+    return CString::concat(tkey, ' : public __CoreCpp::Boxed', '<', k.toCString(), '>', '{ };%n;');
 }
 
 function emitForwardDeclarationBody(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: CString): CString {    
@@ -1014,9 +1044,21 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     return CString::concat(typefuncs, indent, '}%n;');
 }
 
+%%
+%% Might want to emit primitives typeinfo too for the sake of making handling Option<T> easier
+%%
+
 function emitAssembly(asm: CPPAssembly::Assembly): String {    
     let ctx: Context = Context{ asm, CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''} }; %% No known namespace yet
-    let ns_emission = asm.nsdecls.reduce<CString>('', fn(acc, nsname, nsdecl) => {
+    %% Primitive Concepts dont depend on any nesting so we will emit at top of emitted file
+    let pconcept_tinfo = asm.pconcepts.reduce<CString>('', fn(acc, tk, pc) => {
+        return CString::concat(acc, emitTypeInfo(asm.typeinfos.get(tk), pc@<CPPAssembly::AbstractNominalTypeDecl>, false, ''));
+    });
+    let pconcepts_emission = asm.pconcepts.reduce<CString>(pconcept_tinfo, fn(acc, tk, pc) => {
+        return CString::concat(acc, emitPrimtiveConceptTypeDecl(pc, ctx, ''));
+    });
+
+    let ns_emission = asm.nsdecls.reduce<CString>(pconcepts_emission, fn(acc, nsname, nsdecl) => {
         return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, ''));
     });
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -71,12 +71,17 @@ function emitSpecialTemplate(name: CString): CString {
     return third;
 }
 
+%% We dont want this prefix when emitting typeinfo for primitives
+function removeCppPrefix(s: CString): CString {
+    return if(s.startsWithString('__CoreCpp::')) then s.removePrefixString('__CoreCpp::') else s;
+}
+
 function emitTypeKeyBase(tk: CPPAssembly::TypeKey, ctx: Context): CString {
     return emitResolvedNamespace(ctx.fullns_list, emitSpecialTemplate(tk.value)); 
 }
 
 function emitTypeKeyParamField(tk: CPPAssembly::TypeKey, ctx: Context): CString {
-    let resolved = emitResolvedNamespace(ctx.fullns_list, tk.value);
+    let resolved = emitResolvedNamespace(ctx.fullns_list, emitSpecialTemplate(tk.value));
 
     if(!ctx.asm.typeinfos.has(tk)) {
         abort;
@@ -92,18 +97,18 @@ function emitTypeKeyParamField(tk: CPPAssembly::TypeKey, ctx: Context): CString 
 }
 
 function emitIdentifier(ident: CPPAssembly::Identifier): CString {
-    return ident.value;
+    return emitSpecialTemplate(ident.value);
 }
 
 function emitVarIdentifier(vident: CPPAssembly::VarIdentifier): CString {
     if(vident.value === 'this') {
         return emitSpecialThis();
     }
-    return vident.value;
+    return emitSpecialTemplate(vident.value);
 }
 
 function emitInvokeKey(ik: CPPAssembly::InvokeKey, ctx: Context): CString {
-    return emitResolvedNamespace(ctx.fullns_list, ik.value); 
+    return emitResolvedNamespace(ctx.fullns_list, emitSpecialTemplate(ik.value)); 
 }
 
 function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): CString {
@@ -141,8 +146,8 @@ function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression):
 }
 
 %% TODO: Still call the Option<T> constructor, but pass in nones typeinfo and __CoreCpp::None as data
-function emitLiteralNoneExpression(): CString {
-    return '__CoreCpp::None';
+function emitLiteralNoneExpression(exp: CPPAssembly::LiteralNoneExpression): CString {
+    return 'UINT64_MAX';
 }
 
 function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression): CString {
@@ -468,7 +473,7 @@ function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSi
 }
 
 function emitITestSome(it: CPPAssembly::ITestSome, baseType: CPPAssembly::TypeSignature, ctx: Context): CString {
-    return '';
+    return CString::concat('.typeinfo != &NoneType');
 }
 
 function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, ctx: Context): CString {
@@ -514,13 +519,16 @@ function emitConstructorPrimarySpecialSomeExpression(cpsse: CPPAssembly::Constru
     let tinfoptr = CString::concat('&', ttype, 'Type, ');
 
     %% This is quite naieve as we only support one argument and it does not map well to using the getter here
+    if(cpsse.args.args.size() == 0n) {
+        abort;
+    }
     let arg = cpsse.args.args.get(0n);
     if(arg)@none {
         abort;
     }
     else {
-        let tmparg = emitExpression($arg.exp, ctx);
-        let data = CString::concat(tmparg, '.get()');
+        let tmparg = CString::concat( '(', emitExpression($arg.exp, ctx), ').get()');
+        let data = CString::concat('(uint64_t[]){', tmparg, '}');
         return CString::concat(widenedtype, '{', tinfoptr, data, '}');
     }
 }
@@ -549,6 +557,9 @@ function emitConstructorStdExpression(exp: CPPAssembly::ConstructorStdExpression
     %% Eventually might want to rework emitArgumentList to support constructors too 
     let emitargs =  CString::joinAll(', ', exp.args.args.mapIdx<CString>(fn(av, ii) => {
         if(av)@none {
+            if(!ctx.asm.entities.has(exp.ctype.tkeystr)) {
+                abort;
+            }
             let e = ctx.asm.entities.get(exp.ctype.tkeystr);
             let member_defval = e.fields.get(ii).defaultval;
             if(member_defval)@none {
@@ -571,6 +582,10 @@ function emitConstructorStdExpression(exp: CPPAssembly::ConstructorStdExpression
 
     let resolved_type = emitResolvedNamespace(ctx.fullns_list, exp.ctype.tkeystr.value);
     let specialName = emitSpecialTemplate(resolved_type);
+
+    if(!ctx.asm.typeinfos.has(exp.ctype.tkeystr)) {
+        abort;
+    }
 
     if(ctx.asm.typeinfos.get(exp.ctype.tkeystr).tag === CPPAssembly::Tag#Ref) {
         return CString::concat('new ', specialName, '{ ', emitargs, ' }'); %% We use new solely to keep the code compiling before GC integration
@@ -597,7 +612,7 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
         | CPPAssembly::BinLogicExpression => { return emitBinLogicExpression[recursive]($e, ctx); }
         | CPPAssembly::LogicActionAndExpression => { return emitLogicActionAndExpression[recursive]($e, ctx); }
         | CPPAssembly::LogicActionOrExpression => { return emitLogicActionOrExpression[recursive]($e, ctx); }
-        | CPPAssembly::LiteralNoneExpression => { return emitLiteralNoneExpression(); }
+        | CPPAssembly::LiteralNoneExpression => { return emitLiteralNoneExpression($e); }
         | CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($e); }
         | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e); }
         | CPPAssembly::CallNamespaceFunctionExpression => { return emitCallNamespaceFunctionExpression($e, ctx); }
@@ -613,7 +628,13 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
 function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitializationStatement, ctx: Context, indent: CString): CString {
     let name = emitIdentifier(stmt.name);
     let stype = emitTypeSignatureBase(stmt.vtype, ctx);
-    let exp = emitExpression(stmt.exp, ctx);
+    let tmp =  emitExpression(stmt.exp, ctx);
+
+    %% This could break for pconcepts that arent options, fine for now
+    let exp = if(ctx.asm.pconcepts.has(stmt.vtype.tkeystr) && stmt.exp?<CPPAssembly::LiteralNoneExpression>) 
+        then CString::concat(stype, '{&NoneType, (uint64_t[]){', tmp, '}}')
+
+        else tmp;
     let specialName = emitSpecialTemplate(stype);
 
     let full_indent: CString = CString::concat(indent, '    ', specialName);
@@ -635,7 +656,8 @@ function emitIfSimpleStatement(stmt: CPPAssembly::IfSimpleStatement, ctx: Contex
 
 function emitIfTestStatement(stmt: CPPAssembly::IfTestStatement, ctx: Context, indent: CString): CString {
     let itest = emitITestAsTest(stmt.itest, stmt.cond.etype, ctx);
-    let expr = if(itest === '!false!') then 'false' else 'true';
+    let expr = if(itest === '!false!') then 'false' else 
+        (if(itest === 'true') then 'true' else CString::concat(emitExpression(stmt.cond, ctx), itest));
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
 
     let ifstmt = CString::concat(indent, 'if( ', expr, ' ) {%n;');
@@ -668,7 +690,8 @@ function emitIfElseSimpleStatement(stmt: CPPAssembly::IfElseSimpleStatement, ctx
 
 function emitIfElseTestStatement(stmt: CPPAssembly::IfElseTestStatement, ctx: Context, indent: CString): CString {
     let itest = emitITestAsTest(stmt.itest, stmt.cond.etype, ctx);
-    let expr = if(itest === '!false!') then 'false' else 'true';
+    let expr = if(itest === '!false!') then 'false' else 
+        (if(itest === 'true') then 'true' else CString::concat(emitExpression(stmt.cond, ctx), itest));
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
     let falseBlock = emitBlockStatement(stmt.falseBlock, ctx, indent);
     let elseBlockText = CString::concat(indent, 'else {%n;', falseBlock, indent, '}%n;');
@@ -761,7 +784,11 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context):
 %% Determine whether to emit this param as const this* or this
 function emitThisType(tk: CPPAssembly::TypeKey, ctx: Context): CString {
     let resolved_type = emitResolvedNamespace(ctx.fullns_list, tk.value);
-    
+
+    if(!ctx.asm.typeinfos.has(tk)) {
+        abort;
+    }
+
     if(ctx.asm.typeinfos.get(tk).tag === CPPAssembly::Tag#Ref) {
         return CString::concat('const ', resolved_type, '*');
     }
@@ -906,6 +933,9 @@ function emitFunctionForwardDeclaration(decl: CPPAssembly::AbstractInvokeDecl, c
 %%
 
 function generateVTableEntry(entry: CPPAssembly::MemberFieldDecl, resolved_name: CString, enum_name: CString, idx: Nat, ctx: Context, indent: CString): CString {
+    if(!ctx.asm.typeinfos.has(entry.declaredType.tkeystr)) {
+        abort;
+    }
     let tinfo = ctx.asm.typeinfos.get(entry.declaredType.tkeystr);
 
     let id = tinfo.id.toCString();
@@ -947,7 +977,8 @@ function generateEntriesEnum(ant: CPPAssembly::AbstractNominalTypeDecl, fields: 
 function emitTypeInfo(info: CPPAssembly::TypeInfo, ant: Option<CPPAssembly::AbstractNominalTypeDecl>, hasfields: Bool, indent: CString): CString {
     let full_indent = CString::concat('    ', indent);
 
-    let resolved_name = if(ant)@none then info.typekey.value else emitResolvedNamespace($ant.fullns, info.typekey.value);
+    let infotk = removeCppPrefix(info.typekey.value);
+    let resolved_name = if(ant)@none then infotk else emitResolvedNamespace($ant.fullns, infotk);
     let specialName = emitSpecialTemplate(resolved_name);
 
     let tinfo_name = CString::concat(specialName, 'Type');
@@ -967,6 +998,9 @@ function emitTypeInfo(info: CPPAssembly::TypeInfo, ant: Option<CPPAssembly::Abst
 function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, fields: List<CPPAssembly::MemberFieldDecl>, body: CString, ctx: Context, indent: CString): CString {
     let ant_enum = generateEntriesEnum(ant, fields, indent);
     let vtable = generateVTable(ant, fields, ctx, indent);
+    if(!ctx.asm.typeinfos.has(ant.tkey)) {
+        abort;
+    }
     let tinfo = emitTypeInfo(ctx.asm.typeinfos.get(ant.tkey), some(ant), false, indent);
     let staticmethods = ant.staticmethods.reduce<CString>('', fn(acc, m) => { 
         return CString::concat(acc, emitMethodDecl(ctx.asm.staticmethods.get(m), ant.tkey, ctx, indent));
@@ -978,6 +1012,9 @@ function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, 
 function emitPrimtiveConceptTypeDecl(pc: CPPAssembly::PrimitiveConceptTypeDecl, ctx: Context, indent: CString): CString {
     let tkey = emitTypeKeyBase(pc.tkey, ctx);
     let def = CString::concat('class ', emitTypeKeyBase(pc.tkey, ctx));
+    if(!ctx.asm.typeinfos.has(pc.tkey)) {
+        abort;
+    }
     let k = ctx.asm.typeinfos.get(pc.tkey).slotsize;
     let boxed = CString::concat('__CoreCpp::Boxed', '<', k.toCString(), '>'); 
     
@@ -1025,7 +1062,8 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     let full_indent = CString::concat('    ', indent);
 
     let pconcepts = nsdecl.pconcepts.reduce<CString>(ns, fn(acc, tk) => {
-        return CString::concat(acc, emitPrimtiveConceptTypeDecl(ctx.asm.pconcepts.get(tk), ctx, full_indent));
+        let tinfo = emitTypeInfo(ctx.asm.typeinfos.get(tk), none, false, full_indent);
+        return CString::concat(acc, tinfo, emitPrimtiveConceptTypeDecl(ctx.asm.pconcepts.get(tk), ctx, full_indent));
     });
 
     %% Ensure no conflicts when accessing functions from other ns (might need to recursively explore other deeper ns)

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -418,12 +418,6 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CSt
         name = trgt.name;
         args = emitArgumentList(op.args, trgt.params, ctx);
     }
-    %*
-    elif(ctx.asm.virtmethods.has(op.resolvedTrgt)) {
-        let trgt = ctx.asm.virtmethods.get(op.resolvedTrgt);
-        args = emitArgumentList(op.args, trgt.params, ctx);
-    }
-    *%
     else {
         abort; %% TODO: Add support for Override, Abstract, and Virtual methods!
     }
@@ -452,19 +446,39 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CSt
     }
 }
 
+%%
+%% I really feel that this is flawed...
+%%
+function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSignature): CString {
+    if(it.isnot) {
+        if(it.ttype.tkeystr.value === baseType.tkeystr.value) {
+            return 'true';
+        }
+        return 'false';
+    }
+    return if(it.ttype.tkeystr.value === baseType.tkeystr.value) then 'true' else 'false';
+}
+
+function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature): CString {
+    match(it)@ {
+        CPPAssembly::ITestType => { return emitITestType($it, baseType); }
+        | _ => { abort; }
+    }
+}
+
 function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
     let rootExp = emitExpression(pop.rootExp, ctx);
     let ops = pop.ops.mapIdx<CString>(fn(op, ii) => {
-        if(op)@<CPPAssembly::PostfixAccessFromName> {
-            if (ii == 0n) {
-                return CString::concat(rootExp, emitPostfixAccessFromName($op, ctx));
+        match(op)@ {
+            CPPAssembly::PostfixAccessFromName => {
+                if (ii == 0n) {
+                    return CString::concat(rootExp, emitPostfixAccessFromName($op, ctx));
+                }
+                return emitPostfixAccessFromName($op, ctx);
             }
-            return emitPostfixAccessFromName($op, ctx);
+            | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, rootExp, ctx); }
+            | CPPAssembly::PostfixIsTest => { return emitITestAsTest($op.ttest, $op.baseType); }
         }
-        if(op)@<CPPAssembly::PostfixInvokeStatic> {
-            return emitPostfixInvokeStatic($op, rootExp, ctx);
-        }
-        abort; %% TODO: Not implemented
     });
 
     return CString::joinAll('', ops);

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -138,6 +138,11 @@ function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression):
     }
 }
 
+%% Not fully confident on this. I could see it interacting weirdly with our ITests...
+function emitLiteralNoneExpression(exp: CPPAssembly::LiteralNoneExpression): CString {
+    return '__CoreCpp::None';
+}
+
 function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression): CString {
     %% May need some work with type
     return emitVarIdentifier(exp.vname);
@@ -488,6 +493,16 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
     return if(res.containsString('!false!')) then 'false' else if(res.containsString('!true!')) then 'true' else res;
 }
 
+function emitConstructorPrimarySpecialConstructableExpression(exp: CPPAssembly::ConstructorPrimarySpecialConstructableExpression, ctx: Context): CString {
+    %%
+    %% Not 100% confident on this, but I suspect we wont need to generate a special type for Option<T>. We likely can just
+    %% do a resolution of the contained types (i.e. what the Some<T> holds or if none) and directly emit this value.
+    %% I have not tested this yet, but I suspect it could be decent.
+    %%
+    
+    abort;
+}
+
 %%
 %% TODO: Once the GC is integrated we will need to call our special GC allocate on ref type objects instead of the default
 %% constructor like we do now. Currently they call 'new'
@@ -544,11 +559,13 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
         | CPPAssembly::BinLogicExpression => { return emitBinLogicExpression[recursive]($e, ctx); }
         | CPPAssembly::LogicActionAndExpression => { return emitLogicActionAndExpression[recursive]($e, ctx); }
         | CPPAssembly::LogicActionOrExpression => { return emitLogicActionOrExpression[recursive]($e, ctx); }
+        | CPPAssembly::LiteralNoneExpression => { return emitLiteralNoneExpression($e); }
         | CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($e); }
         | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e); }
         | CPPAssembly::CallNamespaceFunctionExpression => { return emitCallNamespaceFunctionExpression($e, ctx); }
         | CPPAssembly::CallTypeFunctionExpression => { return emitCallTypeFunctionExpression($e, ctx); }
         | CPPAssembly::PostfixOp => { return emitPostfixOp($e, ctx); }
+        | CPPAssembly::ConstructorPrimarySpecialConstructableExpression => { return emitConstructorPrimarySpecialConstructableExpression($e, ctx); }
         | CPPAssembly::ConstructorStdExpression => { return emitConstructorStdExpression($e, ctx); }
         | CPPAssembly::IfExpression => { return emitIfExpression($e, ctx); }
         | _ => { abort; }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -446,22 +446,26 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CSt
     }
 }
 
-%%
-%% I really feel that this is flawed...
-%%
-function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSignature): CString {
-    if(it.isnot) {
-        if(it.ttype.tkeystr.value === baseType.tkeystr.value) {
-            return 'true';
+function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSignature, ctx: Context): CString {
+    %% For now we only support ITests where both types are concrete
+    if(ctx.asm.isNominalTypeConcrete(it.ttype.tkeystr) && ctx.asm.isNominalTypeConcrete(baseType.tkeystr)) {
+        let areTypesSame = ctx.asm.areTypesSame(it.ttype, baseType);
+        if(it.isnot) {
+            if(areTypesSame) {
+                return '!true!';
+            }
+            return '!false!';
         }
-        return 'false';
+        return if(areTypesSame) then '!true!' else '!false!';
     }
-    return if(it.ttype.tkeystr.value === baseType.tkeystr.value) then 'true' else 'false';
+    else {
+        abort; %% TODO: ITests on concepts not yet supported!
+    }
 }
 
-function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature): CString {
+function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, ctx: Context): CString {
     match(it)@ {
-        CPPAssembly::ITestType => { return emitITestType($it, baseType); }
+        CPPAssembly::ITestType => { return emitITestType($it, baseType, ctx); }
         | _ => { abort; }
     }
 }
@@ -477,16 +481,19 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
                 return emitPostfixAccessFromName($op, ctx);
             }
             | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, rootExp, ctx); }
-            | CPPAssembly::PostfixIsTest => { return emitITestAsTest($op.ttest, $op.baseType); }
+            | CPPAssembly::PostfixIsTest => { return emitITestAsTest($op.ttest, $op.baseType, ctx); }
         }
     });
 
-    return CString::joinAll('', ops);
+    let res = CString::joinAll('', ops);
+
+    %% This could be a bit clunky - is there anywhere else we need to perform this substitution?
+    return if(res.containsString('!false!')) then 'false' else if(res.containsString('!true!')) then 'true' else res;
 }
 
 %%
 %% TODO: Once the GC is integrated we will need to call our special GC allocate on ref type objects instead of the default
-%% constructor like we do now. Ref type object constructors will not work as is currently.
+%% constructor like we do now. Currently they call 'new'
 %%
 function emitConstructorStdExpression(exp: CPPAssembly::ConstructorStdExpression, ctx: Context): CString {
     %% Eventually might want to rework emitArgumentList to support constructors too 
@@ -674,7 +681,8 @@ function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::Typ
     let this_type = emitThisType(declaredIn, nctx);    
     let specialName = emitSpecialTemplate(name);
     
-    let pre = CString::concat(indent, 'const ', rtype, ' ', specialName);
+    let pre = if(rtype !== 'bool') then CString::concat(indent, 'const ', rtype, ' ', specialName)
+        else CString::concat(indent, rtype, ' ', specialName);
     let specialThis = emitSpecialTemplate(this_type);
 
     var params_impl: CString;

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -446,17 +446,14 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CSt
     }
 }
 
+%% Emitting invalid '!true/false!' allows us to prevent naming conflicts and gives a matchable pattern that we can
+%% replace with 'true/false'
 function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSignature, ctx: Context): CString {
     %% For now we only support ITests where both types are concrete
     if(ctx.asm.isNominalTypeConcrete(it.ttype.tkeystr) && ctx.asm.isNominalTypeConcrete(baseType.tkeystr)) {
         let areTypesSame = ctx.asm.areTypesSame(it.ttype, baseType);
-        if(it.isnot) {
-            if(areTypesSame) {
-                return '!true!';
-            }
-            return '!false!';
-        }
-        return if(areTypesSame) then '!true!' else '!false!';
+        return if(it.isnot) then (if(!areTypesSame) then '!true!' else '!false!')
+            else if(areTypesSame) then '!true!' else '!false!';
     }
     else {
         abort; %% TODO: ITests on concepts not yet supported!
@@ -573,26 +570,70 @@ function emitBlockStatement(block: CPPAssembly::BlockStatement, ctx: Context, in
     return CString::joinAll('%n;', stmts);
 }
 
+function emitIfSimpleStatement(stmt: CPPAssembly::IfSimpleStatement, ctx: Context, indent: CString): CString {
+    let expr = emitExpression(stmt.cond, ctx);
+    let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
+
+    let ifstmt = CString::concat(indent, 'if( ', expr, ' ) {%n;');
+    return CString::concat(ifstmt, trueBlock, indent, '}');
+}
+
+function emitIfTestStatement(stmt: CPPAssembly::IfTestStatement, ctx: Context, indent: CString): CString {
+    let itest = emitITestAsTest(stmt.itest, stmt.cond.etype, ctx);
+    let expr = if(itest === '!false!') then 'false' else 'true';
+    let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
+
+    let ifstmt = CString::concat(indent, 'if( ', expr, ' ) {%n;');
+    return CString::concat(ifstmt, trueBlock, indent, '}');
+}
+
+function emitIfBinderStatement(stmt: CPPAssembly::IfStatement, ctx: Context, indent: CString): CString {
+    abort; %% TODO: Not Implemented!    
+}
+
 function emitIfStatement(stmt: CPPAssembly::IfStatement, ctx: Context, indent: CString): CString {
     let full_indent = CString::concat('    ', indent); 
+
+    match(stmt)@ { 
+        CPPAssembly::IfSimpleStatement => { return emitIfSimpleStatement($stmt, ctx, full_indent); }
+        | CPPAssembly::IfTestStatement => { return emitIfTestStatement($stmt, ctx, full_indent); }
+        | CPPAssembly::IfBinderStatement => { return emitIfBinderStatement($stmt, ctx, full_indent); }
+    }
+}
+
+function emitIfElseSimpleStatement(stmt: CPPAssembly::IfElseSimpleStatement, ctx: Context, indent: CString): CString {
     let expr = emitExpression(stmt.cond, ctx);
-    let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, full_indent);
+    let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
+    let falseBlock = emitBlockStatement(stmt.falseBlock, ctx, indent);
+    let elseBlockText = CString::concat(indent, 'else {%n;', falseBlock, indent, '}%n;');
     
-    let ifstmt = CString::concat(full_indent, 'if( ', expr, ' ) {%n;');
-    return CString::concat(ifstmt, trueBlock, full_indent, '}');
+    let ifstmt = CString::concat(indent, 'if( ', expr, ' ) {%n;'); 
+    return CString::concat(ifstmt, trueBlock, indent, '}%n;', elseBlockText);
+}
+
+function emitIfElseTestStatement(stmt: CPPAssembly::IfElseTestStatement, ctx: Context, indent: CString): CString {
+    let itest = emitITestAsTest(stmt.itest, stmt.cond.etype, ctx);
+    let expr = if(itest === '!false!') then 'false' else 'true';
+    let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
+    let falseBlock = emitBlockStatement(stmt.falseBlock, ctx, indent);
+    let elseBlockText = CString::concat(indent, 'else {%n;', falseBlock, indent, '}%n;');
+    
+    let ifstmt = CString::concat(indent, 'if( ', expr, ' ) {%n;'); 
+    return CString::concat(ifstmt, trueBlock, indent, '}%n;', elseBlockText);
+}
+
+function emitIfElseBinderStatement(stmt: CPPAssembly::IfElseBinderStatement, ctx: Context, ident: CString): CString {
+    abort; %% TODO: Not Implemented!
 }
 
 function emitIfElseStatement(stmt: CPPAssembly::IfElseStatement, ctx: Context, indent: CString): CString {
     let full_indent = CString::concat('    ', indent); 
-    let expr = emitExpression(stmt.cond, ctx);
     
-    let falseBlock = emitBlockStatement(stmt.falseBlock, ctx, full_indent);
-    let elseBlockText = CString::concat(full_indent, 'else {%n;', falseBlock, full_indent, '}%n;');
-
-    let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, full_indent);
-    let ifstmt = CString::concat(full_indent, 'if( ', expr, ' ) {%n;'); 
-
-    return CString::concat(ifstmt, trueBlock, full_indent, '}%n;', elseBlockText);
+    match(stmt)@ {
+        CPPAssembly::IfElseSimpleStatement => { return emitIfElseSimpleStatement($stmt, ctx, full_indent); }
+        | CPPAssembly::IfElseTestStatement => { return emitIfElseTestStatement($stmt, ctx, full_indent); }
+        | CPPAssembly::IfElseBinderStatement => { return emitIfElseBinderStatement($stmt, ctx, full_indent); }
+    }
 }
 
 function emitIfElifElseStatement(stmt: CPPAssembly::IfElifElseStatement, ctx: Context, indent: CString): CString {
@@ -775,7 +816,9 @@ function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CP
 
         let specialThis = emitSpecialTemplate(this_type);
         let specialName = emitSpecialTemplate(pre);
-        let first = CString::concat(indent, 'const ', rtype, ' ', specialName, '(');
+
+        let first = if(rtype !== 'bool') then CString::concat(indent, 'const ', rtype, ' ', specialName, '(')
+            else CString::concat(indent, rtype, ' ', specialName, '(');
 
         if(params === '') {
             return CString::concat(first, specialThis, ' ', emitSpecialThis(), params, ') noexcept;%n;');

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -40,7 +40,9 @@ entity Context {
 %% Could remove these two and just call emitTypeKey... but I suspect we will eventually need to handle
 %% lambda and elist explicitly (so fornow these are fine)
 function emitTypeSignatureBase(ts: CPPAssembly::TypeSignature, ctx: Context): CString {
-    return emitTypeKeyBase(ts.tkeystr, ctx);    
+    %% Core becomes implicit in the ir so we have to add it. Perhaps could modify the ir itself to avoid this? dont want to break any other stuff tho
+    return if(ctx.asm.pconcepts.has(ts.tkeystr)) then emitTypeKeyBase(CPPAssembly::TypeKey::from(CString::concat('Core::', ts.tkeystr.value)), ctx) 
+        else emitTypeKeyBase(ts.tkeystr, ctx);    
 }
 
 function emitTypeSignatureParamFieldType(ts: CPPAssembly::TypeSignature, ctx: Context): CString {
@@ -505,9 +507,22 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
 
 %% Needs to call constructor for our Boxed<K> type, not too sure how to construct the args
 function emitConstructorPrimarySpecialSomeExpression(cpsse: CPPAssembly::ConstructorPrimarySpecialSomeExpression, ctx: Context): CString {
-    let tkey = emitTypeKeyBase(cpsse.ctype.tkeystr, ctx);
-    let tinfoptr = CString::concat('&', tkey, 'Type');
-    return CString::concat(tkey, '{', tinfoptr, '}');
+    let t = getSpecialTemplates();
+    let ttype = if(ctx.asm.isPrimtitiveType(cpsse.ofttype.tkeystr)) then cpsse.ofttype.tkeystr.value.removePrefixString('__CoreCpp::') 
+        else emitTypeSignatureBase(cpsse.ofttype, ctx);
+    let widenedtype = CString::concat('Core::Option', t.0, ttype, t.2);
+    let tinfoptr = CString::concat('&', ttype, 'Type, ');
+
+    %% This is quite naieve as we only support one argument and it does not map well to using the getter here
+    let arg = cpsse.args.args.get(0n);
+    if(arg)@none {
+        abort;
+    }
+    else {
+        let tmparg = emitExpression($arg.exp, ctx);
+        let data = CString::concat(tmparg, '.get()');
+        return CString::concat(widenedtype, '{', tinfoptr, data, '}');
+    }
 }
 
 function emitConstructorPrimarySpecialOkExpression(cpsoe: CPPAssembly::ConstructorPrimarySpecialOkExpression, ctx: Context): CString {
@@ -597,7 +612,7 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
 
 function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitializationStatement, ctx: Context, indent: CString): CString {
     let name = emitIdentifier(stmt.name);
-    let stype = emitTypeSignatureParamFieldType(stmt.vtype, ctx);
+    let stype = emitTypeSignatureBase(stmt.vtype, ctx);
     let exp = emitExpression(stmt.exp, ctx);
     let specialName = emitSpecialTemplate(stype);
 
@@ -929,10 +944,10 @@ function generateEntriesEnum(ant: CPPAssembly::AbstractNominalTypeDecl, fields: 
     return CString::concat(indent, base, CString::joinAll(',%n;', field_names), '%n;', indent, '};%n;');
 }
 
-function emitTypeInfo(info: CPPAssembly::TypeInfo, ant: CPPAssembly::AbstractNominalTypeDecl, hasfields: Bool, indent: CString): CString {
+function emitTypeInfo(info: CPPAssembly::TypeInfo, ant: Option<CPPAssembly::AbstractNominalTypeDecl>, hasfields: Bool, indent: CString): CString {
     let full_indent = CString::concat('    ', indent);
 
-    let resolved_name = emitResolvedNamespace(ant.fullns, info.typekey.value);
+    let resolved_name = if(ant)@none then info.typekey.value else emitResolvedNamespace($ant.fullns, info.typekey.value);
     let specialName = emitSpecialTemplate(resolved_name);
 
     let tinfo_name = CString::concat(specialName, 'Type');
@@ -952,7 +967,7 @@ function emitTypeInfo(info: CPPAssembly::TypeInfo, ant: CPPAssembly::AbstractNom
 function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, fields: List<CPPAssembly::MemberFieldDecl>, body: CString, ctx: Context, indent: CString): CString {
     let ant_enum = generateEntriesEnum(ant, fields, indent);
     let vtable = generateVTable(ant, fields, ctx, indent);
-    let tinfo = emitTypeInfo(ctx.asm.typeinfos.get(ant.tkey), ant, false, indent);
+    let tinfo = emitTypeInfo(ctx.asm.typeinfos.get(ant.tkey), some(ant), false, indent);
     let staticmethods = ant.staticmethods.reduce<CString>('', fn(acc, m) => { 
         return CString::concat(acc, emitMethodDecl(ctx.asm.staticmethods.get(m), ant.tkey, ctx, indent));
     });
@@ -961,10 +976,13 @@ function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, 
 }
 
 function emitPrimtiveConceptTypeDecl(pc: CPPAssembly::PrimitiveConceptTypeDecl, ctx: Context, indent: CString): CString {
-    let tkey = CString::concat('class ', emitTypeKeyBase(pc.tkey, ctx));
+    let tkey = emitTypeKeyBase(pc.tkey, ctx);
+    let def = CString::concat('class ', emitTypeKeyBase(pc.tkey, ctx));
     let k = ctx.asm.typeinfos.get(pc.tkey).slotsize;
-
-    return CString::concat(tkey, ' : public __CoreCpp::Boxed', '<', k.toCString(), '>', '{ };%n;');
+    let boxed = CString::concat('__CoreCpp::Boxed', '<', k.toCString(), '>'); 
+    
+    let constructor = CString::concat('public:%n;', indent, tkey, '(__CoreCpp::TypeInfoBase* ti, uint64_t* data) : ', boxed, '(ti, data) {}%n;');
+    return CString::concat(def, ' : public ', boxed, '{%n;', constructor, '};%n;');
 }
 
 function emitForwardDeclarationBody(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: CString): CString {    
@@ -1006,8 +1024,12 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     let ns = CString::concat(indent, 'namespace ', nsdecl.nsname, ' {%n;');
     let full_indent = CString::concat('    ', indent);
 
+    let pconcepts = nsdecl.pconcepts.reduce<CString>(ns, fn(acc, tk) => {
+        return CString::concat(acc, emitPrimtiveConceptTypeDecl(ctx.asm.pconcepts.get(tk), ctx, full_indent));
+    });
+
     %% Ensure no conflicts when accessing functions from other ns (might need to recursively explore other deeper ns)
-    let subns_fwddecls = nsdecl.subns.reduce<CString>(ns, fn(acc, name, subns) => {
+    let subns_fwddecls = nsdecl.subns.reduce<CString>(pconcepts, fn(acc, name, subns) => {
         return CString::concat(acc, emitForwardDeclarations(subns, ctx, full_indent));
     });
 
@@ -1044,21 +1066,18 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     return CString::concat(typefuncs, indent, '}%n;');
 }
 
-%%
-%% Might want to emit primitives typeinfo too for the sake of making handling Option<T> easier
-%%
-
 function emitAssembly(asm: CPPAssembly::Assembly): String {    
     let ctx: Context = Context{ asm, CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''} }; %% No known namespace yet
-    %% Primitive Concepts dont depend on any nesting so we will emit at top of emitted file
-    let pconcept_tinfo = asm.pconcepts.reduce<CString>('', fn(acc, tk, pc) => {
-        return CString::concat(acc, emitTypeInfo(asm.typeinfos.get(tk), pc@<CPPAssembly::AbstractNominalTypeDecl>, false, ''));
-    });
-    let pconcepts_emission = asm.pconcepts.reduce<CString>(pconcept_tinfo, fn(acc, tk, pc) => {
-        return CString::concat(acc, emitPrimtiveConceptTypeDecl(pc, ctx, ''));
+ 
+    let primitive_typeinfos = asm.typeinfos.reduce<CString>('', fn(acc, tk, ti) => {
+        return if(asm.isPrimtitiveType(tk)) then CString::concat(acc, emitTypeInfo(ti, none, false, '')) else acc;
     });
 
-    let ns_emission = asm.nsdecls.reduce<CString>(pconcepts_emission, fn(acc, nsname, nsdecl) => {
+    %%
+    %% We COULD get a bit spicy and emit pconcepts where T is a primitive here...
+    %%
+
+    let ns_emission = asm.nsdecls.reduce<CString>(primitive_typeinfos, fn(acc, nsname, nsdecl) => {
         return CString::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, ''));
     });
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -31,9 +31,13 @@ entity Context {
     field asm: CPPAssembly::Assembly;
     field fullns_key: CPPAssembly::NamespaceKey; %% Main::Foo::Bar::...
     field fullns_list: List<CString>; %% ['Main', 'Foo', 'Bar', ...]
+    field inoption: Option<CPPAssembly::TypeSignature>;
 
     method updateCurrentNamespace(new_ns: CPPAssembly::NamespaceKey, new_nsname: List<CString>): Context {
-        return Context{ this.asm, new_ns, new_nsname };
+        return Context{ this.asm, new_ns, new_nsname, this.inoption };
+    }
+    method updateInOption(new_inoption: Option<CPPAssembly::TypeSignature>): Context {
+        return Context{ this.asm, this.fullns_key, this.fullns_list, new_inoption };
     }
 }
 
@@ -48,7 +52,6 @@ function emitTypeSignatureBase(ts: CPPAssembly::TypeSignature, ctx: Context): CS
 function emitTypeSignatureParamFieldType(ts: CPPAssembly::TypeSignature, ctx: Context): CString {
     return emitTypeKeyParamField(ts.tkeystr, ctx);
 }
-
 
 %% Temporary invalid string we replace just before emission (with our special unicode tᖺis)
 function emitSpecialThis(): CString {
@@ -69,6 +72,14 @@ function emitSpecialTemplate(name: CString): CString {
     let third = second.replaceAllStringOccurrences('>', st.2);
 
     return third;
+}
+
+%% We represent booleans as '!false!' or '!true!' to prevent naming conflicts when resolving boolean expressions,
+%% this function resolves to their true boolean value 
+function resolveSpecialBoolean(s: CString): CString {
+    return if(s.containsString('!false!')) then 'false' 
+        else if(s.containsString('!true!')) then 'true'
+        else s;
 }
 
 %% We dont want this prefix when emitting typeinfo for primitives
@@ -145,9 +156,23 @@ function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression):
     }
 }
 
-%% TODO: Still call the Option<T> constructor, but pass in nones typeinfo and __CoreCpp::None as data
-function emitLiteralNoneExpression(exp: CPPAssembly::LiteralNoneExpression): CString {
-    return 'UINT64_MAX';
+function emitLiteralNoneExpression(exp: CPPAssembly::LiteralNoneExpression, ctx: Context): CString {
+    let opttk = ctx.inoption;
+    if(opttk)@none {
+        return 'UINT64_MAX';
+    }
+    else {
+        if(!ctx.asm.pconcepts.has($opttk.tkeystr)) {
+            abort;
+        }
+        let opt = ctx.asm.pconcepts.get($opttk.tkeystr)@<CPPAssembly::OptionTypeDecl>;
+        let name = CString::concat('Core::', emitTypeKeyBase($opttk.tkeystr, ctx));
+        let ttype = if(ctx.asm.isPrimtitiveType(opt.oftype.tkeystr) && opt.oftype.tkeystr.value !== 'bool') 
+            then opt.oftype.tkeystr.value.removePrefixString('__CoreCpp::') 
+            else emitTypeSignatureBase(opt.oftype, ctx);
+        
+        return CString::concat(name, '{ &NoneType, (uint64_t[]){ UINT64_MAX }}');
+    }
 }
 
 function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression): CString {
@@ -156,7 +181,7 @@ function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression
 }
 
 function emitReturnSingleStatement(ret: CPPAssembly::ReturnSingleStatement, ctx: Context, indent: CString): CString {
-    let exp = emitExpression(ret.value, ctx);
+    let exp = emitResolvedBooleansExpression(ret.value, ctx);
 
     let full_indent: CString = CString::concat(indent, '    ');
     return CString::concat(full_indent, 'return ', exp, ';%n;');
@@ -458,8 +483,6 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: CSt
     }
 }
 
-%% Emitting invalid '!true/false!' allows us to prevent naming conflicts and gives a matchable pattern that we can
-%% replace with 'true/false'
 function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSignature, ctx: Context): CString {
     %% For now we only support ITests where both types are concrete
     if(ctx.asm.isNominalTypeConcrete(it.ttype.tkeystr) && ctx.asm.isNominalTypeConcrete(baseType.tkeystr)) {
@@ -472,14 +495,14 @@ function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSi
     }
 }
 
-function emitITestSome(it: CPPAssembly::ITestSome, baseType: CPPAssembly::TypeSignature, ctx: Context): CString {
-    return CString::concat('.typeinfo != &NoneType');
+function emitITestSome(it: CPPAssembly::ITestSome, baseType: CPPAssembly::TypeSignature, rootExp: CString, ctx: Context): CString {
+    return if(it.isnot) then CString::concat(rootExp, '.typeinfo == &NoneType') else CString::concat(rootExp, '.typeinfo != &NoneType');
 }
 
-function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, ctx: Context): CString {
+function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, rootExp: CString, ctx: Context): CString {
     match(it)@ {
         CPPAssembly::ITestType => { return emitITestType($it, baseType, ctx); }
-        | CPPAssembly::ITestSome => { return emitITestSome($it, baseType, ctx); }
+        | CPPAssembly::ITestSome => { return emitITestSome($it, baseType, rootExp, ctx); }
         | _ => { abort; } %% TODO: Not Implemented!
     }
 }
@@ -495,14 +518,11 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
                 return emitPostfixAccessFromName($op, ctx);
             }
             | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, rootExp, ctx); }
-            | CPPAssembly::PostfixIsTest => { return emitITestAsTest($op.ttest, $op.baseType, ctx); }
+            | CPPAssembly::PostfixIsTest => { return emitITestAsTest($op.ttest, $op.baseType, rootExp, ctx); }
         }
     });
 
-    let res = CString::joinAll('', ops);
-
-    %% This could be a bit clunky - is there anywhere else we need to perform this substitution?
-    return if(res.containsString('!false!')) then 'false' else if(res.containsString('!true!')) then 'true' else res;
+    return CString::joinAll('', ops);
 }
 
 %%
@@ -513,7 +533,8 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): CString {
 %% Needs to call constructor for our Boxed<K> type, not too sure how to construct the args
 function emitConstructorPrimarySpecialSomeExpression(cpsse: CPPAssembly::ConstructorPrimarySpecialSomeExpression, ctx: Context): CString {
     let t = getSpecialTemplates();
-    let ttype = if(ctx.asm.isPrimtitiveType(cpsse.ofttype.tkeystr)) then cpsse.ofttype.tkeystr.value.removePrefixString('__CoreCpp::') 
+    let ttype = if(ctx.asm.isPrimtitiveType(cpsse.ofttype.tkeystr) && cpsse.ofttype.tkeystr.value !== 'bool') 
+        then cpsse.ofttype.tkeystr.value.removePrefixString('__CoreCpp::') 
         else emitTypeSignatureBase(cpsse.ofttype, ctx);
     let widenedtype = CString::concat('Core::Option', t.0, ttype, t.2);
     let tinfoptr = CString::concat('&', ttype, 'Type, ');
@@ -612,7 +633,7 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
         | CPPAssembly::BinLogicExpression => { return emitBinLogicExpression[recursive]($e, ctx); }
         | CPPAssembly::LogicActionAndExpression => { return emitLogicActionAndExpression[recursive]($e, ctx); }
         | CPPAssembly::LogicActionOrExpression => { return emitLogicActionOrExpression[recursive]($e, ctx); }
-        | CPPAssembly::LiteralNoneExpression => { return emitLiteralNoneExpression($e); }
+        | CPPAssembly::LiteralNoneExpression => { return emitLiteralNoneExpression($e, ctx); }
         | CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($e); }
         | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e); }
         | CPPAssembly::CallNamespaceFunctionExpression => { return emitCallNamespaceFunctionExpression($e, ctx); }
@@ -625,17 +646,22 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): CString {
     }
 }
 
+%% Resolves special '!true!' and '!false!' to true/false
+%% Intended to be used with any conditionals
+function emitResolvedBooleansExpression(e: CPPAssembly::Expression, ctx: Context): CString {
+    let expr = emitExpression(e, ctx);
+    return resolveSpecialBoolean(expr);
+}
+
 function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitializationStatement, ctx: Context, indent: CString): CString {
+    let nctx = if(ctx.asm.pconcepts.has(stmt.vtype.tkeystr)) then ctx.updateInOption(some(stmt.vtype))
+        else ctx;
+    
     let name = emitIdentifier(stmt.name);
-    let stype = emitTypeSignatureBase(stmt.vtype, ctx);
-    let tmp =  emitExpression(stmt.exp, ctx);
-
-    %% This could break for pconcepts that arent options, fine for now
-    let exp = if(ctx.asm.pconcepts.has(stmt.vtype.tkeystr) && stmt.exp?<CPPAssembly::LiteralNoneExpression>) 
-        then CString::concat(stype, '{&NoneType, (uint64_t[]){', tmp, '}}')
-
-        else tmp;
+    let stype = emitTypeSignatureBase(stmt.vtype, nctx);
+    let exp =  emitExpression(stmt.exp, nctx);
     let specialName = emitSpecialTemplate(stype);
+
 
     let full_indent: CString = CString::concat(indent, '    ', specialName);
     return CString::concat(full_indent, ' ', name, ' = ', exp, ';');
@@ -647,7 +673,7 @@ function emitBlockStatement(block: CPPAssembly::BlockStatement, ctx: Context, in
 }
 
 function emitIfSimpleStatement(stmt: CPPAssembly::IfSimpleStatement, ctx: Context, indent: CString): CString {
-    let expr = emitExpression(stmt.cond, ctx);
+    let expr = emitResolvedBooleansExpression(stmt.cond, ctx);
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
 
     let ifstmt = CString::concat(indent, 'if( ', expr, ' ) {%n;');
@@ -655,12 +681,11 @@ function emitIfSimpleStatement(stmt: CPPAssembly::IfSimpleStatement, ctx: Contex
 }
 
 function emitIfTestStatement(stmt: CPPAssembly::IfTestStatement, ctx: Context, indent: CString): CString {
-    let itest = emitITestAsTest(stmt.itest, stmt.cond.etype, ctx);
-    let expr = if(itest === '!false!') then 'false' else 
-        (if(itest === 'true') then 'true' else CString::concat(emitExpression(stmt.cond, ctx), itest));
+    let expr = emitResolvedBooleansExpression(stmt.cond, ctx);
+    let itest = emitITestAsTest(stmt.itest, stmt.cond.etype, expr, ctx);
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
 
-    let ifstmt = CString::concat(indent, 'if( ', expr, ' ) {%n;');
+    let ifstmt = CString::concat(indent, 'if( ', itest, ' ) {%n;');
     return CString::concat(ifstmt, trueBlock, indent, '}');
 }
 
@@ -679,7 +704,7 @@ function emitIfStatement(stmt: CPPAssembly::IfStatement, ctx: Context, indent: C
 }
 
 function emitIfElseSimpleStatement(stmt: CPPAssembly::IfElseSimpleStatement, ctx: Context, indent: CString): CString {
-    let expr = emitExpression(stmt.cond, ctx);
+    let expr = emitResolvedBooleansExpression(stmt.cond, ctx);
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
     let falseBlock = emitBlockStatement(stmt.falseBlock, ctx, indent);
     let elseBlockText = CString::concat(indent, 'else {%n;', falseBlock, indent, '}%n;');
@@ -689,14 +714,13 @@ function emitIfElseSimpleStatement(stmt: CPPAssembly::IfElseSimpleStatement, ctx
 }
 
 function emitIfElseTestStatement(stmt: CPPAssembly::IfElseTestStatement, ctx: Context, indent: CString): CString {
-    let itest = emitITestAsTest(stmt.itest, stmt.cond.etype, ctx);
-    let expr = if(itest === '!false!') then 'false' else 
-        (if(itest === 'true') then 'true' else CString::concat(emitExpression(stmt.cond, ctx), itest));
+    let expr = emitResolvedBooleansExpression(stmt.cond, ctx);
+    let itest = emitITestAsTest(stmt.itest, stmt.cond.etype, expr, ctx);
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
     let falseBlock = emitBlockStatement(stmt.falseBlock, ctx, indent);
     let elseBlockText = CString::concat(indent, 'else {%n;', falseBlock, indent, '}%n;');
     
-    let ifstmt = CString::concat(indent, 'if( ', expr, ' ) {%n;'); 
+    let ifstmt = CString::concat(indent, 'if( ', itest, ' ) {%n;'); 
     return CString::concat(ifstmt, trueBlock, indent, '}%n;', elseBlockText);
 }
 
@@ -1015,7 +1039,7 @@ function emitPrimtiveConceptTypeDecl(pc: CPPAssembly::PrimitiveConceptTypeDecl, 
     if(!ctx.asm.typeinfos.has(pc.tkey)) {
         abort;
     }
-    let k = ctx.asm.typeinfos.get(pc.tkey).slotsize;
+    let k = ctx.asm.typeinfos.get(pc.tkey).slotsize - 1n; %% Slot size includes '2' ptr to typeinfo, so we ignore
     let boxed = CString::concat('__CoreCpp::Boxed', '<', k.toCString(), '>'); 
     
     let constructor = CString::concat('public:%n;', indent, tkey, '(__CoreCpp::TypeInfoBase* ti, uint64_t* data) : ', boxed, '(ti, data) {}%n;');
@@ -1105,7 +1129,7 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): String {    
-    let ctx: Context = Context{ asm, CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''} }; %% No known namespace yet
+    let ctx: Context = Context{ asm, CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''}, none }; %% No known namespace yet
  
     let primitive_typeinfos = asm.typeinfos.reduce<CString>('', fn(acc, tk, ti) => {
         return if(asm.isPrimtitiveType(tk)) then CString::concat(acc, emitTypeInfo(ti, none, false, '')) else acc;

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -681,11 +681,12 @@ entity CPPTransformer {
 
     method transformDatatypeToCpp(dt: BSQAssembly::DatatypeTypeDecl): CPPAssembly::DatatypeTypeDecl {
         let base = this.transformAbstractNominalTypeDeclBase(dt@<BSQAssembly::AbstractNominalTypeDecl>);
+        let subtypes = dt.subtypes.map<CPPAssembly::TypeKey>(fn(tk) => CPPTransformNameManager::convertTypeKey(tk));
         let fields = this.transformMemberFieldDecl(dt.saturatedBFieldInfo, dt, dt.fields);
         let associatedMemberEntityDecls = dt.associatedMemberEntityDecls.map<CPPAssembly::NominalTypeSignature>(
             fn(e) => CPPTransformNameManager::convertNominalTypeSignature(e));
 
-        return CPPAssembly::DatatypeTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9, fields, associatedMemberEntityDecls }; 
+        return CPPAssembly::DatatypeTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9, subtypes, fields, associatedMemberEntityDecls }; 
     }
 
     method transformEntityDeclToCpp(e: BSQAssembly::EntityTypeDecl): CPPAssembly::EntityTypeDecl {
@@ -798,7 +799,7 @@ entity CPPTransformer {
                 let cppabsmethods = cppdatatype.absmethods.map<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>(fn(m) => (|m, cpptk|));
                 let cppovermethods = cppdatatype.overmethods.map<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>(fn(m) => (|m, cpptk|));
 
-                 return CPPTransformNameManager::getNamespaceDeclMapping(cppdatatype.fullns, acc,
+                return CPPTransformNameManager::getNamespaceDeclMapping(cppdatatype.fullns, acc,
                     fn(decl) => {
                         let new_datatypes = decl.datatypes.pushBack(cpptk);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, decl.typefuncs, decl.entities,
@@ -821,6 +822,12 @@ entity CPPTransformer {
             else {
                 abort; 
             }
+        });
+
+        let transformer_primitives = bsqasm.primtives.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveEntityTypeDecl>>(
+            Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveEntityTypeDecl>{}, fn(acc, tkey, pe) => {
+                let base = transformer.transformAbstractNominalTypeDeclBase(bsqasm.primtives.get(tkey)@<BSQAssembly::AbstractNominalTypeDecl>);
+                return acc.insert(base.2, CPPAssembly::PrimitiveEntityTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9 });
         });
 
         let transformer_staticmethods = bsqasm.staticmethods.reduce<Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclStatic>>(
@@ -862,6 +869,7 @@ entity CPPTransformer {
             absmethods = transformer_absmethods, %% Not fully implemented
             overmethods = transformer_overmethods, %% Not fully implemented
             entities = transformer_entities,
+            primitives = transformer_primitives,
             datamembers = transformer_datamembers,
             datatypes = transformer_datatypes,
             allmethods = transformer_allmethods, %% Might need to do someting like the funcs, being able to get the ns is nice

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -310,6 +310,7 @@ entity CPPTransformer {
         return CPPAssembly::ITestType{isnot, ttype};    
     }
 
+    %% TODO: Support for ITest as convert
     method transformITestAsTest(itest: BSQAssembly::ITest): CPPAssembly::ITest {
         let isnot = itest.isnot;
         match(itest)@ {
@@ -430,7 +431,11 @@ entity CPPTransformer {
         let cond = this.transformExpressionToCpp[recursive](stmt.texp);
         let trueBlock = this.transformBlockStatement(stmt.trueBlock);
 
-        return CPPAssembly::IfStatement{ cond, trueBlock };
+        match(stmt)@ {
+            BSQAssembly::IfSimpleStatement => { return CPPAssembly::IfSimpleStatement{ cond, trueBlock }; }
+            | BSQAssembly::IfTestStatement => { return CPPAssembly::IfTestStatement{ cond, trueBlock, this.transformITestAsTest($stmt.itest) }; }
+            | BSQAssembly::IfBinderStatement => { abort; } %% TODO: Not Implemented
+        }
     }
 
     recursive method transformIfElseStatement(stmt: BSQAssembly::IfElseStatement): CPPAssembly::IfElseStatement {
@@ -438,7 +443,11 @@ entity CPPTransformer {
         let trueBlock = this.transformBlockStatement(stmt.trueBlock);
         let falseBlock = this.transformBlockStatement(stmt.falseBlock);
 
-        return CPPAssembly::IfElseStatement{ cond, trueBlock, falseBlock };
+        match(stmt)@ {
+            BSQAssembly::IfElseSimpleStatement => { return CPPAssembly::IfElseSimpleStatement{ cond, trueBlock, falseBlock }; }
+            | BSQAssembly::IfElseTestStatement => { return CPPAssembly::IfElseTestStatement{ cond, trueBlock, falseBlock, this.transformITestAsTest($stmt.itest) }; }
+            | BSQAssembly::IfElseBinderStatement => { abort; } %% TODO: Not Implemented
+        }
     }
 
     recursive method transformIfElifElseStatement(stmt: BSQAssembly::IfElifElseStatement): CPPAssembly::IfElifElseStatement {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -436,7 +436,7 @@ entity CPPTransformer {
 
         match(exp)@ {
             BSQAssembly::IfSimpleExpression => { return CPPAssembly::IfSimpleExpression{ etype, texp, thenexp, elseexp }; }
-            | _ => { abort; } %% TODO: Not Implemented (need itests)
+            | _ => { abort; } %% TODO: Not Implemented 
         }
     }
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -737,7 +737,7 @@ entity CPPTransformer {
                 let pc = bsqasm.pconcepts.get(typekey);
                 if(pc)@<BSQAssembly::OptionTypeDecl> { %% I "think" sometype would be best here
                     let pcinfo = this.generateTypeInfo[recursive]($pc.someType.tkeystr, tinfos, cur_tid, bsqasm).0;
-                    let named_pcinfo = CPPAssembly::TypeInfo{ pcinfo.id, pcinfo.typesize, pcinfo.slotsize, pcinfo.ptrmask, cpptkey, pcinfo.tag };
+                    let named_pcinfo = CPPAssembly::TypeInfo{ pcinfo.id, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, CString::concat('2', pcinfo.ptrmask), cpptkey, pcinfo.tag };
 
                     %% Same as calculating Some<T> typeinfo
                     return (| named_pcinfo, tinfos.insert(cpptkey, named_pcinfo) |);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -12,7 +12,7 @@ namespace CPPTransformNameManager {
 
     function convertTypeKey(tk: BSQAssembly::TypeKey): CPPAssembly::TypeKey {
         switch(tk.value) {
-            'None' => { return CPPAssembly::TypeKey::from('None'); }
+            'None' => { return CPPAssembly::TypeKey::from('__CoreCpp::None'); }
             | 'Bool' => { return CPPAssembly::TypeKey::from('bool'); }
             | 'Nat' => { return CPPAssembly::TypeKey::from('__CoreCpp::Nat'); }
             | 'Int' => { return CPPAssembly::TypeKey::from('__CoreCpp::Int'); }
@@ -665,7 +665,7 @@ entity CPPTransformer {
     }
 
     recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat, bsqasm: BSQAssembly::Assembly): CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> { 
-        let cpptkey = if(!bsqasm.isPrimitiveType(typekey)) then CPPTransformNameManager::convertTypeKey(typekey) else CPPAssembly::TypeKey::from(typekey.value);
+        let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);
 
         var matchedType: CPPAssembly::TypeInfo;
         if(tinfos.has(cpptkey)) {
@@ -677,7 +677,7 @@ entity CPPTransformer {
 
         if(bsqasm.isPrimitiveType(typekey)) {
             switch(typekey) {
-                'None'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{     next_tid, 0n, 0n, '', cpptkey, CPPAssembly::Tag#Value }; }
+                'None'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{     next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
                 | 'Bool'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{   next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
                 | 'Nat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{    next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
                 | 'Int'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{    next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
@@ -758,7 +758,7 @@ entity CPPTransformer {
             abort; %% TODO: Type not supported for generating typeinfo!
         }
 
-        return matchedType, tinfos.insert(CPPTransformNameManager::convertTypeKey(typekey), matchedType);
+        return matchedType, tinfos.insert(cpptkey, matchedType);
     }
 
     method transformSaturatedFieldInfo(sfi: BSQAssembly::SaturatedFieldInfo): CPPAssembly::SaturatedFieldInfo {
@@ -953,7 +953,7 @@ entity CPPTransformer {
 
         %% I could see name conflicts arising with emitting pconcepts at top of file, so we do in ns to be safe
         let transformer_nsdecls_pconcepts = transformer_pconcepts.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            transformer_nsdecls_datamembers, fn(acc, cpptk, cpppc) => {
+            transformer_nsdecls_datatypes, fn(acc, cpptk, cpppc) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cpppc.fullns, acc,
                     fn(decl) => {
                         let new_pconcepts = decl.pconcepts.pushBack(cpptk);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -622,6 +622,33 @@ entity CPPTransformer {
         });
     }
 
+    %% Explore all subtypes and find largest possible field count
+    method findMaxFieldCount(cur: BSQAssembly::AbstractConceptTypeDecl, bsqasm: BSQAssembly::Assembly): Nat {
+        return cur.subtypes.reduce<Nat>(0n, fn(acc, subtk) => {
+            if(bsqasm.entities.has(subtk)) {
+                let fieldssize = bsqasm.entities.get(subtk).saturatedBFieldInfo.size();
+                return if(fieldssize > acc) then fieldssize else acc;
+            }
+            elif(bsqasm.datamembers.has(subtk)) {
+                let fieldssize = bsqasm.datamembers.get(subtk).saturatedBFieldInfo.size();
+                return if(fieldssize > acc) then fieldssize else acc;
+            }
+            else {
+                var subtype: BSQAssembly::AbstractConceptTypeDecl;
+                if(bsqasm.concepts.has(subtk)){
+                    subtype = bsqasm.concepts.get(subtk);
+                }
+                elif(bsqasm.datatypes.has(subtk)) {
+                    subtype = bsqasm.datatypes.get(subtk);
+                }
+                else {
+                    abort; %% Unsupported non-concrete type!
+                }
+                return this.findMaxFieldCount[recursive](subtype, bsqasm);
+            }
+        });
+    }
+
     method generateNominalConcreteTypeInfo(fields_tinfo: List<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>, tid: Nat, tkey: CPPAssembly::TypeKey, tag: CPPAssembly::Tag, asm: BSQAssembly::Assembly): CPPAssembly::TypeInfo {
         return fields_tinfo.reduce<CPPAssembly::TypeInfo>(CPPAssembly::TypeInfo{ tid, 0n, 0n, '', tkey, tag }, fn(acc, tinfo) => {
             let bsqtkey = CPPTransformNameManager::revertTypeKey(tinfo.0.typekey);
@@ -636,51 +663,54 @@ entity CPPTransformer {
         });
     }
 
-    recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, asm: BSQAssembly::Assembly): CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> { 
+    recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat, bsqasm: BSQAssembly::Assembly): CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> { 
         let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);
 
         var matchedType: CPPAssembly::TypeInfo;
         if(tinfos.has(cpptkey)) {
             return tinfos.get(cpptkey), tinfos;
         }
-        elif(asm.isPrimtitiveType(typekey)) {
+
+        let cur_tid = tid;
+        let next_tid = tid + 1n;
+
+        if(bsqasm.isPrimtitiveType(typekey)) {
             switch(typekey) {
-                'None'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 6n, 0n, 0n, '', cpptkey, CPPAssembly::Tag#Value }; }
-                | 'Bool'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 5n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
-                | 'Nat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 1n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
-                | 'Int'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 0n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
-                | 'BigNat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 1n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
-                | 'BigInt'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 2n, 16n, 2n, '00', cpptkey, CPPAssembly::Tag#Value }; }
-                | 'Float'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ 4n, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                'None'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{     next_tid, 0n, 0n, '', cpptkey, CPPAssembly::Tag#Value }; }
+                | 'Bool'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{   next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                | 'Nat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{    next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                | 'Int'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{    next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                | 'BigNat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                | 'BigInt'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ next_tid, 16n, 2n, '00', cpptkey, CPPAssembly::Tag#Value }; }
+                | 'Float'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{  next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
                 | _ => { abort; } %% Not supported by cpp emitter yet!
             }
         }
-        elif(asm.isNominalTypeConcrete(typekey)) {
+        elif(bsqasm.isNominalTypeConcrete(typekey)) {
             %% We can't compare tkey like primtives, so check if container has our tkey
             var fields_tinfo: List<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>;
-            var tid: Nat;
             var tag: CPPAssembly::Tag;
             var tkey: CPPAssembly::TypeKey;
-            if(asm.entities.has(typekey)) {
-                let e = asm.entities.get(typekey);
-                let isRef = CPPTransformNameManager::shouldBeRef(e.fields, asm);
-                fields_tinfo = e.saturatedBFieldInfo.map<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(fn(f_tkey) => this.generateTypeInfo[recursive](f_tkey.ftype.tkeystr, tinfos, asm) );
-                tid = 7n;
+            if(bsqasm.entities.has(typekey)) {
+                let e = bsqasm.entities.get(typekey);
+                let isRef = CPPTransformNameManager::shouldBeRef(e.fields, bsqasm);
+                fields_tinfo = e.saturatedBFieldInfo.map<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(
+                    fn(f_tkey) => this.generateTypeInfo[recursive](f_tkey.ftype.tkeystr, tinfos, cur_tid, bsqasm) );
                 tag = if(isRef) then CPPAssembly::Tag#Ref else CPPAssembly::Tag#Value;
                 tkey = CPPTransformNameManager::convertTypeKey(e.tkey);
             }
-            elif(asm.datamembers.has(typekey)) {
-                let dm = asm.datamembers.get(typekey);
-                let isRef = CPPTransformNameManager::shouldBeRef(dm.fields, asm);
-                fields_tinfo = dm.saturatedBFieldInfo.map<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(fn(f_tkey) => this.generateTypeInfo[recursive](f_tkey.ftype.tkeystr, tinfos, asm) );
-                tid = 8n;
+            elif(bsqasm.datamembers.has(typekey)) {
+                let dm = bsqasm.datamembers.get(typekey);
+                let isRef = CPPTransformNameManager::shouldBeRef(dm.fields, bsqasm);
+                fields_tinfo = dm.saturatedBFieldInfo.map<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(
+                    fn(f_tkey) => this.generateTypeInfo[recursive](f_tkey.ftype.tkeystr, tinfos, cur_tid, bsqasm) );
                 tag = if(isRef) then CPPAssembly::Tag#Ref else CPPAssembly::Tag#Value;
                 tkey = CPPTransformNameManager::convertTypeKey(dm.tkey);
             }
-            elif(asm.constructables.has(typekey)) { %% Not totally sure if we need to add constructables to cpp asm...
-                let cons = asm.constructables.get(typekey);
+            elif(bsqasm.constructables.has(typekey)) { %% Not totally sure if we need to add constructables to cpp bsqasm...
+                let cons = bsqasm.constructables.get(typekey);
                 if(cons)@<BSQAssembly::SomeTypeDecl> { %% Only support Some<T> for now
-                    let someinfo = this.generateTypeInfo[recursive]($cons.oftype.tkeystr, tinfos, asm).0;
+                    let someinfo = this.generateTypeInfo[recursive]($cons.oftype.tkeystr, tinfos, cur_tid, bsqasm).0;
                     let named_someinfo = CPPAssembly::TypeInfo{ someinfo.id, someinfo.typesize, someinfo.slotsize, someinfo.ptrmask, cpptkey, someinfo.tag };
 
                     %% We need to return early as all work was done in calculating someinfo
@@ -692,20 +722,20 @@ entity CPPTransformer {
                 abort; %% TODO: Type not supported for typeinfo emission!
             }
 
-            matchedType = this.generateNominalConcreteTypeInfo(fields_tinfo, tid, tkey, tag, asm);
+            matchedType = this.generateNominalConcreteTypeInfo(fields_tinfo, next_tid, tkey, tag, bsqasm);
         }
-        elif(asm.isNominalTypeConcept(typekey)) {
+        elif(bsqasm.isNominalTypeConcept(typekey)) {
             var maxFieldCount: Nat;
-            if(asm.concepts.has(typekey)) {
-                maxFieldCount = asm.concepts.reduce<Nat>(0n, fn(acc, c, e) => {
-                    let size = e.fields.size();
-                    return if(acc < size) then size else acc;
-                });
+            if(bsqasm.concepts.has(typekey)) {
+                maxFieldCount = this.findMaxFieldCount(bsqasm.concepts.get(typekey)@<BSQAssembly::AbstractConceptTypeDecl>, bsqasm);
             }
-            elif(asm.pconcepts.has(typekey)) {
-                let pc = asm.pconcepts.get(typekey);
-                if(pc)@<BSQAssembly::OptionTypeDecl> { %% is $pc.someType right here? what about oftype?
-                    let pcinfo = this.generateTypeInfo[recursive]($pc.someType.tkeystr, tinfos, asm).0;
+            elif(bsqasm.datatypes.has(typekey)) { 
+                maxFieldCount = this.findMaxFieldCount(bsqasm.datatypes.get(typekey)@<BSQAssembly::AbstractConceptTypeDecl>, bsqasm);
+            }
+            elif(bsqasm.pconcepts.has(typekey)) {
+                let pc = bsqasm.pconcepts.get(typekey);
+                if(pc)@<BSQAssembly::OptionTypeDecl> { %% I "think" sometype would be best here
+                    let pcinfo = this.generateTypeInfo[recursive]($pc.someType.tkeystr, tinfos, cur_tid, bsqasm).0;
                     let named_pcinfo = CPPAssembly::TypeInfo{ pcinfo.id, pcinfo.typesize, pcinfo.slotsize, pcinfo.ptrmask, cpptkey, pcinfo.tag };
 
                     %% Same as calculating Some<T> typeinfo
@@ -718,15 +748,14 @@ entity CPPTransformer {
             else {
                 abort; %% Not a concept
             }
-            %%
-            %% TODO: Our concepts will all need a unique TypeId in their emission! Hardcoding them as 8n will not work.
-            %%
 
+            %%
             %% ptrmask == '2' means it is storing type info
             %% To prevent dataloss we fill the rest of slots with zeros, where the number of 
             %% zeros represents the maximum number of possible fields in subtypes
+            %%
             let ptr_mask = CPPTransformNameManager::repeatCString('0', maxFieldCount, '2');
-            matchedType = CPPAssembly::TypeInfo{ 8n, 8n + (maxFieldCount * 8n), maxFieldCount + 1n, ptr_mask, CPPTransformNameManager::convertTypeKey(typekey), CPPAssembly::Tag#Tagged }; 
+            matchedType = CPPAssembly::TypeInfo{ next_tid, 8n + (maxFieldCount * 8n), maxFieldCount + 1n, ptr_mask, CPPTransformNameManager::convertTypeKey(typekey), CPPAssembly::Tag#Tagged }; 
         }
         else {
             abort; %% TODO: Type not supported for generating typeinfo!
@@ -972,14 +1001,16 @@ entity CPPTransformer {
             return CPPTransformNameManager::convertInvokeKey(ikey);
         });
 
-        let generated_typeinfos_concrete = bsqasm.allconcretetypes.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>>(
-            Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>{}, fn(acc, tkey) => {
-                return transformer.generateTypeInfo(tkey, acc, bsqasm).1;
+        let generated_typeinfos_concrete = bsqasm.allconcretetypes.reduce<(| Nat, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> |)>(
+            (| 0n, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>{} |), fn(acc, tkey) => {
+                let gen_tinfo = transformer.generateTypeInfo(tkey, acc.1, acc.0, bsqasm);
+                return (| acc.0 + 1n, gen_tinfo.1 |);
             });
         
-        let generated_typeinfos_abstract = bsqasm.allabstracttypes.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>>(
-            generated_typeinfos_concrete, fn(acc,tkey) => {
-                return transformer.generateTypeInfo(tkey, acc, bsqasm).1;
+        let generated_typeinfos_abstract = bsqasm.allabstracttypes.reduce<(| Nat, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> |)>(
+            generated_typeinfos_concrete, fn(acc, tkey) => {
+                let gen_tinfo = transformer.generateTypeInfo(tkey, acc.1, acc.0, bsqasm);
+                return (| acc.0 + 1n, gen_tinfo.1 |);
             });
 
         return CPPAssembly::Assembly {
@@ -997,7 +1028,7 @@ entity CPPTransformer {
             datatypes = transformer_datatypes,
             pconcepts = transformer_pconcepts,
             allmethods = transformer_allmethods, %% Might need to do someting like the funcs, being able to get the ns is nice
-            typeinfos = generated_typeinfos_abstract
+            typeinfos = generated_typeinfos_abstract.1
         };
     }
 }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -159,6 +159,11 @@ entity CPPTransformer {
         return CPPAssembly::BinMultExpression{ lexpr.etype, lexpr, rexpr };
     }
 
+    method transformLiteralNoneExpression(expr: BSQAssembly::LiteralNoneExpression): CPPAssembly::LiteralNoneExpression {
+        let etype = CPPTransformNameManager::convertTypeSignature(expr.etype);
+        return CPPAssembly::LiteralNoneExpression{ etype };
+    }
+
     method transformLiteralSimpleExpression(expr: BSQAssembly::LiteralSimpleExpression): CPPAssembly::LiteralSimpleExpression {
         let val = expr.value;
         let exprtype = CPPTransformNameManager::convertTypeSignature(expr.etype);
@@ -283,6 +288,11 @@ entity CPPTransformer {
         });
         return CPPAssembly::ArgumentList{ shuffled };   
     }
+    
+    %% This does not shuffle
+    method transformArgumentList(al: BSQAssembly::ArgumentList): CPPAssembly::ArgumentList {
+        return CPPAssembly::ArgumentList{ al.args.map<Option<CPPAssembly::ArgumentValue>>(fn(arg) => some(this.transformArgument(arg))) };
+    }
 
     method transformCallNamespaceFunctionExpression(expr: BSQAssembly::CallNamespaceFunctionExpression): CPPAssembly::CallNamespaceFunctionExpression {
         let ts = CPPTransformNameManager::convertTypeSignature(expr.etype);
@@ -351,29 +361,65 @@ entity CPPTransformer {
         return CPPAssembly::PostfixOp{ etype, rootExp, ops };
     }
 
-    method transformConstructorStdExpression(e: BSQAssembly::ConstructorStdExpression): CPPAssembly::ConstructorStdExpression {
-        %% Would be good to have transformArgumentInfo eventually be able to handle different format shuffleinfo
-        let args = e.shuffleinfo.mapIdx<Option<CPPAssembly::ArgumentValue>>(fn(she, ii) => {
-            var cur_arg: CPPAssembly::ArgumentValue;
-            if(ii >= e.args.args.size()) {
-                return none;
-            }
-            else { %% Resolve shuffle value
-                let shuffle_idx = she.0;
-                if(shuffle_idx)@none {
-                    let arg = e.args.args.get(ii);
-                    return some(this.transformArgument(arg));
-                }
-                else {
-                    let arg = e.args.args.get($shuffle_idx);
-                    return some(this.transformArgument(arg));
-                }
-            }
-         });
-        let ctype = CPPTransformNameManager::convertNominalTypeSignature(e.ctype);
-        let etype = CPPTransformNameManager::convertTypeSignature(e.etype);
+    method transformConstructorPrimaryExpressionBase(cpe: BSQAssembly::ConstructorPrimaryExpression): (| CPPAssembly::TypeSignature,
+        CPPAssembly::ArgumentList, CPPAssembly::NominalTypeSignature |) {
+            let etype = CPPTransformNameManager::convertTypeSignature(cpe.etype);
+            let args = this.transformArgumentList(cpe.args);
+            let ctype = CPPTransformNameManager::convertNominalTypeSignature(cpe.ctype);
 
-        return CPPAssembly::ConstructorStdExpression{ etype, CPPAssembly::ArgumentList{ args }, ctype, e.fullns };
+            return (| etype, args, ctype|);
+    }
+
+    method transformConstructorPrimarySpecialSomeExpression(cpsse: BSQAssembly::ConstructorPrimarySpecialSomeExpression): CPPAssembly::ConstructorPrimarySpecialSomeExpression {
+        let base = this.transformConstructorPrimaryExpressionBase(cpsse@<BSQAssembly::ConstructorPrimaryExpression>);
+        let ofttype = CPPTransformNameManager::convertTypeSignature(cpsse.ofttype);
+
+        return CPPAssembly::ConstructorPrimarySpecialSomeExpression{ base.0, base.1, base.2, ofttype };
+    }
+
+    method transformConstructorPrimarySpecialOkExpression(cpsoe: BSQAssembly::ConstructorPrimarySpecialOkExpression): CPPAssembly::ConstructorPrimarySpecialOkExpression {
+        abort; %% TODO: Not Implemented
+    }   
+
+    method transformConstructorPrimarySpecialFailExpression(cpsfe: BSQAssembly::ConstructorPrimarySpecialFailExpression): CPPAssembly::ConstructorPrimarySpecialFailExpression {
+        abort; %% TODO: Not Implemented
+    }
+
+    method transformConstructorPrimarySpecialConstructableExpression(cpsce: BSQAssembly::ConstructorPrimarySpecialConstructableExpression): CPPAssembly::ConstructorPrimarySpecialConstructableExpression {
+        match(cpsce)@ {
+            BSQAssembly::ConstructorPrimarySpecialSomeExpression => { return this.transformConstructorPrimarySpecialSomeExpression($cpsce); }
+            | BSQAssembly::ConstructorPrimarySpecialOkExpression => { return this.transformConstructorPrimarySpecialOkExpression($cpsce); }
+            | BSQAssembly::ConstructorPrimarySpecialFailExpression => { return this.transformConstructorPrimarySpecialFailExpression($cpsce); }
+        }
+    }
+
+    method transformConstructorStdExpression(e: BSQAssembly::ConstructorStdExpression): CPPAssembly::ConstructorStdExpression {
+        let base = this.transformConstructorPrimaryExpressionBase(e@<BSQAssembly::ConstructorPrimaryExpression>);        
+        let shuffledargs = e.shuffleinfo.mapIdx<Option<CPPAssembly::ArgumentValue>>(fn(she, ii) => {
+                var cur_arg: CPPAssembly::ArgumentValue;
+                if(ii >= e.args.args.size()) {
+                    return none;
+                }
+                else { %% Resolve shuffle value
+                    let shuffle_idx = she.0;
+                    if(shuffle_idx)@none {
+                        let arg = base.1.args.get(ii);
+                        if(arg)@!none {
+                            return some($arg);
+                        }
+                        abort;
+                    }
+                    else {
+                        let arg = base.1.args.get($shuffle_idx);
+                        if(arg)@!none {
+                            return some($arg);
+                        }
+                        abort;
+                    }
+                }
+            });
+
+        return CPPAssembly::ConstructorStdExpression{ base.0, CPPAssembly::ArgumentList{ shuffledargs }, base.2, e.fullns };
     } 
 
     method transformIfExpression(exp: BSQAssembly::IfExpression): CPPAssembly::IfExpression {
@@ -392,6 +438,7 @@ entity CPPTransformer {
         match(expr)@ {
             BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpression[recursive]($expr); }
             | BSQAssembly::BinaryNumericExpression => { return this.transformBinaryNumericCompareExpression[recursive]($expr); }
+            | BSQAssembly::LiteralNoneExpression => { return this.transformLiteralNoneExpression($expr); }
             | BSQAssembly::LiteralSimpleExpression => { return this.transformLiteralSimpleExpression($expr); }
             | BSQAssembly::UnaryExpression => { return this.transformUnaryExpression[recursive]($expr); }
             | BSQAssembly::BinLogicExpression => { return this.transformBinLogicExpression[recursive]($expr); }
@@ -401,6 +448,7 @@ entity CPPTransformer {
             | BSQAssembly::CallNamespaceFunctionExpression => { return this.transformCallNamespaceFunctionExpression($expr); } 
             | BSQAssembly::CallTypeFunctionExpression => { return this.transformCallTypeFunctionExpression($expr); }
             | BSQAssembly::PostfixOp => { return this.transformPostfixOp($expr); }
+            | BSQAssembly::ConstructorPrimarySpecialConstructableExpression => { return this.transformConstructorPrimarySpecialConstructableExpression($expr); }
             | BSQAssembly::ConstructorStdExpression => { return this.transformConstructorStdExpression($expr); }
             | BSQAssembly::IfExpression => { return this.transformIfExpression($expr); }
             | _ => { abort; }
@@ -680,6 +728,15 @@ entity CPPTransformer {
             ant.name, staticmethods, virtmethods, absmethods, overmethods, saturatedProvides, saturatedBFieldInfo|);
     }
 
+    method transformAbstractConceptTypeDeclBase(act: BSQAssembly::AbstractConceptTypeDecl): (|CPPAssembly::NamespaceKey, List<CString>, CPPAssembly::TypeKey, 
+        CString, List<CPPAssembly::InvokeKey>, List<CPPAssembly::InvokeKey>, List<CPPAssembly::InvokeKey>, List<CPPAssembly::InvokeKey>, 
+        List<CPPAssembly::NominalTypeSignature>, List<CPPAssembly::SaturatedFieldInfo>, List<CPPAssembly::TypeKey>|) {
+            let base = this.transformAbstractNominalTypeDeclBase(act@<BSQAssembly::AbstractNominalTypeDecl>);
+            let subtypes = act.subtypes.map<CPPAssembly::TypeKey>(fn(tk) => CPPTransformNameManager::convertTypeKey(tk));
+    
+            return (|base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9, subtypes|);
+    }
+
     method transformDatatypeMemberToCpp(dm: BSQAssembly::DatatypeMemberEntityTypeDecl): CPPAssembly::DatatypeMemberEntityTypeDecl {
         let base = this.transformAbstractNominalTypeDeclBase(dm@<BSQAssembly::AbstractNominalTypeDecl>);
         let fields = this.transformMemberFieldDecl(dm.saturatedBFieldInfo, dm, dm.fields);
@@ -689,13 +746,12 @@ entity CPPTransformer {
     }
 
     method transformDatatypeToCpp(dt: BSQAssembly::DatatypeTypeDecl): CPPAssembly::DatatypeTypeDecl {
-        let base = this.transformAbstractNominalTypeDeclBase(dt@<BSQAssembly::AbstractNominalTypeDecl>);
-        let subtypes = dt.subtypes.map<CPPAssembly::TypeKey>(fn(tk) => CPPTransformNameManager::convertTypeKey(tk));
+        let base = this.transformAbstractConceptTypeDeclBase(dt@<BSQAssembly::AbstractConceptTypeDecl>);
         let fields = this.transformMemberFieldDecl(dt.saturatedBFieldInfo, dt, dt.fields);
         let associatedMemberEntityDecls = dt.associatedMemberEntityDecls.map<CPPAssembly::NominalTypeSignature>(
             fn(e) => CPPTransformNameManager::convertNominalTypeSignature(e));
 
-        return CPPAssembly::DatatypeTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9, subtypes, fields, associatedMemberEntityDecls }; 
+        return CPPAssembly::DatatypeTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9, base.10, fields, associatedMemberEntityDecls }; 
     }
 
     method transformEntityDeclToCpp(e: BSQAssembly::EntityTypeDecl): CPPAssembly::EntityTypeDecl {
@@ -705,11 +761,29 @@ entity CPPTransformer {
         return CPPAssembly::EntityTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9, fields };
     }
 
-    %*
-    method transformNamespaceConstDecl(decl: BSQAssembly::NamespaceConstDecl): CPPAssembly::NamespaceConstDecl {
-        abort;
+    method transformOptionTypeDecl(opt: BSQAssembly::OptionTypeDecl): CPPAssembly::OptionTypeDecl {
+        let base = this.transformAbstractConceptTypeDeclBase(opt@<BSQAssembly::AbstractConceptTypeDecl>);
+        let ttype = CPPTransformNameManager::convertTypeSignature(opt.oftype);
+        let someType = CPPTransformNameManager::convertTypeSignature(opt.someType);
+
+        return CPPAssembly::OptionTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9, base.10, ttype, someType };
     }
-    *%
+
+    method transformResultTypeDecl(rtd: BSQAssembly::ResultTypeDecl): CPPAssembly::ResultTypeDecl {
+        abort; %% TODO: Not Implemented
+    }
+
+    method transformAPIResultTypeDecl(apirtd: BSQAssembly::APIResultTypeDecl): CPPAssembly::APIResultTypeDecl {
+        abort; %% TODO: Not Implemented
+    }
+
+    method transformPrimitiveConceptDeclToCpp(pc: BSQAssembly::PrimitiveConceptTypeDecl): CPPAssembly::PrimitiveConceptTypeDecl {
+        match(pc)@ {
+            BSQAssembly::OptionTypeDecl => { return this.transformOptionTypeDecl($pc); }
+            | BSQAssembly::ResultTypeDecl => { return this.transformResultTypeDecl($pc); }
+            | BSQAssembly::APIResultTypeDecl => { return this.transformAPIResultTypeDecl($pc); }
+        }
+    }
 
     function convertBsqAsmToCpp(bsqasm: BSQAssembly::Assembly): CPPAssembly::Assembly {
         let transformer = CPPTransformer{ bsqasm };            
@@ -859,6 +933,12 @@ entity CPPTransformer {
                 return acc.insert(CPPTransformNameManager::convertInvokeKey(ikey), transformer.transformOverrideMethodDecl(decl));
         });
 
+        let transformer_pconcepts = bsqasm.pconcepts.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveConceptTypeDecl>>(
+            Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveConceptTypeDecl>{}, fn(acc, tk, pc) => {
+                let cpppc = transformer.transformPrimitiveConceptDeclToCpp(pc);
+                return acc.insert(cpppc.tkey, cpppc);
+            });
+
         let transformer_allmethods = bsqasm.allmethods.map<CPPAssembly::InvokeKey>(fn(ikey) => {
             return CPPTransformNameManager::convertInvokeKey(ikey);
         });
@@ -877,10 +957,11 @@ entity CPPTransformer {
             virtmethods = transformer_virtmethods,
             absmethods = transformer_absmethods, %% Not fully implemented
             overmethods = transformer_overmethods, %% Not fully implemented
-            entities = transformer_entities,
             primitives = transformer_primitives,
+            entities = transformer_entities,
             datamembers = transformer_datamembers,
             datatypes = transformer_datatypes,
+            pconcepts = transformer_pconcepts,
             allmethods = transformer_allmethods, %% Might need to do someting like the funcs, being able to get the ns is nice
             typeinfos = generated_typeinfos
         };

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -317,7 +317,11 @@ entity CPPTransformer {
 
     method transformITestType(it: BSQAssembly::ITestType, isnot: Bool): CPPAssembly::ITestType {
         let ttype = CPPTransformNameManager::convertTypeSignature(it.ttype);
-        return CPPAssembly::ITestType{isnot, ttype};    
+        return CPPAssembly::ITestType{ isnot, ttype };    
+    }
+
+    method transformITestSome(isnot: Bool): CPPAssembly::ITestSome {
+        return CPPAssembly::ITestSome{ isnot };
     }
 
     %% TODO: Support for ITest as convert
@@ -325,7 +329,8 @@ entity CPPTransformer {
         let isnot = itest.isnot;
         match(itest)@ {
             BSQAssembly::ITestType => { return this.transformITestType($itest, isnot); }
-            | _ => { abort; } %% Gonna do in a sec
+            | BSQAssembly::ITestSome => { return this.transformITestSome(isnot); }
+            | _ => { abort; } 
         }
     }
 
@@ -672,6 +677,17 @@ entity CPPTransformer {
                 tag = if(isRef) then CPPAssembly::Tag#Ref else CPPAssembly::Tag#Value;
                 tkey = CPPTransformNameManager::convertTypeKey(dm.tkey);
             }
+            elif(asm.constructables.has(typekey)) { %% Not totally sure if we need to add constructables to cpp asm...
+                let cons = asm.constructables.get(typekey);
+                if(cons)@<BSQAssembly::SomeTypeDecl> { %% Only support Some<T> for now
+                    let someinfo = this.generateTypeInfo[recursive]($cons.oftype.tkeystr, tinfos, asm).0;
+                    let named_someinfo = CPPAssembly::TypeInfo{ someinfo.id, someinfo.typesize, someinfo.slotsize, someinfo.ptrmask, cpptkey, someinfo.tag };
+
+                    %% We need to return early as all work was done in calculating someinfo
+                    return (| named_someinfo, tinfos.insert(cpptkey, named_someinfo) |);
+                }
+                abort;
+            }
             else {
                 abort; %% TODO: Type not supported for typeinfo emission!
             }
@@ -687,12 +703,25 @@ entity CPPTransformer {
                 });
             }
             elif(asm.pconcepts.has(typekey)) {
-                abort; %% TODO: Add support for primtive concepts 
+                let pc = asm.pconcepts.get(typekey);
+                if(pc)@<BSQAssembly::OptionTypeDecl> { %% is $pc.someType right here? what about oftype?
+                    let pcinfo = this.generateTypeInfo[recursive]($pc.someType.tkeystr, tinfos, asm).0;
+                    let named_pcinfo = CPPAssembly::TypeInfo{ pcinfo.id, pcinfo.typesize, pcinfo.slotsize, pcinfo.ptrmask, cpptkey, pcinfo.tag };
+
+                    %% Same as calculating Some<T> typeinfo
+                    return (| named_pcinfo, tinfos.insert(cpptkey, named_pcinfo) |);
+                }
+                else {
+                    abort; %% TODO: Support for other primitive concepts! 
+                }
             }
             else {
                 abort; %% Not a concept
             }
-            
+            %%
+            %% TODO: Our concepts will all need a unique TypeId in their emission! Hardcoding them as 8n will not work.
+            %%
+
             %% ptrmask == '2' means it is storing type info
             %% To prevent dataloss we fill the rest of slots with zeros, where the number of 
             %% zeros represents the maximum number of possible fields in subtypes
@@ -943,8 +972,13 @@ entity CPPTransformer {
             return CPPTransformNameManager::convertInvokeKey(ikey);
         });
 
-        let generated_typeinfos = bsqasm.allconcretetypes.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>>(
+        let generated_typeinfos_concrete = bsqasm.allconcretetypes.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>>(
             Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>{}, fn(acc, tkey) => {
+                return transformer.generateTypeInfo(tkey, acc, bsqasm).1;
+            });
+        
+        let generated_typeinfos_abstract = bsqasm.allabstracttypes.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>>(
+            generated_typeinfos_concrete, fn(acc,tkey) => {
                 return transformer.generateTypeInfo(tkey, acc, bsqasm).1;
             });
 
@@ -963,7 +997,7 @@ entity CPPTransformer {
             datatypes = transformer_datatypes,
             pconcepts = transformer_pconcepts,
             allmethods = transformer_allmethods, %% Might need to do someting like the funcs, being able to get the ns is nice
-            typeinfos = generated_typeinfos
+            typeinfos = generated_typeinfos_abstract
         };
     }
 }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -749,11 +749,7 @@ entity CPPTransformer {
                 abort; %% Not a concept
             }
 
-            %%
-            %% ptrmask == '2' means it is storing type info
-            %% To prevent dataloss we fill the rest of slots with zeros, where the number of 
-            %% zeros represents the maximum number of possible fields in subtypes
-            %%
+            %% ptrmask == 2 means we store typeinfo, fill rest with zeros so gc ignores
             let ptr_mask = CPPTransformNameManager::repeatCString('0', maxFieldCount, '2');
             matchedType = CPPAssembly::TypeInfo{ next_tid, 8n + (maxFieldCount * 8n), maxFieldCount + 1n, ptr_mask, CPPTransformNameManager::convertTypeKey(typekey), CPPAssembly::Tag#Tagged }; 
         }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -61,13 +61,14 @@ namespace CPPTransformNameManager {
         let entities = List<CPPAssembly::TypeKey>{};
         let datamembers = List<CPPAssembly::TypeKey>{};
         let datatypes = List<CPPAssembly::TypeKey>{};
+        let pconcepts = List<CPPAssembly::TypeKey>{};
         let staticmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>{};
         let virtmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>{};
         let absmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>{};
         let overmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>{};
 
-        return CPPAssembly::NamespaceDecl{ name, subns, nsfuncs, typefuncs, entities, datamembers, datatypes, staticmethods, 
-            virtmethods, absmethods, overmethods };
+        return CPPAssembly::NamespaceDecl{ name, subns, nsfuncs, typefuncs, entities, datamembers, datatypes, pconcepts,
+            staticmethods, virtmethods, absmethods, overmethods };
     }
 
     %% If ns decl does not exist for name insert, otherwise continue recursing until fullns is empty
@@ -90,7 +91,7 @@ namespace CPPTransformNameManager {
         %% Recursively process remaining names
         let subns = getNamespaceDeclMapping[recursive](remaining_ns_names, cur_nsdecl.subns, insertion);
         let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, subns, cur_nsdecl.nsfuncs, cur_nsdecl.typefuncs, cur_nsdecl.entities, 
-            cur_nsdecl.datamembers, cur_nsdecl.datatypes, cur_nsdecl.staticmethods, cur_nsdecl.virtmethods, cur_nsdecl.absmethods, cur_nsdecl.overmethods };
+            cur_nsdecl.datamembers, cur_nsdecl.datatypes, cur_nsdecl.pconcepts, cur_nsdecl.staticmethods, cur_nsdecl.virtmethods, cur_nsdecl.absmethods, cur_nsdecl.overmethods };
 
         if(remaining_ns_names.empty()) { %% Insert at most nested possible depth
             if(!nsdecls.has(ns_name)) {
@@ -114,7 +115,7 @@ namespace CPPTransformNameManager {
     }
 
     function shouldBeRef(fields: List<BSQAssembly::MemberFieldDecl>, asm: BSQAssembly::Assembly): Bool {
-        let fieldsPrimitive = fields.reduce<Bool>(true, fn(acc, f) => acc && asm.isPrimtitiveType(f.declaredType.tkeystr));
+        let fieldsPrimitive = fields.reduce<Bool>(true, fn(acc, f) => acc && asm.isPrimitiveType(f.declaredType.tkeystr));
         if(fields.size() > 4n || !fieldsPrimitive) {
             return true;
         }
@@ -652,7 +653,7 @@ entity CPPTransformer {
     method generateNominalConcreteTypeInfo(fields_tinfo: List<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>, tid: Nat, tkey: CPPAssembly::TypeKey, tag: CPPAssembly::Tag, asm: BSQAssembly::Assembly): CPPAssembly::TypeInfo {
         return fields_tinfo.reduce<CPPAssembly::TypeInfo>(CPPAssembly::TypeInfo{ tid, 0n, 0n, '', tkey, tag }, fn(acc, tinfo) => {
             let bsqtkey = CPPTransformNameManager::revertTypeKey(tinfo.0.typekey);
-            if(asm.isNominalTypeConcrete(bsqtkey) && !asm.isPrimtitiveType(bsqtkey)) { %% Pointer to other Concrete Nominal (non primitive) type
+            if(asm.isNominalTypeConcrete(bsqtkey) && !asm.isPrimitiveType(bsqtkey)) { %% Pointer to other Concrete Nominal (non primitive) type
                 if(tinfo.0.tag === CPPAssembly::Tag#Ref) {
                     return CPPAssembly::TypeInfo{ acc.id, acc.typesize + 8n, acc.slotsize + 1n, CString::concat(acc.ptrmask, '1'), acc.typekey, acc.tag };
                 }
@@ -664,7 +665,7 @@ entity CPPTransformer {
     }
 
     recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat, bsqasm: BSQAssembly::Assembly): CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> { 
-        let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);
+        let cpptkey = if(!bsqasm.isPrimitiveType(typekey)) then CPPTransformNameManager::convertTypeKey(typekey) else CPPAssembly::TypeKey::from(typekey.value);
 
         var matchedType: CPPAssembly::TypeInfo;
         if(tinfos.has(cpptkey)) {
@@ -674,7 +675,7 @@ entity CPPTransformer {
         let cur_tid = tid;
         let next_tid = tid + 1n;
 
-        if(bsqasm.isPrimtitiveType(typekey)) {
+        if(bsqasm.isPrimitiveType(typekey)) {
             switch(typekey) {
                 'None'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{     next_tid, 0n, 0n, '', cpptkey, CPPAssembly::Tag#Value }; }
                 | 'Bool'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{   next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
@@ -859,7 +860,7 @@ entity CPPTransformer {
                     fn(decl) => { 
                         let new_nsfuncs = decl.nsfuncs.pushBack(cppfunc.ikey);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, new_nsfuncs, decl.typefuncs, decl.entities, 
-                            decl.datamembers, decl.datatypes, decl.staticmethods, decl.virtmethods, decl.absmethods, decl.overmethods };
+                            decl.datamembers, decl.datatypes, decl.pconcepts, decl.staticmethods, decl.virtmethods, decl.absmethods, decl.overmethods };
                     });
         });
 
@@ -876,7 +877,7 @@ entity CPPTransformer {
                     fn(decl) => { 
                         let new_typefuncs = decl.typefuncs.pushBack(ikey);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, new_typefuncs, decl.entities, 
-                            decl.datamembers, decl.datatypes, decl.staticmethods, decl.virtmethods, decl.absmethods, decl.overmethods };
+                            decl.datamembers, decl.datatypes, decl.pconcepts, decl.staticmethods, decl.virtmethods, decl.absmethods, decl.overmethods };
                     });
         });
 
@@ -898,7 +899,7 @@ entity CPPTransformer {
                     fn(decl) => {
                         let new_entities = decl.entities.pushBack(cpptk);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, decl.typefuncs, new_entities,
-                            decl.datamembers, decl.datatypes, cppstaticmethods, cppvirtmethods, cppabsmethods, cppovermethods };
+                            decl.datamembers, decl.datatypes, decl.pconcepts, cppstaticmethods, cppvirtmethods, cppabsmethods, cppovermethods };
                     });
         });
 
@@ -919,7 +920,7 @@ entity CPPTransformer {
                     fn(decl) => {
                         let new_datamembers = decl.datamembers.pushBack(cpptk);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, decl.typefuncs, decl.entities,
-                            new_datamembers, decl.datatypes, cppstaticmethods, cppvirtmethods, cppabsmethods, cppovermethods };
+                            new_datamembers, decl.datatypes, decl.pconcepts, cppstaticmethods, cppvirtmethods, cppabsmethods, cppovermethods };
                     });                     
             });
 
@@ -940,9 +941,26 @@ entity CPPTransformer {
                     fn(decl) => {
                         let new_datatypes = decl.datatypes.pushBack(cpptk);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, decl.typefuncs, decl.entities,
-                            decl.datamembers, new_datatypes, cppstaticmethods, cppvirtmethods, cppabsmethods, cppovermethods };
+                            decl.datamembers, new_datatypes, decl.pconcepts, cppstaticmethods, cppvirtmethods, cppabsmethods, cppovermethods };
                     });                     
             });
+
+        let transformer_pconcepts = bsqasm.pconcepts.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveConceptTypeDecl>>(
+            Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveConceptTypeDecl>{}, fn(acc, tk, pc) => {
+                let cpppc = transformer.transformPrimitiveConceptDeclToCpp(pc);
+                return acc.insert(cpppc.tkey, cpppc);
+            });
+
+        %% I could see name conflicts arising with emitting pconcepts at top of file, so we do in ns to be safe
+        let transformer_nsdecls_pconcepts = transformer_pconcepts.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
+            transformer_nsdecls_datamembers, fn(acc, cpptk, cpppc) => {
+                return CPPTransformNameManager::getNamespaceDeclMapping(cpppc.fullns, acc,
+                    fn(decl) => {
+                        let new_pconcepts = decl.pconcepts.pushBack(cpptk);
+                        return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, decl.typefuncs, decl.entities,
+                            decl.datamembers, decl.datatypes, new_pconcepts, decl.staticmethods, decl.virtmethods, decl.absmethods, decl.overmethods };
+                    });                     
+            }); 
 
         let transformer_allfuncs = bsqasm.allfuncs.map<CPPAssembly::FunctionDecl>(fn(ikey) => {
             let cppikey = CPPTransformNameManager::convertInvokeKey(ikey);
@@ -987,12 +1005,6 @@ entity CPPTransformer {
                 return acc.insert(CPPTransformNameManager::convertInvokeKey(ikey), transformer.transformOverrideMethodDecl(decl));
         });
 
-        let transformer_pconcepts = bsqasm.pconcepts.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveConceptTypeDecl>>(
-            Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveConceptTypeDecl>{}, fn(acc, tk, pc) => {
-                let cpppc = transformer.transformPrimitiveConceptDeclToCpp(pc);
-                return acc.insert(cpppc.tkey, cpppc);
-            });
-
         let transformer_allmethods = bsqasm.allmethods.map<CPPAssembly::InvokeKey>(fn(ikey) => {
             return CPPTransformNameManager::convertInvokeKey(ikey);
         });
@@ -1010,7 +1022,7 @@ entity CPPTransformer {
             });
 
         return CPPAssembly::Assembly {
-            nsdecls = transformer_nsdecls_datatypes,
+            nsdecls = transformer_nsdecls_pconcepts,
             allfuncs = transformer_allfuncs,
             nsfuncs = transformer_nsfuncs,
             typefuncs = transformer_typefuncs,

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -305,23 +305,39 @@ entity CPPTransformer {
         return CPPAssembly::CallTypeFunctionExpression{ ts, ikey, ttype, resolvedDeclType, args };
     }
 
+    method transformITestType(it: BSQAssembly::ITestType, isnot: Bool): CPPAssembly::ITestType {
+        let ttype = CPPTransformNameManager::convertTypeSignature(it.ttype);
+        return CPPAssembly::ITestType{isnot, ttype};    
+    }
+
+    method transformITestAsTest(itest: BSQAssembly::ITest): CPPAssembly::ITest {
+        let isnot = itest.isnot;
+        match(itest)@ {
+            BSQAssembly::ITestType => { return this.transformITestType($itest, isnot); }
+            | _ => { abort; } %% Gonna do in a sec
+        }
+    }
+
     method transformPostfixOpImpl(op: BSQAssembly::PostfixOperation): CPPAssembly::PostfixOperation {
         let baseType = CPPTransformNameManager::convertTypeSignature(op.baseType);
-        if(op)@ <BSQAssembly::PostfixAccessFromName> {
-            let name = CPPTransformNameManager::convertIdentifier($op.name);
-            let declaredInType = CPPTransformNameManager::convertNominalTypeSignature($op.declaredInType);
-            let ftype = CPPTransformNameManager::convertTypeSignature($op.ftype);
+        match(op)@ {
+            BSQAssembly::PostfixAccessFromName => {
+                let name = CPPTransformNameManager::convertIdentifier($op.name);
+                let declaredInType = CPPTransformNameManager::convertNominalTypeSignature($op.declaredInType);
+                let ftype = CPPTransformNameManager::convertTypeSignature($op.ftype);
 
-            return CPPAssembly::PostfixAccessFromName{ baseType, name, declaredInType, ftype };
-        }
-        if(op)@<BSQAssembly::PostfixInvokeStatic> { %% Currently used for methods
-            let resolvedType = CPPTransformNameManager::convertNominalTypeSignature($op.resolvedType);
-            let resolvedTrgt = CPPTransformNameManager::convertInvokeKey($op.resolvedTrgt);
-            let args = this.transformArgumentInfo($op.argsinfo);
+                return CPPAssembly::PostfixAccessFromName{ baseType, name, declaredInType, ftype };
+            }
+            | BSQAssembly::PostfixInvokeStatic => {
+                let resolvedType = CPPTransformNameManager::convertNominalTypeSignature($op.resolvedType);
+                let resolvedTrgt = CPPTransformNameManager::convertInvokeKey($op.resolvedTrgt);
+                let args = this.transformArgumentInfo($op.argsinfo);
 
-            return CPPAssembly::PostfixInvokeStatic{ baseType, resolvedType, resolvedTrgt, args };
+                return CPPAssembly::PostfixInvokeStatic{ baseType, resolvedType, resolvedTrgt, args };
+            }
+            | BSQAssembly::PostfixIsTest => { return CPPAssembly::PostfixIsTest{ baseType, this.transformITestAsTest($op.ttest) }; }
+            | _ => { abort; } %% TODO: Not Implemented
         }
-        abort; %% TODO: Not implemented
     }
 
     method transformPostfixOp(pop: BSQAssembly::PostfixOp): CPPAssembly::PostfixOp {

--- a/src/backend/jsemitter/jsemitter.ts
+++ b/src/backend/jsemitter/jsemitter.ts
@@ -2310,7 +2310,7 @@ class JSEmitter {
             bop = `s.endsWith(suffix)`;
         }
         else if(bname === "cstring_contains_string") {
-            bop = `s.includes(find)`;
+            bop = `s.includes(target)`;
         }
         else if(bname === "cstring_contains_string_unique") {
             bop = `[...s.matchAll(target)].length === 1`

--- a/src/bsqir/asm/assembly.bsq
+++ b/src/bsqir/asm/assembly.bsq
@@ -507,7 +507,7 @@ entity Assembly {
         return this.lookupNominalTypeDeclaration(tkey)?<AbstractEntityTypeDecl>;
     }
 
-    method isPrimtitiveType(tkey: TypeKey): Bool {
+    method isPrimitiveType(tkey: TypeKey): Bool {
         return this.lookupNominalTypeDeclaration(tkey)?<PrimitiveEntityTypeDecl>;
     }
 

--- a/test/cppoutput/cppemit_nf.ts
+++ b/test/cppoutput/cppemit_nf.ts
@@ -17,7 +17,7 @@ const cpp_transform_bin_path = path.join(bosque_dir, "bin/cppemit/CPPEmitter.mjs
 const cpp_runtime_dir_path = path.join(bosque_dir, "bin/cppruntime/");
 const cpp_runtime_code_path = path.join(bosque_dir, "bin/cppruntime/emit.cpp");
 
-const cc_flags: string = "-Og -Wall -Wextra -Wno-unused-parameter -Wuninitialized -Werror -std=gnu++20 -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-omit-frame-pointer -fno-stack-protector";
+const cc_flags: string = "-Og -Wall -Wextra -Wno-unused-parameter -Wuninitialized -std=gnu++20 -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-omit-frame-pointer -fno-stack-protector";
 const cc: string = "/usr/bin/g++"; // Note: This will not work on all systems :(
 
 const bsq_max_int: string = "4611686018427387903";

--- a/test/cppoutput/if_stmts/simple_if.test.js
+++ b/test/cppoutput/if_stmts/simple_if.test.js
@@ -8,4 +8,9 @@ describe ("CPP Emit Evaluate -- If Statement", () => {
         runMainCode("public function main(): Int { if(true) { return 3i; } return 1i; }", "3_i");
         runMainCode("public function main(): Int { if(false) { return 3i; } return 1i; }", "1_i");
     });
+
+    it("should exec itest ifs", function () {
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)some { return 3i; } return 1i; }", "3_i");
+        runMainCode("public function main(): Int { let x: Option<Int> = none; if(x)some { return 3i; } return 1i; }", "1_i");
+    });
 });

--- a/test/cppoutput/if_stmts/simple_ifelse.test.js
+++ b/test/cppoutput/if_stmts/simple_ifelse.test.js
@@ -10,4 +10,8 @@ describe ("CPP Emit Evaluate -- Simple if-elif-else statements", () => {
     it("should exec simple ifelifelse", function () {
         runMainCode("public function main(): Int { if(1n == 2n) { return 2i; } elif(1n == 3n) { return 1i; } elif(2i == 2i) { return 4i; } else { return 3i; } }", "4_i")
     });
+    it("should exec itest ifelses", function () {
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)some { return 3i; } else { return 1i; } }", "3_i");
+        runMainCode("public function main(): Int { let x: Option<Int> = none; if(x)some { return 3i; } else { return 1i; } }", "1_i");
+    });
 });

--- a/test/cppoutput/mcall_exps/simple_resolved.test.js
+++ b/test/cppoutput/mcall_exps/simple_resolved.test.js
@@ -46,12 +46,12 @@ describe ("CPP Emit Evaluate -- eADT methods", () => {
         runMainCode('datatype Foo<T> of Foo1 { field f: T; method foo(x: T): T { return if (true) then x else this.f; }} ; public function main(): Int { let x = Foo1<Int>{3i}; return x.foo(2i); }', "2_i"); 
     });
     
-    /*
-    it("should exec simple eADT methods with template", function () {
+     it("should exec simple eADT methods with template", function () {
         runMainCode('datatype Foo of Foo1 { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} ; public function main(): Bool { let x = Foo1{3i}; return x.foo<Nat>(); }', "false"); 
         runMainCode('datatype Foo of Foo1 { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} ; public function main(): Bool { let x = Foo1{3i}; return x.foo<Int>(); }', "true"); 
     });
 
+/*
     it("should exec simple ROOT eADT methods", function () {
         runMainCode('datatype Foo of F1 { } | F2 { } & { method foo(): Int { return if(this)<F1> then 1i else 0i; } } public function main(): Int { return F1{}.foo(); }', "1i"); 
 

--- a/test/cppoutput/special_cons_exps/optional_const.test.js
+++ b/test/cppoutput/special_cons_exps/optional_const.test.js
@@ -1,0 +1,39 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate -- Special Constructor infer in if-else and assign positions", () => {
+    it("should exec some/none with if-else", function () {
+        //runMainCode("public function main(): Int { let x: Option<Int> = if(true) then some(3i) else none; return x@some; }", "3i");
+        runMainCode("public function main(): Bool { let x: Option<Int> = if(false) then some(3i) else none; return x?!some; }", "true");
+    });
+
+    /*
+    it("should exec ok/fail with if-else", function () {
+        runMainCode("public function main(): Int { let x: Result<Int, Bool> = if(true) then ok(3i) else fail(true); return x@ok; }", "3i");
+        runMainCode("public function main(): Bool { let x: Result<Int, Bool> = if(false) then ok(3i) else fail(true); return x@!ok; }", "true");
+    });
+    */
+});
+
+/*
+describe ("Exec -- Special Constructor Optional", () => {
+    it("should exec none with simple infer", function () {
+        runMainCode("public function main(): Int { let x: Some<Int> = some(3i); return x.value; }", "3i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return x@some; }", "3i");
+    });
+});
+
+describe ("Exec -- Special Constructor Result", () => {
+    it("should exec ok with simple infer", function () {
+        runMainCode("public function main(): Int { let x: Result<Int, Bool>::Ok = ok(3i); return x.value; }", "3i");
+        runMainCode("public function main(): Int { let x: Result<Int, Bool> = ok(3i); return x@ok; }", "3i");
+    });
+
+    it("should exec fail with simple infer", function () {
+        runMainCode("public function main(): Bool { let x: Result<Int, Bool>::Fail = fail(true); return x.info; }", "true");
+        runMainCode("public function main(): Bool { let x: Result<Int, Bool> = fail(true); return x@fail; }", "true");
+    });
+});
+*/


### PR DESCRIPTION
Added support for 
 - ITest for types and `some` 
 - If statements with non-binding ITests (`some` and type testing)
 - `Option<T>` emission which uses a `Boxed<K>` class for its construction (which holds the typeinfo ptr and data)
 
 Some Bosque code like so
 ```
 public function main(): Int { 
    let x: Option<Int> = none; 
    let y: Option<Nat> = some(3n);
    if(x)some { 
        return 3i; 
    }
    else { 
        if(y)some {
            return 2i;
        }
        return 1i; 
    } 
}
 ```
 Emits in cpp
 ```
 // Other primitives typeinfos would be here too
__CoreCpp::TypeInfoBase NoneType = {
    .type_id = 1,
    .type_size = 8, 
    .slot_size = 1,
    .ptr_mask = "0",
    .typekey = "__CoreCpp::None",
    .vtable = nullptr
};
namespace Core {
    __CoreCpp::TypeInfoBase OptionᐸIntᐳType = {
        .type_id = 3,
        .type_size = 16, 
        .slot_size = 2,
        .ptr_mask = "20",
        .typekey = "Option<Int>",
        .vtable = nullptr
    };
    class OptionᐸIntᐳ : public __CoreCpp::Boxed<1>{
    public:
        OptionᐸIntᐳ(__CoreCpp::TypeInfoBase* ti, uint64_t* data) : __CoreCpp::Boxed<1>(ti, data) {}
    };
    __CoreCpp::TypeInfoBase OptionᐸNatᐳType = {
        .type_id = 2,
        .type_size = 16, 
        .slot_size = 2,
        .ptr_mask = "20",
        .typekey = "Option<Nat>",
        .vtable = nullptr
    };
    class OptionᐸNatᐳ : public __CoreCpp::Boxed<1>{
    public:
        OptionᐸNatᐳ(__CoreCpp::TypeInfoBase* ti, uint64_t* data) : __CoreCpp::Boxed<1>(ti, data) {}
    };
}
namespace Main {
    __CoreCpp::Int main() noexcept;
    __CoreCpp::Int main() noexcept  {
        Core::OptionᐸIntᐳ x = Core::OptionᐸIntᐳ{ &NoneType, (uint64_t[]){ UINT64_MAX }};
        Core::OptionᐸNatᐳ y = Core::OptionᐸNatᐳ{&NatType, (uint64_t[]){(3_n).get()}};
        if( x.typeinfo != &NoneType ) {
            return 3_i;
        }
        else {
            if( y.typeinfo != &NoneType ) {
                return 2_i;
            }
            return 1_i;
        }
    }
}
 ```