### PR TITLE
Const Simplify and Explicitify Updates

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -20,6 +20,9 @@ concept Operation {
 concept Statement {
 }
 
+entity EmptyStatement provides Statement {
+}
+
 entity BinderInfo { %% TODO: Not implemented
     field srcname: VarIdentifier;
     field refineonfollow: Bool;

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -75,7 +75,7 @@ RefArgumentValue { } %% TODO: Not implemented
 ;
 
 entity ArgumentList {
-    field args: List<Option<ArgumentValue>>; %% if none get default val in emitter
+    field args: List<ArgumentValue>; %% if none get default val in emitter
 }
 
 datatype IfStatement provides Statement using {

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -266,13 +266,16 @@ PostfixAccessFromName {
     field declaredInType: NominalTypeSignature;
     field ftype: TypeSignature;
 }
+| PostfixIsTest {
+    field ttest: ITest;
+}
 | PostfixInvokeStatic { 
     field resolvedType: NominalTypeSignature;
     field resolvedTrgt: InvokeKey;
     field args: ArgumentList;
 }
-| PostfixIsTest {
-    field ttest: ITest;
+| PostfixBoolConstant {
+    field value: Bool;
 }
 ;
 

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -185,7 +185,7 @@ public:
             std::longjmp(info.error_handler, true);
         }
     };
-    constexpr int64_t get() noexcept { return value; } 
+    constexpr int64_t get() const noexcept { return value; } 
 
     // Overloaded operations on Int
     constexpr Int& operator+=(const Int& rhs) noexcept {
@@ -252,7 +252,7 @@ public:
             std::longjmp(info.error_handler, true);
         }
     };
-    constexpr __int128_t get() noexcept { return value; }
+    constexpr __int128_t get() const noexcept { return value; }
 
     // Overloaded operators on BigInt
     constexpr BigInt& operator+=(const BigInt& rhs) noexcept {
@@ -310,7 +310,7 @@ public:
             std::longjmp(info.error_handler, true);
         }
     };
-    constexpr uint64_t get() noexcept { return value; } 
+    constexpr uint64_t get() const noexcept { return value; } 
 
     // Overloaded operators on Nat
     constexpr Nat& operator+=(const Nat& rhs) noexcept {
@@ -371,7 +371,7 @@ public:
             std::longjmp(info.error_handler, true);
         }
     };
-    constexpr __uint128_t get() noexcept { return value; }
+    constexpr __uint128_t get() const noexcept { return value; }
     
     // Overloaded operators on BigInt
     constexpr BigNat& operator+=(const BigNat& rhs) noexcept {
@@ -423,7 +423,7 @@ public:
             std::longjmp(info.error_handler, true);
         } 
     }
-    constexpr double get() noexcept { return value; }
+    constexpr double get() const noexcept { return value; }
 
     static constexpr Float from_literal(double v) noexcept { return Float(v); }
 
@@ -582,8 +582,8 @@ constexpr __CoreCpp::BigNat operator "" _N(const char* v) { return __CoreCpp::Bi
 constexpr __CoreCpp::Float operator "" _f(long double v) { return __CoreCpp::Float(static_cast<double>(v)); }
 
 // For debugging
-std::ostream& operator<<(std::ostream &os, __CoreCpp::Int& t) { return os << t.get(); }
-std::ostream& operator<<(std::ostream &os, __CoreCpp::BigInt& t) { return os << __CoreCpp::t_to_string<__int128_t>(t.get()); }
-std::ostream& operator<<(std::ostream &os, __CoreCpp::Nat& t) { return os << t.get(); }
-std::ostream& operator<<(std::ostream &os, __CoreCpp::BigNat& t) { return os << __CoreCpp::t_to_string<__uint128_t>(t.get()); }
-std::ostream& operator<<(std::ostream &os, __CoreCpp::Float& t) { return os << t.get(); }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::Int& t) { return os << t.get(); }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::BigInt& t) { return os << __CoreCpp::t_to_string<__int128_t>(t.get()); }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::Nat& t) { return os << t.get(); }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::BigNat& t) { return os << __CoreCpp::t_to_string<__uint128_t>(t.get()); }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::Float& t) { return os << t.get(); }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -607,6 +607,14 @@ function emitNarrowedTypeExpression(exp: CPPAssembly::CoerceNarrowTypeExpression
     return emitExpression(exp.exp, ctx);
 }
 
+function emitSafeConvertExpression(exp: CPPAssembly::SafeConvertExpression, ctx: Context): String {
+   return emitExpression(exp.exp, ctx);
+}
+
+function emitCreateDirectExpression(exp: CPPAssembly::CreateDirectExpression, ctx: Context): String {
+   return emitExpression(exp.exp, ctx); 
+}
+
 function emitExpression(e: CPPAssembly::Expression, ctx: Context): String {
     match(e)@ {
         CPPAssembly::BinaryArithExpression => { return emitBinaryArithExpression[recursive]($e, ctx); }
@@ -732,11 +740,14 @@ function emitIfElifElseStatement(stmt: CPPAssembly::IfElifElseStatement, ctx: Co
 
 function emitStatement(stmt: CPPAssembly::Statement, ctx: Context, indent: String): String {
     match(stmt)@ {
-        CPPAssembly::VariableInitializationStatement => { return emitVariableInitializationStatement($stmt, ctx, indent); }
+        CPPAssembly::EmptyStatement => { return ""; }
+        | CPPAssembly::VariableInitializationStatement => { return emitVariableInitializationStatement($stmt, ctx, indent); }
         | CPPAssembly::ReturnSingleStatement => { return emitReturnSingleStatement($stmt, ctx, indent); }
         | CPPAssembly::IfStatement => { return emitIfStatement($stmt, ctx, indent); }
         | CPPAssembly::IfElseStatement => { return emitIfElseStatement($stmt, ctx, indent); }
         | CPPAssembly::IfElifElseStatement => { return emitIfElifElseStatement($stmt, ctx, indent); }
+        | CPPAssembly::EmptyStatement => { return ""; }
+        | CPPAssembly::BlockStatement => { return emitBlockStatement($stmt, ctx, indent); }
         | _ => { abort; }
     }
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -394,6 +394,7 @@ function emitArgumentValue(av: Option<CPPAssembly::ArgumentValue>, i: Nat, param
     }
 }
 
+%% May want to do this resolution in the transformer
 function resolveDefaultParams(al: List<String>, params: List<CPPAssembly::ParameterDecl>): List<String> {
     return al.map<String>(fn(arg) => { 
         if(arg.startsWithString("$")) {
@@ -1048,11 +1049,11 @@ function emitPrimtiveConceptTypeDecl(pc: CPPAssembly::PrimitiveConceptTypeDecl, 
     let indenttkey = String::concat(full_indent, tkey);
 
     let somecons = if(k === "0") then "" 
-        else if(k === "1") then String::concat(indenttkey, "(__CoreCpp::TypeInfoBase* ti, ", sometkey," d) noexcept : Boxed(ti, reinterpret_cast<uintptr_t>(&d)) {};%n;")
+        else if(k === "1") then String::concat(indenttkey, "(__CoreCpp::TypeInfoBase* ti, ", sometkey," d) noexcept : Boxed(ti, *reinterpret_cast<uintptr_t*>(&d)) {};%n;")
         else String::concat(indenttkey, "(__CoreCpp::TypeInfoBase* ti, ", sometkey ," d) noexcept : Boxed(ti, *reinterpret_cast<uintptr_t(*)[", k,"]>(&d)) {};%n;");
     let nonecons = String::concat(indenttkey, "(__CoreCpp::TypeInfoBase* ti) noexcept : Boxed(ti) {};%n;%n;");
 
-    let someaccessor = String::concat(full_indent, sometkey, " some() noexcept { return *reinterpret_cast<", sometkey,"*>(this->data); }%n;");
+    let someaccessor = String::concat(full_indent, sometkey, " some() noexcept { return *reinterpret_cast<", sometkey,"*>(&this->data); }%n;");
 
     let cons = String::concat(defaultc, assign, copy, somecons, nonecons);
     return String::concat(visibility, cons, someaccessor, indent, "};%n;");

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -444,43 +444,38 @@ function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSi
     }
 }
 
-function emitITestSome(it: CPPAssembly::ITestSome, baseType: CPPAssembly::TypeSignature, rootExp: String, ctx: Context): String {
+function emitITestSome(it: CPPAssembly::ITestSome, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
     return if(it.isnot) 
-        then String::concat(rootExp, ".typeinfo == &NoneType") 
-        else String::concat(rootExp, ".typeinfo != &NoneType");
+        then ".typeinfo == &NoneType" 
+        else ".typeinfo != &NoneType";
 }
 
-function emitITestNone(it: CPPAssembly::ITestNone, baseType: CPPAssembly::TypeSignature, rootExp: String, ctx: Context): String {
+function emitITestNone(it: CPPAssembly::ITestNone, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
     return if(it.isnot) 
-        then String::concat(rootExp, ".typeinfo != &NoneType") 
-        else String::concat(rootExp, ".typeinfo == &NoneType");
+        then ".typeinfo != &NoneType" 
+        else ".typeinfo == &NoneType";
 }
 
-function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, rootExp: String, ctx: Context): String {
+function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
     match(it)@ {
         CPPAssembly::ITestType => { return emitITestType($it, baseType, ctx); }
-        | CPPAssembly::ITestSome => { return emitITestSome($it, baseType, rootExp, ctx); }
-        | CPPAssembly::ITestNone => { return emitITestNone($it, baseType, rootExp, ctx); }
+        | CPPAssembly::ITestSome => { return emitITestSome($it, baseType, ctx); }
+        | CPPAssembly::ITestNone => { return emitITestNone($it, baseType, ctx); }
         | _ => { abort; } %% TODO: Not Implemented!
     }
 }
 
 function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
     let rootExp = emitExpression(pop.rootExp, ctx);
-    let ops = pop.ops.mapIdx<String>(fn(op, ii) => {
+
+    return pop.ops.reduce<String>(rootExp, fn(acc, op) => {
         match(op)@ {
-            CPPAssembly::PostfixAccessFromName => {
-                if (ii == 0n) {
-                    return String::concat(rootExp, emitPostfixAccessFromName($op, ctx));
-                }
-                return emitPostfixAccessFromName($op, ctx);
-            }
-            | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, rootExp, ctx); }
-            | CPPAssembly::PostfixIsTest => { return emitITestAsTest($op.ttest, $op.baseType, rootExp, ctx); }
+            CPPAssembly::PostfixAccessFromName => { return String::concat(acc, emitPostfixAccessFromName($op, ctx)); }
+            | CPPAssembly::PostfixIsTest => { return String::concat(acc, emitITestAsTest($op.ttest, $op.baseType, ctx)); }
+            | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, rootExp, ctx); } %% This will not chain method calls :(
+            | CPPAssembly::PostfixBoolConstant => { return if($op.value === true) then "true" else "false"; }
         }
     });
-
-    return String::joinAll("", ops);
 }
 
 function emitConstructorPrimarySpecialSomeExpression(cpsse: CPPAssembly::ConstructorPrimarySpecialSomeExpression, ctx: Context): String {
@@ -609,7 +604,7 @@ function emitIfSimpleStatement(stmt: CPPAssembly::IfSimpleStatement, ctx: Contex
 
 function emitIfTestStatement(stmt: CPPAssembly::IfTestStatement, ctx: Context, indent: String): String {
     let expr = emitExpression(stmt.cond, ctx);
-    let itest = emitITestAsTest(stmt.itest, stmt.cond.etype, expr, ctx);
+    let itest = String::concat(expr, emitITestAsTest(stmt.itest, stmt.cond.etype, ctx));
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
 
     let ifstmt = String::concat(indent, "if( ", itest, " ) {%n;");
@@ -642,7 +637,7 @@ function emitIfElseSimpleStatement(stmt: CPPAssembly::IfElseSimpleStatement, ctx
 
 function emitIfElseTestStatement(stmt: CPPAssembly::IfElseTestStatement, ctx: Context, indent: String): String {
     let expr = emitExpression(stmt.cond, ctx);
-    let itest = emitITestAsTest(stmt.itest, stmt.cond.etype, expr, ctx);
+    let itest = String::concat(expr, emitITestAsTest(stmt.itest, stmt.cond.etype, ctx));
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
     let falseBlock = emitBlockStatement(stmt.falseBlock, ctx, indent);
     let elseBlockText = String::concat(indent, "else {%n;", falseBlock, indent, "}%n;");
@@ -735,7 +730,7 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context):
 
 %% Determine whether to emit this param as const this* or this
 function emitThisType(tk: CPPAssembly::TypeKey, ctx: Context): String {
-    let resolved_type = emitTypeKey(tk, false, ctx);
+    let resolved_type = String::concat("[[maybe_unused]] ", emitTypeKey(tk, false, ctx));
 
     if(ctx.asm.typeinfos.get(tk).tag === CPPAssembly::Tag#Ref) {
         return String::concat("const ", resolved_type, "*");
@@ -771,7 +766,7 @@ function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::Typ
 
 function emitMethods(ant: CPPAssembly::AbstractNominalTypeDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
     let staticmethods = ant.staticmethods
-        .reduce<String>("", fn(acc, ik) => {
+        .reduce<String>(indent, fn(acc, ik) => {
             return String::concat(acc, emitMethodDecl(ctx.asm.staticmethods.get(ik), declaredIn, ctx, indent));
     });
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -373,57 +373,25 @@ recursive function emitLogicActionOrExpression(e: CPPAssembly::LogicActionOrExpr
     return String::concat("(", String::joinAll(" || ", args), ")");
 }
 
-function emitArgumentValue(av: Option<CPPAssembly::ArgumentValue>, i: Nat, params: List<CPPAssembly::ParameterDecl>, ctx: Context): String {
-    if(av)@none {
-        let param = params.get(i).defaultval;
-        if(param)@none {
-            abort; %% Should be impossible
-        }
-        else {
-            return emitExpression[recursive]($param, ctx);
-        }
-    }
-    else {
-        let arg = $av;
-        let expr = emitExpression[recursive](arg.exp, ctx);
-        match(arg)@ {
-            CPPAssembly::NamedArgumentValue => { return expr; } 
-            | CPPAssembly::PositionalArgumentValue => { return expr; }
-            | _ => { abort; }
-        }
+function emitArgumentValue(av: CPPAssembly::ArgumentValue, ctx: Context): String {
+    let expr = emitExpression[recursive](av.exp, ctx);
+    match(av)@ {
+        CPPAssembly::NamedArgumentValue => { return expr; } 
+        | CPPAssembly::PositionalArgumentValue => { return expr; }
+        | _ => { abort; }
     }
 }
 
-%% May want to do this resolution in the transformer
-function resolveDefaultParams(al: List<String>, params: List<CPPAssembly::ParameterDecl>): List<String> {
-    return al.map<String>(fn(arg) => { 
-        if(arg.startsWithString("$")) {
-            let ident = arg.removePrefixString("$");
-
-            %% This is a bit hacky but works for getting default val idx
-            let idx = params.mapIdx<Nat>(fn(param, ii) => {
-                if(emitIdentifier(param.pname) === ident) {
-                    return ii;
-                }
-                return 0n;
-            }).sum();
-
-            return al.get(idx);
-        }
-        return arg; 
-    });
-}
-
-function emitArgumentList(al: CPPAssembly::ArgumentList, params: List<CPPAssembly::ParameterDecl>, ctx: Context): String {
-    let emit_al = al.args.mapIdx<String>(fn(arg, ii) => emitArgumentValue(arg, ii, params, ctx));
+function emitArgumentList(al: CPPAssembly::ArgumentList, ctx: Context): String {
+    let emit_al = al.args.mapIdx<String>(fn(arg, ii) => emitArgumentValue(arg, ctx));
     
-    return String::joinAll(", ", resolveDefaultParams[recursive](emit_al, params));
+    return String::joinAll(", ", emit_al);
 }
 
 function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFunctionExpression, ctx: Context): String { 
     let name = emitInvokeKey(e.ikey, ctx);
     let nsfunc = ctx.asm.nsfuncs.get(e.ikey); 
-    let args = emitArgumentList(e.args, nsfunc.params, ctx); 
+    let args = emitArgumentList(e.args, ctx); 
 
     return String::concat(name, "(", args, ")");
 }
@@ -431,7 +399,7 @@ function emitCallNamespaceFunctionExpression(e: CPPAssembly::CallNamespaceFuncti
 function emitCallTypeFunctionExpression(e: CPPAssembly::CallTypeFunctionExpression, ctx: Context): String { 
     let typefunc = ctx.asm.typefuncs.get(e.ikey);
     let name = emitInvokeKey(typefunc.ikey, ctx);
-    let args = emitArgumentList(e.args, typefunc.params, ctx); 
+    let args = emitArgumentList(e.args, ctx); 
 
     return String::concat(name, "(", args, ")");
 }
@@ -452,15 +420,8 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: Str
     let ik = String::fromCString(op.resolvedTrgt.value);
     let tk = String::fromCString(op.resolvedType.tkeystr.value);
 
-    var args: String;
-    if(ctx.asm.staticmethods.has(op.resolvedTrgt)) {
-        let trgt = ctx.asm.staticmethods.get(op.resolvedTrgt);
-        args = emitArgumentList(op.args, trgt.params, ctx);
-    }
-    else {
-        abort; %% TODO: Add support for Override, Abstract, and Virtual methods!
-    }
-
+    let args = emitArgumentList(op.args, ctx);
+    
     %% Remove abstract nominal we were in
     var resolvedInvoke = emitSpecialTemplate(ik.removePrefixString(tk).removePrefixString("::"));
     if(args === "") {
@@ -489,10 +450,17 @@ function emitITestSome(it: CPPAssembly::ITestSome, baseType: CPPAssembly::TypeSi
         else String::concat(rootExp, ".typeinfo != &NoneType");
 }
 
+function emitITestNone(it: CPPAssembly::ITestNone, baseType: CPPAssembly::TypeSignature, rootExp: String, ctx: Context): String {
+    return if(it.isnot) 
+        then String::concat(rootExp, ".typeinfo != &NoneType") 
+        else String::concat(rootExp, ".typeinfo == &NoneType");
+}
+
 function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, rootExp: String, ctx: Context): String {
     match(it)@ {
         CPPAssembly::ITestType => { return emitITestType($it, baseType, ctx); }
         | CPPAssembly::ITestSome => { return emitITestSome($it, baseType, rootExp, ctx); }
+        | CPPAssembly::ITestNone => { return emitITestNone($it, baseType, rootExp, ctx); }
         | _ => { abort; } %% TODO: Not Implemented!
     }
 }
@@ -516,7 +484,7 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
 }
 
 function emitConstructorPrimarySpecialSomeExpression(cpsse: CPPAssembly::ConstructorPrimarySpecialSomeExpression, ctx: Context): String {
-    let args = cpsse.args.args.map<String>(fn(arg) => emitExpression(arg@some.exp, ctx) );
+    let args = cpsse.args.args.map<String>(fn(arg) => emitExpression(arg.exp, ctx) );
     let sometype = String::concat("Core::", emitTypeKey(cpsse.ctype.tkeystr, false, ctx));
 
     return String::concat(sometype, "{ ", String::joinAll(", ", args), "}");
@@ -543,29 +511,7 @@ function emitConstructorPrimarySpecialConstructableExpression(exp: CPPAssembly::
 %% constructor like we do now. Currently they call "new"
 %%
 function emitConstructorStdExpression(exp: CPPAssembly::ConstructorStdExpression, ctx: Context): String {
-    %% Eventually might want to rework emitArgumentList to support constructors too 
-    let emitargs =  String::joinAll(", ", exp.args.args.mapIdx<String>(fn(av, ii) => {
-        if(av)@none {
-            let e = ctx.asm.entities.tryGet(exp.ctype.tkeystr)@some;
-            let member_defval = e.fields.get(ii).defaultval;
-            if(member_defval)@none {
-                abort; %% Default value detected in transform, yet none provided for emission
-            }
-            else {
-                return emitExpression[recursive]($member_defval, ctx);
-            }
-        }
-        else {
-            let arg = $av;
-            let argexp = emitExpression[recursive](arg.exp, ctx);
-            match(arg)@ {
-                CPPAssembly::NamedArgumentValue => { return argexp; } 
-                | CPPAssembly::PositionalArgumentValue => { return argexp; }
-                | _ => { abort; }
-            }
-        }
-    }));
-
+    let emitargs = emitArgumentList(exp.args, ctx); 
     let name = emitTypeKey(exp.ctype.tkeystr, false, ctx);
     if(ctx.asm.typeinfos.get(exp.ctype.tkeystr).tag === CPPAssembly::Tag#Ref) {
         return String::concat("new ", name, "{ ", emitargs, " }"); %% We use new solely to keep the code compiling before GC integration

--- a/src/backend/cpp/transformer/cppprocessor.bsq
+++ b/src/backend/cpp/transformer/cppprocessor.bsq
@@ -6,10 +6,10 @@ declare namespace CPPEmitter {
 %% Our API for emitting cpp
 public function main(asm: BSQAssembly::Assembly): String {
     %% TODO: Once Explicitify is built up more we will just call it here 
-    %%let explicitAssembly = BSQAssembly::ExplicitifyTransform::process(asm);
-    %%let simpleAssembly = BSQAssembly::ConstantSimplification::process(explicitAssembly);
+    let explicitAssembly = BSQAssembly::ExplicitifyTransform::process(asm);
+    let simpleAssembly = BSQAssembly::ConstantSimplification::process(explicitAssembly);
 
-    let tasm = CPPEmitter::CPPTransformer::convertBsqAsmToCpp(asm);
+    let tasm = CPPEmitter::CPPTransformer::convertBsqAsmToCpp(simpleAssembly);
     let cppstr = CPPEmitter::emitAssembly(tasm);
 
     return cppstr;

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -271,37 +271,16 @@ entity CPPTransformer {
         }
     }
 
-    method transformArgumentInfo(bsqargs: BSQAssembly::InvokeArgumentInfo): CPPAssembly::ArgumentList {
-        let shuffled = bsqargs.shuffleinfo.mapIdx<Option<CPPAssembly::ArgumentValue>>(fn(e, ii) => {
-            var cur_arg: CPPAssembly::ArgumentValue;
-            if(ii >= bsqargs.args.args.size()) {
-                return none;
-            }
-            else { %% Resolve shuffle value
-                let shuffle_idx = e.0;
-                if(shuffle_idx)@none {
-                    let arg = bsqargs.args.args.get(ii);
-                    return some(this.transformArgument(arg));
-                }
-                else {
-                    let arg = bsqargs.args.args.get($shuffle_idx);
-                    return some(this.transformArgument(arg));
-                }
-            }
-        });
-        return CPPAssembly::ArgumentList{ shuffled };   
-    }
-    
-    %% This does not shuffle
     method transformArgumentList(al: BSQAssembly::ArgumentList): CPPAssembly::ArgumentList {
-        return CPPAssembly::ArgumentList{ al.args.map<Option<CPPAssembly::ArgumentValue>>(fn(arg) => some(this.transformArgument(arg))) };
+        let args = al.args.map<CPPAssembly::ArgumentValue>(fn(arg) => this.transformArgument(arg));
+        return CPPAssembly::ArgumentList{ args };   
     }
 
     method transformCallNamespaceFunctionExpression(expr: BSQAssembly::CallNamespaceFunctionExpression): CPPAssembly::CallNamespaceFunctionExpression {
         let ts = CPPTransformNameManager::convertTypeSignature(expr.etype);
         let ikey = CPPTransformNameManager::convertInvokeKey(expr.ikey);
         let ns = CPPTransformNameManager::convertNamespaceKey(expr.ns);
-        let args = this.transformArgumentInfo(expr.argsinfo);
+        let args = this.transformArgumentList(expr.argsinfo.args);
         let fullns = expr.fullns;
 
         return CPPAssembly::CallNamespaceFunctionExpression{ ts, ikey, ns, fullns, args };
@@ -312,7 +291,7 @@ entity CPPTransformer {
         let ikey = CPPTransformNameManager::convertInvokeKey(expr.ikey);
         let ttype = CPPTransformNameManager::convertNominalTypeSignature(expr.ttype);
         let resolvedDeclType = CPPTransformNameManager::convertNominalTypeSignature(expr.resolvedDeclType);
-        let args = this.transformArgumentInfo(expr.argsinfo);
+        let args = this.transformArgumentList(expr.argsinfo.args);
 
         return CPPAssembly::CallTypeFunctionExpression{ ts, ikey, ttype, resolvedDeclType, args };
     }
@@ -326,12 +305,17 @@ entity CPPTransformer {
         return CPPAssembly::ITestSome{ isnot };
     }
 
+    method transformITestNone(isnot: Bool): CPPAssembly::ITestNone {
+        return CPPAssembly::ITestNone{ isnot };
+    }
+
     %% TODO: Support for ITest as convert
     method transformITestAsTest(itest: BSQAssembly::ITest): CPPAssembly::ITest {
         let isnot = itest.isnot;
         match(itest)@ {
             BSQAssembly::ITestType => { return this.transformITestType($itest, isnot); }
             | BSQAssembly::ITestSome => { return this.transformITestSome(isnot); }
+            | BSQAssembly::ITestNone => { return this.transformITestNone(isnot); }
             | _ => { abort; } 
         }
     }
@@ -349,7 +333,7 @@ entity CPPTransformer {
             | BSQAssembly::PostfixInvokeStatic => {
                 let resolvedType = CPPTransformNameManager::convertNominalTypeSignature($op.resolvedType);
                 let resolvedTrgt = CPPTransformNameManager::convertInvokeKey($op.resolvedTrgt);
-                let args = this.transformArgumentInfo($op.argsinfo);
+                let args = this.transformArgumentList($op.argsinfo.args);
 
                 return CPPAssembly::PostfixInvokeStatic{ baseType, resolvedType, resolvedTrgt, args };
             }
@@ -402,31 +386,8 @@ entity CPPTransformer {
 
     method transformConstructorStdExpression(e: BSQAssembly::ConstructorStdExpression): CPPAssembly::ConstructorStdExpression {
         let base = this.transformConstructorPrimaryExpressionBase(e@<BSQAssembly::ConstructorPrimaryExpression>);        
-        let shuffledargs = e.shuffleinfo.mapIdx<Option<CPPAssembly::ArgumentValue>>(fn(she, ii) => {
-                var cur_arg: CPPAssembly::ArgumentValue;
-                if(ii >= e.args.args.size()) {
-                    return none;
-                }
-                else { %% Resolve shuffle value
-                    let shuffle_idx = she.0;
-                    if(shuffle_idx)@none {
-                        let arg = base.1.args.get(ii);
-                        if(arg)@!none {
-                            return some($arg);
-                        }
-                        abort;
-                    }
-                    else {
-                        let arg = base.1.args.get($shuffle_idx);
-                        if(arg)@!none {
-                            return some($arg);
-                        }
-                        abort;
-                    }
-                }
-            });
-
-        return CPPAssembly::ConstructorStdExpression{ base.0, CPPAssembly::ArgumentList{ shuffledargs }, base.2, e.fullns };
+        let args = this.transformArgumentList(e.args);
+        return CPPAssembly::ConstructorStdExpression{ base.0, args, base.2, e.fullns };
     } 
 
     method transformIfExpression(exp: BSQAssembly::IfExpression): CPPAssembly::IfExpression {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -302,8 +302,7 @@ entity CPPTransformer {
         let ikey = CPPTransformNameManager::convertInvokeKey(expr.ikey);
         let ns = CPPTransformNameManager::convertNamespaceKey(expr.ns);
         let args = this.transformArgumentInfo(expr.argsinfo);
-        let fullns = expr.fullns; %% For looking up func we are calling
-        %% let callingikey = expr.callingikey; %% Typefuncs (since they get grouped with nsfuncs due to type resolution)
+        let fullns = expr.fullns;
 
         return CPPAssembly::CallNamespaceFunctionExpression{ ts, ikey, ns, fullns, args };
     }
@@ -756,7 +755,7 @@ entity CPPTransformer {
                 let cons = bsqasm.constructables.get(typekey);
                 if(cons)@<BSQAssembly::SomeTypeDecl> { %% Only support Some<T> for now (are always value too)
                     let someinfo = this.generateTypeInfo[recursive]($cons.oftype.tkeystr, tinfos, cur_tid, bsqasm).0;
-                    var named_someinfo = CPPAssembly::TypeInfo{ someinfo.id, someinfo.typesize, someinfo.slotsize, someinfo.ptrmask, cpptkey, CPPAssembly::Tag#Value }; 
+                    var named_someinfo = CPPAssembly::TypeInfo{ next_tid, someinfo.typesize, someinfo.slotsize, someinfo.ptrmask, cpptkey, CPPAssembly::Tag#Value }; 
 
                     %% We need to return early as all work was done in calculating someinfo
                     return (| named_someinfo, tinfos.insert(cpptkey, named_someinfo) |);
@@ -781,7 +780,7 @@ entity CPPTransformer {
                 let pc = bsqasm.pconcepts.get(typekey);
                 if(pc)@<BSQAssembly::OptionTypeDecl> { %% I "think" sometype would be best here
                     let pcinfo = this.generateTypeInfo[recursive]($pc.someType.tkeystr, tinfos, cur_tid, bsqasm).0;
-                    let named_pcinfo = CPPAssembly::TypeInfo{ pcinfo.id, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, CString::concat('2', pcinfo.ptrmask), cpptkey, CPPAssembly::Tag#Tagged };
+                    let named_pcinfo = CPPAssembly::TypeInfo{ next_tid, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, CString::concat('2', pcinfo.ptrmask), cpptkey, CPPAssembly::Tag#Tagged };
 
                     %% Same as calculating Some<T> typeinfo
                     return (| named_pcinfo, tinfos.insert(cpptkey, named_pcinfo) |);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -330,6 +330,11 @@ entity CPPTransformer {
 
                 return CPPAssembly::PostfixAccessFromName{ baseType, name, declaredInType, ftype };
             }
+            | BSQAssembly::PostfixProjectFromNames => { abort; }
+            | BSQAssembly::PostfixAccessFromIndex => { abort; }
+            | BSQAssembly::PostfixIsTest => { return CPPAssembly::PostfixIsTest{ baseType, this.transformITestAsTest($op.ttest) }; }
+            | BSQAssembly::PostfixAsConvert => { abort; }
+            | BSQAssembly::PostfixAssignFields => { abort; }
             | BSQAssembly::PostfixInvokeStatic => {
                 let resolvedType = CPPTransformNameManager::convertNominalTypeSignature($op.resolvedType);
                 let resolvedTrgt = CPPTransformNameManager::convertInvokeKey($op.resolvedTrgt);
@@ -337,8 +342,14 @@ entity CPPTransformer {
 
                 return CPPAssembly::PostfixInvokeStatic{ baseType, resolvedType, resolvedTrgt, args };
             }
-            | BSQAssembly::PostfixIsTest => { return CPPAssembly::PostfixIsTest{ baseType, this.transformITestAsTest($op.ttest) }; }
-            | _ => { abort; } %% TODO: Not Implemented
+            | BSQAssembly::PostfixInvokeVirtual => { abort; }
+            | BSQAssembly::PostfixLiteralKeyAccess => { abort; }
+            | BSQAssembly::PostfixBoolConstant => { return CPPAssembly::PostfixBoolConstant{ baseType, $op.value }; }
+            | BSQAssembly::PostfixNop => { abort; }
+            | BSQAssembly::PostfixAbort => { abort; }
+            | BSQAssembly::PostfixWidenConvert => { abort; }
+            | BSQAssembly::PostfixAccessSomeValue => { abort; }
+            | BSQAssembly::PostfixLiteralNoneValue => { abort; }
         }
     }
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -433,11 +433,8 @@ entity CPPTransformer {
         let etype = CPPTransformNameManager::convertTypeSignature(exp.etype);
         let texp = this.transformExpressionToCpp(exp.texp);
 
-        let coerced_thenexp = this.processCoerceTypeAsNeeded(exp.thenexp, exp.etype);
-        let coerced_elseexp = this.processCoerceTypeAsNeeded(exp.elseexp, exp.etype);
-
-        let thenexp = this.transformExpressionToCpp(coerced_thenexp);
-        let elseexp = this.transformExpressionToCpp(coerced_elseexp);
+        let thenexp = this.transformExpressionToCpp(exp.thenexp);
+        let elseexp = this.transformExpressionToCpp(exp.elseexp);
 
         match(exp)@ {
             BSQAssembly::IfSimpleExpression => { return CPPAssembly::IfSimpleExpression{ etype, texp, thenexp, elseexp }; }
@@ -445,7 +442,6 @@ entity CPPTransformer {
         }
     }
 
-    %% Will be used when we are running Explicitify
     method transformCoerceWidenTypeExpression(exp: BSQAssembly::CoerceWidenTypeExpression): CPPAssembly::CoerceWidenTypeExpression {
         let etype = CPPTransformNameManager::convertTypeSignature(exp.etype);
         let expr = this.transformExpressionToCpp(exp.exp);
@@ -455,7 +451,6 @@ entity CPPTransformer {
         return CPPAssembly::CoerceWidenTypeExpression{ etype, expr, srctype, trgttype };
     }
 
-    %% Same here
     method transformCoerceNarrowTypeExpression(exp: BSQAssembly::CoerceNarrowTypeExpression): CPPAssembly::CoerceNarrowTypeExpression {
         let etype = CPPTransformNameManager::convertTypeSignature(exp.etype);
         let expr = this.transformExpressionToCpp(exp.exp);
@@ -463,6 +458,24 @@ entity CPPTransformer {
         let trgttype = CPPTransformNameManager::convertNominalTypeSignature(exp.trgttype);
 
         return CPPAssembly::CoerceNarrowTypeExpression{ etype, expr, srctype, trgttype };
+    }
+
+    method transformSafeConvertExpression(exp: BSQAssembly::SafeConvertExpression): CPPAssembly::SafeConvertExpression {
+        let etype = CPPTransformNameManager::convertTypeSignature(exp.etype);
+        let expr = this.transformExpressionToCpp(exp.exp);
+        let srctype = CPPTransformNameManager::convertNominalTypeSignature(exp.srctype);
+        let trgttype = CPPTransformNameManager::convertNominalTypeSignature(exp.trgttype);
+
+        return CPPAssembly::SafeConvertExpression{ etype, expr, srctype, trgttype };
+    }
+
+    method transformCreateDirectExpression(exp: BSQAssembly::CreateDirectExpression): CPPAssembly::CreateDirectExpression {
+        let etype = CPPTransformNameManager::convertTypeSignature(exp.etype);
+        let expr = this.transformExpressionToCpp(exp.exp);
+        let srctype = CPPTransformNameManager::convertNominalTypeSignature(exp.srctype);
+        let trgttype = CPPTransformNameManager::convertNominalTypeSignature(exp.trgttype);
+
+        return CPPAssembly::CreateDirectExpression{ etype, expr, srctype, trgttype };
     }
 
     recursive method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
@@ -484,6 +497,8 @@ entity CPPTransformer {
             | BSQAssembly::IfExpression => { return this.transformIfExpression($expr); }
             | BSQAssembly::CoerceWidenTypeExpression => { return this.transformCoerceWidenTypeExpression($expr); }   
             | BSQAssembly::CoerceNarrowTypeExpression => { return this.transformCoerceNarrowTypeExpression($expr); }
+            | BSQAssembly::SafeConvertExpression => { return this.transformSafeConvertExpression($expr); }
+            | BSQAssembly::CreateDirectExpression => { return this.transformCreateDirectExpression($expr); }
             | _ => { abort; }
         }
     }
@@ -495,26 +510,10 @@ entity CPPTransformer {
         return CPPAssembly::ReturnSingleStatement{rtype, rexp};
     }
 
-    %% Temporary
-    method processCoerceTypeAsNeeded(e: BSQAssembly::Expression, into: BSQAssembly::TypeSignature): BSQAssembly::Expression {
-        if(this.bsqasm.areTypesSame(e.etype, into)) {
-            return e;
-        }
-        else {
-            if(this.bsqasm.isSubtypeOf(e.etype, into)) {
-                return BSQAssembly::CoerceWidenTypeExpression{ e.sinfo, into, e, e.etype@<BSQAssembly::NominalTypeSignature>, into@<BSQAssembly::NominalTypeSignature> };
-            }
-            else {
-                return BSQAssembly::CoerceNarrowTypeExpression{ e.sinfo, into, e, e.etype@<BSQAssembly::NominalTypeSignature>, into@<BSQAssembly::NominalTypeSignature> };
-            }
-        }
-    }
-
     recursive method transformVariableInitializationStatementToCpp(stmt: BSQAssembly::VariableInitializationStatement): CPPAssembly::VariableInitializationStatement {
         let name = CPPTransformNameManager::convertIdentifier(stmt.name);
         let stype = CPPTransformNameManager::convertTypeSignature(stmt.vtype);
-        let coerced_expr = this.processCoerceTypeAsNeeded(stmt.exp, stmt.vtype);
-        let cppexpr = this.transformExpressionToCpp[recursive](coerced_expr);
+        let cppexpr = this.transformExpressionToCpp[recursive](stmt.exp);
 
         return CPPAssembly::VariableInitializationStatement{ name, stype, cppexpr };
     }
@@ -560,11 +559,32 @@ entity CPPTransformer {
 
     method transformStatementToCpp(stmt: BSQAssembly::Statement): CPPAssembly::Statement {
         match(stmt)@ {
-            BSQAssembly::VariableInitializationStatement => { return this.transformVariableInitializationStatementToCpp($stmt); }
+            BSQAssembly::EmptyStatement => { return CPPAssembly::EmptyStatement{ }; }
+            | BSQAssembly::VariableDeclarationStatement => { abort; }
+            | BSQAssembly::VariableMultiDeclarationStatement => { abort; }
+            | BSQAssembly::VariableInitializationStatement => { return this.transformVariableInitializationStatementToCpp($stmt); }
+            | BSQAssembly::VariableMultiInitializationExplicitStatement => { abort; }
+            | BSQAssembly::VariableMultiInitializationImplicitStatement => { abort; }
+            | BSQAssembly::VariableAssignmentStatement => { abort; }
+            | BSQAssembly::VariableMultiInitializationExplicitStatement => { abort; }
+            | BSQAssembly::VariableMultiAssignmentImplicitStatement => { abort; }
+            | BSQAssembly::VariableRetypeStatement => { abort; }
+            | BSQAssembly::ReturnVoidStatement => { abort; }
             | BSQAssembly::ReturnSingleStatement => { return this.transformReturnSingleStatementToCpp[recursive]($stmt); }
+            | BSQAssembly::ReturnMultiStatement => { abort; }
             | BSQAssembly::IfStatement => { return this.transformIfStatement[recursive]($stmt); }
             | BSQAssembly::IfElseStatement => { return this.transformIfElseStatement[recursive]($stmt); }
             | BSQAssembly::IfElifElseStatement => { return this.transformIfElifElseStatement[recursive]($stmt); }
+            | BSQAssembly::SwitchStatement => { abort; }
+            | BSQAssembly::MatchStatement => { abort; }
+            | BSQAssembly::AbortStatement => { abort; }
+            | BSQAssembly::AssertStatement => { abort; } 
+            | BSQAssembly::ValidateStatement => { abort; }
+            | BSQAssembly::DebugStatement => { abort; }
+            | BSQAssembly::VoidRefCallStatement => { abort; }
+            | BSQAssembly::UpdateDirectStatement => { abort; }
+            | BSQAssembly::UpdateIndirectStatement => { abort; }
+            | BSQAssembly::BlockStatement => { return this.transformBlockStatement($stmt); }
             | _ => { abort; }
         }
     }

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -579,7 +579,22 @@ entity ConstantSimplification {
     }
 
     method simplifyBinIFF(e: BinLogicExpression, nlhs: Expression, nrhs: Expression): Expression {
-        abort;
+        if(nlhs)@<LiteralSimpleExpression> {
+            if(nrhs)@<LiteralSimpleExpression> {
+                if($nlhs.value === $nrhs.value) {
+                    return ConstantSimplification::trueExp;
+                }
+                else {
+                    return e[lhs=nlhs, rhs=nrhs];
+                }
+            }
+            else {
+                return e[lhs=nlhs, rhs=nrhs];
+            }
+        }
+        else {
+            return e[lhs=nlhs, rhs=nrhs];
+        }
     }
 
     recursive method processBinLogicExpression(e: BinLogicExpression): Expression {

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -945,7 +945,7 @@ entity ConstantSimplification {
         else {
             let dv = this.processExpression(param.defaultval@some);
             
-            return param[ptype=dv.etype, defaultval=some(dv)];
+            return param[defaultval=some(dv)];
         }
     }
 

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -55,22 +55,7 @@ entity ConstantSimplification {
     }
 
     method processITestTypeAsTest(sinfo: SourceInfo, srctype: TypeSignature, itest: ITestType): PostfixOperation {
-        if(this.assembly.isSubtypeOf(srctype, itest.ttype)) {
-            if(itest.isnot) {
-                return PostfixBoolConstant{ sinfo, srctype, false };
-            }
-            else {
-                return PostfixBoolConstant{ sinfo, srctype, true };
-            } 
-        }
-        else {
-            if(itest.isnot) {
-                return PostfixBoolConstant{ sinfo, srctype, true };
-            }
-            else {
-                return PostfixBoolConstant{ sinfo, srctype, false };
-            }
-        }
+        abort; %% Not implemented 
     }
 
     method processITestNoneAsTest(sinfo: SourceInfo, srctype: TypeSignature, itest: ITestNone): PostfixOperation {

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -55,7 +55,22 @@ entity ConstantSimplification {
     }
 
     method processITestTypeAsTest(sinfo: SourceInfo, srctype: TypeSignature, itest: ITestType): PostfixOperation {
-        abort; %% Not implemented
+        if(this.assembly.isSubtypeOf(srctype, itest.ttype)) {
+            if(itest.isnot) {
+                return PostfixBoolConstant{ sinfo, srctype, false };
+            }
+            else {
+                return PostfixBoolConstant{ sinfo, srctype, true };
+            } 
+        }
+        else {
+            if(itest.isnot) {
+                return PostfixBoolConstant{ sinfo, srctype, true };
+            }
+            else {
+                return PostfixBoolConstant{ sinfo, srctype, false };
+            }
+        }
     }
 
     method processITestNoneAsTest(sinfo: SourceInfo, srctype: TypeSignature, itest: ITestNone): PostfixOperation {
@@ -859,24 +874,25 @@ entity ConstantSimplification {
                 => (|this.processExpression[recursive](eb.0), this.processBlockStatement(eb.1)|));
         let nelseflow = this.processBlockStatement(s.elseflow);
 
-        if(nifcond)@!<LiteralSimpleExpression> {
-            let evalcondflow = ncondflow.tryFind(pred(eb) => eb.0?<LiteralSimpleExpression> && eb.0@<LiteralSimpleExpression>.value === 'true');
-
-            if(evalcondflow)@!none {
-                return $evalcondflow.1;
-            }
-            else { 
-                return s[ifcond=nifcond, ifflow=nifflow, condflow=ncondflow, elseflow=nelseflow];
-            }
+        if(nifcond?<LiteralSimpleExpression> && nifcond@<LiteralSimpleExpression>.value === 'true') {
+            return nifflow;
         }
         else {
-            if($nifcond.value === 'true') {
-                return nifflow;
-            }
-            else {
-                return nelseflow;
-            }
-        } 
+            return ncondflow.lreduce<Statement>(nelseflow, fn(acc, eb) => {
+                let cur = eb.0;
+                if(cur)@!<LiteralSimpleExpression> {
+                    return s[ifcond=nifcond, ifflow=nifflow, condflow=ncondflow, elseflow=nelseflow];
+                }
+                else {
+                    if($cur.value === 'true') {
+                        return eb.1;
+                    }
+                    else {
+                        return acc;
+                    }
+                }
+            });
+        }
     }
 
     recursive method processStatement(s: Statement): Statement {

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -579,21 +579,16 @@ entity ConstantSimplification {
     }
 
     method simplifyBinIFF(e: BinLogicExpression, nlhs: Expression, nrhs: Expression): Expression {
-        if(nlhs)@<LiteralSimpleExpression> {
-            if(nrhs)@<LiteralSimpleExpression> {
-                if($nlhs.value === $nrhs.value) {
-                    return ConstantSimplification::trueExp;
-                }
-                else {
-                    return e[lhs=nlhs, rhs=nrhs];
-                }
-            }
-            else {
-                return e[lhs=nlhs, rhs=nrhs];
-            }
+        if(nlhs?!<LiteralSimpleExpression> || nrhs?!<LiteralSimpleExpression>) {
+            return e[lhs=nlhs, rhs=nrhs];
         }
         else {
-            return e[lhs=nlhs, rhs=nrhs];
+            if(nlhs@<LiteralSimpleExpression>.value === nrhs@<LiteralSimpleExpression>.value) {
+                return ConstantSimplification::trueExp;
+            }
+            else {
+                return ConstantSimplification::falseExp;
+            }
         }
     }
 

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -248,6 +248,11 @@ entity ConstantSimplification {
         return e[argsinfo=$argsinfo[args=nargs]];
     }
 
+    recursive method processCallTypeFunctionExpression(e: CallTypeFunctionExpression): Expression {
+        let nargs = this.processArgumentList[recursive](e.argsinfo.args);
+        return e[argsinfo=$argsinfo[args=nargs]];
+    }
+
     recursive method processLogicActionAndExpression(e: LogicActionAndExpression): Expression {
         let nargs = this.processArgs(e.args);
 
@@ -671,7 +676,7 @@ entity ConstantSimplification {
             | LetExpression => { abort; }
             | LambdaInvokeExpression => { return this.processLambdaInvokeExpression[recursive]($e); }
             | CallNamespaceFunctionExpression => { return this.processCallNamespaceFunctionExpression[recursive]($e); }
-            | CallTypeFunctionExpression => { abort; }
+            | CallTypeFunctionExpression => { return this.processCallTypeFunctionExpression[recursive]($e); }
             | CallTypeFunctionSpecialExpression => { abort; }
             | CallRefInvokeStaticResolveExpression => { abort; }
             | CallRefInvokeVirtualExpression => { abort; }
@@ -836,6 +841,34 @@ entity ConstantSimplification {
         }
     }
 
+    recursive method processIfElifElseStatement(s: IfElifElseStatement): Statement {
+        let nifcond = this.processExpression[recursive](s.ifcond);
+        let nifflow = this.processBlockStatement[recursive](s.ifflow);
+        let ncondflow = s.condflow
+            .map<(|Expression, BlockStatement|)>(fn(eb) 
+                => (|this.processExpression[recursive](eb.0), this.processBlockStatement(eb.1)|));
+        let nelseflow = this.processBlockStatement(s.elseflow);
+
+        if(nifcond)@!<LiteralSimpleExpression> {
+            let evalcondflow = ncondflow.tryFind(pred(eb) => eb.0?<LiteralSimpleExpression> && eb.0@<LiteralSimpleExpression>.value === 'true');
+
+            if(evalcondflow)@!none {
+                return $evalcondflow.1;
+            }
+            else { 
+                return s[ifcond=nifcond, ifflow=nifflow, condflow=ncondflow, elseflow=nelseflow];
+            }
+        }
+        else {
+            if($nifcond.value === 'true') {
+                return nifflow;
+            }
+            else {
+                return nelseflow;
+            }
+        } 
+    }
+
     recursive method processStatement(s: Statement): Statement {
         match(s)@ {
             VariableDeclarationStatement => {
@@ -877,6 +910,9 @@ entity ConstantSimplification {
             | IfElseStatement => {
                 return this.processIfElseStatement[recursive]($s);
             }
+            | IfElifElseStatement => {
+                return this.processIfElifElseStatement[recursive]($s);
+            }
             | AbortStatement => {
                 return s;
             }
@@ -897,7 +933,9 @@ entity ConstantSimplification {
             return param;
         }
         else {
-            abort;
+            let dv = this.processExpression(param.defaultval@some);
+            
+            return param[ptype=dv.etype, defaultval=some(dv)];
         }
     }
 
@@ -1098,7 +1136,32 @@ entity ConstantSimplification {
     }
 
     method processDatatypeMemberEntityTypeDecl(dmtype: DatatypeMemberEntityTypeDecl): DatatypeMemberEntityTypeDecl {
-        abort;
+        return DatatypeMemberEntityTypeDecl{
+            file=dmtype.file,
+            sinfo=dmtype.sinfo,
+            fullns = dmtype.fullns,
+            declaredInNS=dmtype.declaredInNS,
+            
+            tkey=dmtype.tkey,
+            name=dmtype.name,
+
+            invariants=dmtype.invariants.map<InvariantDecl>(fn(iiv) => this.processInvariant(iiv)),
+            validates=dmtype.validates.map<ValidateDecl>(fn(vv) => this.processValidate(vv)),
+
+            absmethods=dmtype.absmethods,
+            virtmethods=dmtype.virtmethods,
+            overmethods=dmtype.overmethods,
+            staticmethods=dmtype.staticmethods,
+
+            saturatedProvides=dmtype.saturatedProvides,
+            saturatedBFieldInfo=dmtype.saturatedBFieldInfo,
+
+            allInvariants=dmtype.allInvariants,
+            allValidates=dmtype.allValidates,
+
+            fields=dmtype.fields.map<MemberFieldDecl>(fn(fd) => this.processMemberFieldDecl(fd)),
+            parentTypeDecl=dmtype.parentTypeDecl
+        };
     }
 
     method processPrimitiveConceptTypeDecl(pconcept: PrimitiveConceptTypeDecl): PrimitiveConceptTypeDecl {
@@ -1110,7 +1173,34 @@ entity ConstantSimplification {
     }
 
     method processDatatypeTypeDecl(ddatatype: DatatypeTypeDecl): DatatypeTypeDecl {
-        abort;
+        return DatatypeTypeDecl {
+            file=ddatatype.file,
+            sinfo=ddatatype.sinfo,
+            fullns = ddatatype.fullns,
+            declaredInNS=ddatatype.declaredInNS,
+            
+            tkey=ddatatype.tkey,
+            name=ddatatype.name,
+
+            invariants=ddatatype.invariants.map<InvariantDecl>(fn(iiv) => this.processInvariant(iiv)),
+            validates=ddatatype.validates.map<ValidateDecl>(fn(vv) => this.processValidate(vv)),
+
+            absmethods=ddatatype.absmethods,
+            virtmethods=ddatatype.virtmethods,
+            overmethods=ddatatype.overmethods,
+            staticmethods=ddatatype.staticmethods,
+
+            saturatedProvides=ddatatype.saturatedProvides,
+            saturatedBFieldInfo=ddatatype.saturatedBFieldInfo,
+
+            allInvariants=ddatatype.allInvariants,
+            allValidates=ddatatype.allValidates,
+
+            subtypes=ddatatype.subtypes,
+
+            fields=ddatatype.fields.map<MemberFieldDecl>(fn(fd) => this.processMemberFieldDecl(fd)),
+            associatedMemberEntityDecls=ddatatype.associatedMemberEntityDecls
+        };
     }
 
     function process(assembly: Assembly): Assembly {

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -537,8 +537,8 @@ entity ExplicitifyTransform {
 
         let nifflow = this.processBlockStatement[recursive](s.ifflow, vmap);
         let ncondflow = s.condflow
-            .map<(|Expression, BlockStatement|)>(fn(eb) %% Need new varmapping? 
-                => (|this.processExpression[recursive](eb.0, vmap), this.processBlockStatement[recursive](eb.1, vmap)|));
+            .map<(|Expression, BlockStatement|)>(fn(eb) => 
+                (|this.processExpression[recursive](eb.0, vmap), this.processBlockStatement[recursive](eb.1, vmap)|));
         let nelseflow = this.processBlockStatement[recursive](s.elseflow, vmap);
 
         return s[ifcond=nifcond, ifflow=nifflow, condflow=ncondflow, elseflow=nelseflow];

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -627,7 +627,7 @@ entity ExplicitifyTransform {
             let dv = this.processExpression(param.defaultval@some, VarMapping::createEmpty());
             let dvc = this.processCoerceTypeAsNeeded(dv, param.ptype);
             
-            return param[ptype=dvc.etype, defaultval=some(dvc)];
+            return param[defaultval=some(dvc)];
         }
     }
 

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -180,6 +180,13 @@ entity ExplicitifyTransform {
         return e[argsinfo=$argsinfo[args=nargs]];
     }
 
+    recursive method processCallTypeFunctionExpression(e: CallTypeFunctionExpression, vmap: VarMapping): Expression {
+        let types = e.argsinfo.shuffleinfo.map<TypeSignature>(fn(si) => si.1); 
+        let nargs = this.processArgumentListStd(e.argsinfo.args, types, vmap);
+
+        return e[argsinfo=$argsinfo[args=nargs]];
+    }
+
     recursive method processLogicActionAndExpression(e: LogicActionAndExpression, vmap: VarMapping): Expression {
         let nargs = this.processArgs(e.args, vmap).map<Expression>(fn(ee) => this.processExplicitBoolConvertAsNeeded(ee));
 
@@ -428,7 +435,7 @@ entity ExplicitifyTransform {
             | LetExpression => { abort; }
             | LambdaInvokeExpression => { return this.processLambdaInvokeExpression[recursive]($e, vmap); }
             | CallNamespaceFunctionExpression => { return this.processCallNamespaceFunctionExpression[recursive]($e, vmap); }
-            | CallTypeFunctionExpression => { abort; }
+            | CallTypeFunctionExpression => { return this.processCallTypeFunctionExpression[recursive]($e, vmap); }
             | CallTypeFunctionSpecialExpression => { abort; }
             | CallRefInvokeStaticResolveExpression => { abort; }
             | CallRefInvokeVirtualExpression => { abort; }
@@ -525,6 +532,18 @@ entity ExplicitifyTransform {
         }
     }
 
+    recursive method processIfElifElseStatement(s: IfElifElseStatement, vmap: VarMapping): Statement {
+        let nifcond = this.processExplicitBoolConvertAsNeeded(this.processExpression[recursive](s.ifcond, vmap));
+
+        let nifflow = this.processBlockStatement[recursive](s.ifflow, vmap);
+        let ncondflow = s.condflow
+            .map<(|Expression, BlockStatement|)>(fn(eb) %% Need new varmapping? 
+                => (|this.processExpression[recursive](eb.0, vmap), this.processBlockStatement[recursive](eb.1, vmap)|));
+        let nelseflow = this.processBlockStatement[recursive](s.elseflow, vmap);
+
+        return s[ifcond=nifcond, ifflow=nifflow, condflow=ncondflow, elseflow=nelseflow];
+    }
+
     recursive method processStatement(s: Statement, vmap: VarMapping): Statement {
         match(s)@ {
             EmptyStatement => {
@@ -577,6 +596,9 @@ entity ExplicitifyTransform {
             | IfElseStatement => {
                 return this.processIfElseStatement[recursive]($s, vmap);
             }
+            | IfElifElseStatement => {
+                return this.processIfElifElseStatement[recursive]($s, vmap);
+            }
             | AbortStatement => {
                 return s;
             }
@@ -602,7 +624,10 @@ entity ExplicitifyTransform {
             return param;
         }
         else {
-            abort;
+            let dv = this.processExpression(param.defaultval@some, VarMapping::createEmpty());
+            let dvc = this.processCoerceTypeAsNeeded(dv, param.ptype);
+            
+            return param[ptype=dvc.etype, defaultval=some(dvc)];
         }
     }
 
@@ -775,7 +800,32 @@ entity ExplicitifyTransform {
     }
 
     method processDatatypeMemberEntityTypeDecl(dmtype: DatatypeMemberEntityTypeDecl): DatatypeMemberEntityTypeDecl {
-        abort;
+        return DatatypeMemberEntityTypeDecl{
+            file=dmtype.file,
+            sinfo=dmtype.sinfo,
+            fullns = dmtype.fullns,
+            declaredInNS=dmtype.declaredInNS,
+            
+            tkey=dmtype.tkey,
+            name=dmtype.name,
+
+            invariants=dmtype.invariants.map<InvariantDecl>(fn(iiv) => this.processInvariant(iiv)),
+            validates=dmtype.validates.map<ValidateDecl>(fn(vv) => this.processValidate(vv)),
+
+            absmethods=dmtype.absmethods,
+            virtmethods=dmtype.virtmethods,
+            overmethods=dmtype.overmethods,
+            staticmethods=dmtype.staticmethods,
+
+            saturatedProvides=dmtype.saturatedProvides,
+            saturatedBFieldInfo=dmtype.saturatedBFieldInfo,
+
+            allInvariants=dmtype.allInvariants,
+            allValidates=dmtype.allValidates,
+
+            fields=dmtype.fields.map<MemberFieldDecl>(fn(fd) => this.processMemberFieldDecl(fd)),
+            parentTypeDecl=dmtype.parentTypeDecl
+        };
     }
 
     method processConceptTypeDecl(cconcept: ConceptTypeDecl): ConceptTypeDecl {
@@ -783,7 +833,34 @@ entity ExplicitifyTransform {
     }
 
     method processDatatypeTypeDecl(ddatatype: DatatypeTypeDecl): DatatypeTypeDecl {
-        abort;
+        return DatatypeTypeDecl {
+            file=ddatatype.file,
+            sinfo=ddatatype.sinfo,
+            fullns = ddatatype.fullns,
+            declaredInNS=ddatatype.declaredInNS,
+            
+            tkey=ddatatype.tkey,
+            name=ddatatype.name,
+
+            invariants=ddatatype.invariants.map<InvariantDecl>(fn(iiv) => this.processInvariant(iiv)),
+            validates=ddatatype.validates.map<ValidateDecl>(fn(vv) => this.processValidate(vv)),
+
+            absmethods=ddatatype.absmethods,
+            virtmethods=ddatatype.virtmethods,
+            overmethods=ddatatype.overmethods,
+            staticmethods=ddatatype.staticmethods,
+
+            saturatedProvides=ddatatype.saturatedProvides,
+            saturatedBFieldInfo=ddatatype.saturatedBFieldInfo,
+
+            allInvariants=ddatatype.allInvariants,
+            allValidates=ddatatype.allValidates,
+
+            subtypes=ddatatype.subtypes,
+
+            fields=ddatatype.fields.map<MemberFieldDecl>(fn(fd) => this.processMemberFieldDecl(fd)),
+            associatedMemberEntityDecls=ddatatype.associatedMemberEntityDecls
+        };
     }
 
     function process(assembly: Assembly): Assembly {

--- a/test/cppoutput/fcall_exps/ns_fcalls.test.js
+++ b/test/cppoutput/fcall_exps/ns_fcalls.test.js
@@ -9,21 +9,25 @@ describe ("CPP Emit Evaluate -- NamespaceFunction (no template)", () => {
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(1i, true); }", "1_i");
     });
 
+/*  Enable when default val support in explicitify
     it("should exec simple named", function () {
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(x=1i, y=true); }", "1_i");
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(y=true, x=1i); }", "1_i");
     });
-
+*/
+/*  Enable when default val support in explicitify
     it("should exec simple mixed", function () {
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(1i, y=true); }", "1_i");
         runMainCode("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(y=true, x=1i); }", "1_i");
     });
-
+*/
+/*  Enable when default val support in explicitify
     it("should exec simple default", function () {
         runMainCode("function foo(x: Int, y: Int = $x): Int { return x + y; } public function main(): Int { return foo(1i, 2i); }", "3_i");
         runMainCode("function foo(x: Int, y: Int = $x): Int { return x + y; } public function main(): Int { return foo(1i); }", "2_i");
     });
- });
+*/
+});
 
 describe ("CPP Emit Evaluate -- NamespaceFunction (with template)", () => {
     it("should exec simple positional", function () {

--- a/test/cppoutput/if_exp/basic_if.test.js
+++ b/test/cppoutput/if_exp/basic_if.test.js
@@ -8,8 +8,23 @@ describe ("CPP Emit Evaluate -- Simple if-expression", () => {
         runMainCode("public function main(): Int { return if(1n != 2n) then 2i else 3i; }", "2_i");
         runMainCode("public function main(): Int { return if(2n != 2n) then 2i else 3i; }", "3_i");
     });
-});
 
-//
-// TODO: Add support for ITests so we can run some ITest + ifexp tests
-//
+    it("should exec expressions w/ itest", function () {
+        
+        // Need to add ifTestExpression support to cpp emitter
+        
+        //runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)!none then 2i else 3i; }", "2_i");
+        //runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)some then 2i else 3i; }", "2_i");
+        //runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)<Some<Int>> then 2i else 3i; }", "2_i");
+
+        //runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if(x)@!none then $x else 3i; }", "1i");
+        runMainCode("public function main(): Int { let x: Int = 1i; return if(x < 3i) then 0i else x; }", "0_i");
+        
+        //runMainCode("public function main(): Int { let x: Int = 1i; return if(if(x < 3i) then none else some(x))@!none then $_ else 3i; }", "3i");
+        //runMainCode("public function main(): Int { let x: Int = 5i; return if(if(x < 3i) then none else some(x))@!none then $_ else 3i; }", "5i");
+        
+        //runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if($y = x)@<Some<Int>> then $y.value else 3i; }", "1i");
+        //runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if($y = x)@some then $y else 3i; }", "1i");
+        //runMainCode("public function main(): Int { let x: Option<Int> = none; return if($y = x)@some then $y else 3i; }", "3i");
+    });
+});

--- a/test/cppoutput/mcall_exps/simple_resolved.test.js
+++ b/test/cppoutput/mcall_exps/simple_resolved.test.js
@@ -11,7 +11,7 @@ describe ("CPP Emit Evaluate -- entity methods", () => {
 
     it("should exec simple entity methods with args", function () {
         runMainCode('entity Foo { field f: Int; method foo(x: Int): Int { return this.f + x; }} public function main(): Int { return Foo{3i}.foo(1i); }', "4_i"); 
-        runMainCode('entity Foo { field f: Int; method foo(x: Int = 1i): Int { return this.f + x; }} public function main(): Int { let x = Foo{3i}; return x.foo(); }', "4_i"); 
+        //runMainCode('entity Foo { field f: Int; method foo(x: Int = 1i): Int { return this.f + x; }} public function main(): Int { let x = Foo{3i}; return x.foo(); }', "4_i"); 
     });
 
     it("should exec simple entity methods with named args", function () {

--- a/test/cppoutput/mcall_exps/simple_resolved.test.js
+++ b/test/cppoutput/mcall_exps/simple_resolved.test.js
@@ -28,11 +28,13 @@ describe ("CPP Emit Evaluate -- entity methods", () => {
         runMainCode('entity Foo<T> { field f: T; method foo(x: T): T { return if (true) then x else this.f; }} public function main(): Int { let x = Foo<Int>{3i}; return x.foo(2i); }', "2_i"); 
     });
 
+/*   Needs ITestType in constsimplify
     it("should exec simple entity methods with both template", function () {
         runMainCode('entity Foo<T> { field f: T; method foo<U>(): Bool { return this.f?<U>; }} public function main(): Bool { let x = Foo<Int>{3i}; return x.foo<Nat>(); }', "false"); 
         runMainCode('entity Foo<T> { field f: T; method foo<U>(): Bool { return this.f?<U>; }} public function main(): Bool { let x = Foo<Int>{3i}; return x.foo<Int>(); }', "true"); 
     });
- });
+*/
+});
 
 describe ("CPP Emit Evaluate -- eADT methods", () => {
     it("should exec simple eADT methods", function () {
@@ -44,12 +46,13 @@ describe ("CPP Emit Evaluate -- eADT methods", () => {
         runMainCode('datatype Foo<T> of Foo1 { field f: T; method foo(x: T): T { return if (true) then x else this.f; }} ; public function main(): Int { let x = Foo1<Int>{3i}; return x.foo(2i); }', "2_i"); 
     });
    
-   
+/*  Needs ITestType in constsimplify 
     it("should exec simple eADT methods with template", function () {
         runMainCode('datatype Foo of Foo1 { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} ; public function main(): Bool { let x = Foo1{3i}; return x.foo<Nat>(); }', "false"); 
         runMainCode('datatype Foo of Foo1 { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} ; public function main(): Bool { let x = Foo1{3i}; return x.foo<Int>(); }', "true"); 
     });
-    
+*/  
+
 /*
     it("should exec simple ROOT eADT methods", function () {
         runMainCode('datatype Foo of F1 { } | F2 { } & { method foo(): Int { return if(this)<F1> then 1i else 0i; } } public function main(): Int { return F1{}.foo(); }', "1i"); 

--- a/test/cppoutput/mcall_exps/simple_resolved.test.js
+++ b/test/cppoutput/mcall_exps/simple_resolved.test.js
@@ -28,13 +28,11 @@ describe ("CPP Emit Evaluate -- entity methods", () => {
         runMainCode('entity Foo<T> { field f: T; method foo(x: T): T { return if (true) then x else this.f; }} public function main(): Int { let x = Foo<Int>{3i}; return x.foo(2i); }', "2_i"); 
     });
 
-    /*
     it("should exec simple entity methods with both template", function () {
         runMainCode('entity Foo<T> { field f: T; method foo<U>(): Bool { return this.f?<U>; }} public function main(): Bool { let x = Foo<Int>{3i}; return x.foo<Nat>(); }', "false"); 
         runMainCode('entity Foo<T> { field f: T; method foo<U>(): Bool { return this.f?<U>; }} public function main(): Bool { let x = Foo<Int>{3i}; return x.foo<Int>(); }', "true"); 
     });
-    */
-});
+ });
 
 describe ("CPP Emit Evaluate -- eADT methods", () => {
     it("should exec simple eADT methods", function () {
@@ -46,13 +44,11 @@ describe ("CPP Emit Evaluate -- eADT methods", () => {
         runMainCode('datatype Foo<T> of Foo1 { field f: T; method foo(x: T): T { return if (true) then x else this.f; }} ; public function main(): Int { let x = Foo1<Int>{3i}; return x.foo(2i); }', "2_i"); 
     });
    
-    // Once we get explicitify supporting datatypes we this test should be good
-    /*
+   
     it("should exec simple eADT methods with template", function () {
         runMainCode('datatype Foo of Foo1 { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} ; public function main(): Bool { let x = Foo1{3i}; return x.foo<Nat>(); }', "false"); 
         runMainCode('datatype Foo of Foo1 { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} ; public function main(): Bool { let x = Foo1{3i}; return x.foo<Int>(); }', "true"); 
     });
-    */
     
 /*
     it("should exec simple ROOT eADT methods", function () {

--- a/test/cppoutput/special_cons_exps/optional_const.test.js
+++ b/test/cppoutput/special_cons_exps/optional_const.test.js
@@ -4,13 +4,10 @@ import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
 import { describe, it } from "node:test";
 
 describe ("CPP Emit Evaluate -- Special Constructor infer in if-else and assign positions", () => {
-    // Will uncomment when constsimplify is running    
-    /*
     it("should exec some/none with if-else", function () {
-        runMainCode("public function main(): Int { let x: Option<Int> = if(true) then some(3i) else none; return x@some; }", "3i");
+        // runMainCode("public function main(): Int { let x: Option<Int> = if(true) then some(3i) else none; return x@some; }", "3_i");
         runMainCode("public function main(): Bool { let x: Option<Int> = if(false) then some(3i) else none; return x?!some; }", "true");
     });
-    */
 
     /*
     it("should exec ok/fail with if-else", function () {
@@ -20,14 +17,14 @@ describe ("CPP Emit Evaluate -- Special Constructor infer in if-else and assign 
     */
 });
 
-/*
 describe ("Exec -- Special Constructor Optional", () => {
     it("should exec none with simple infer", function () {
-        runMainCode("public function main(): Int { let x: Some<Int> = some(3i); return x.value; }", "3i");
-        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return x@some; }", "3i");
+        runMainCode("public function main(): Int { let x: Some<Int> = some(3i); return x.value; }", "3_i");
+        // runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return x@some; }", "3i");
     });
 });
 
+/*
 describe ("Exec -- Special Constructor Result", () => {
     it("should exec ok with simple infer", function () {
         runMainCode("public function main(): Int { let x: Result<Int, Bool>::Ok = ok(3i); return x.value; }", "3i");


### PR DESCRIPTION
Added support in explicitify and constsimplify for:
 - `DatatypeTypeDecl` and `DatatypeMemberEntityTypeDecl`
 - `CallTypeFunctionExpression`
 - `IfElifElseStatement`
 - `ITestType`
 - `BinLogicIFFExpression`
 
 Also deleted default val related code from the cpp emitter as eventually this would be handled in explicitify/constsimplify (and commented out any tests relying on them).