### PR TITLE
Cpp Emit Tuple

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -8,6 +8,9 @@ datatype TypeSignature using {
 of
 VoidTypeSignature { }
 | NominalTypeSignature { }
+| EListTypeSignature {
+    field entries: List<TypeSignature>;
+}
 ;
 
 concept Expression {
@@ -240,6 +243,9 @@ concept ConstructorPrimaryExpression provides ConstructorExpression {
 
 entity ConstructorStdExpression provides ConstructorPrimaryExpression {
     field fullns: List<CString>;
+}
+
+entity ConstructorEListExpression provides ConstructorExpression {
 }
 
 datatype ConstructorPrimarySpecialConstructableExpression provides ConstructorPrimaryExpression 

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -272,6 +272,9 @@ PostfixAccessFromName {
     field declaredInType: NominalTypeSignature;
     field ftype: TypeSignature;
 }
+| PostfixAccessFromIndex {
+    field idx: CString;
+}
 | PostfixIsTest {
     field ttest: ITest;
 }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -11,8 +11,9 @@ type NamespaceKey = CString of CPPAssembly::namespaceKeyRE; %%Core is implicit h
 %% to matching our __CoreCpp namespace
 const basicNominalTypeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}'::')?[_a-zA-Z0-9'::']+('<'.+'>')?/c;
 const nominalTypeKeyRE: CRegex = /(${CPPAssembly::basicNominalTypeKeyRE})/c; %% Will need to handle special scoped type key?
+const elistTypeKeyRE: CRegex = /'(|'.*'|)'/c;
 
-const typeKeyRE: CRegex = /${CPPAssembly::nominalTypeKeyRE}/c;
+const typeKeyRE: CRegex = /${CPPAssembly::nominalTypeKeyRE}|${CPPAssembly::elistTypeKeyRE}/c;
 type TypeKey = CString of CPPAssembly::typeKeyRE;
 
 %% Optional '<' * '>' allows support for resolved templates on functions or methods

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -226,6 +226,8 @@ entity Assembly {
     field allmethods: List<InvokeKey>;
     field typeinfos: Map<TypeKey, TypeInfo>;
 
+    %%field elists: Map<TypeKey, ConstructorEListExpression>;
+
     method lookupNominalTypeDeclaration(tkey: TypeKey): AbstractNominalTypeDecl {
         if(this.entities.has(tkey)) {
             return this.entities.get(tkey);

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -132,6 +132,7 @@ public:
     }
 };
 
+// We may want to specialize K=2,3,4 as well
 template <>
 class TupleEntry<1> {
 public:

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -42,22 +42,22 @@ public:
     Boxed() noexcept = default;
     Boxed(const Boxed& rhs) noexcept : typeinfo(rhs.typeinfo) {
         memcpy<K>(this->data, rhs.data);
-    };
+    }
     Boxed& operator=(const Boxed& rhs) noexcept {
         if(this != &rhs) {
             this->typeinfo = rhs.typeinfo;
             memcpy<K>(this->data, rhs.data);
         }
         return *this;
-    };
+    }
 
     // Some constructor
     Boxed(TypeInfoBase* ti, uintptr_t d[K]) noexcept : typeinfo(ti) {
         memcpy<K>(this->data, d);
-    };
+    }
 
     // None constructor
-    Boxed(TypeInfoBase* ti) noexcept : typeinfo(ti) {};
+    Boxed(TypeInfoBase* ti) noexcept : typeinfo(ti) {}
 };
 
 template<>
@@ -91,9 +91,63 @@ public:
     Boxed& operator=(const Boxed& rhs) noexcept {
         this->typeinfo = rhs.typeinfo;
         return *this;
-    };
+    }
 
     Boxed(TypeInfoBase* ti) noexcept: typeinfo(ti) {};
+};
+
+template <size_t K>
+class TupleEntry {
+public:
+    uintptr_t data[K] = {};
+
+    TupleEntry() noexcept = default;
+    TupleEntry(const TupleEntry& rhs) noexcept {
+        memcpy<K>(this->data, rhs->data);
+    }
+    TupleEntry& operator=(const TupleEntry& rhs) noexcept {
+        memcpy<K>(this->data, rhs->data);
+        
+        return *this;
+    }
+
+    TupleEntry(uintptr_t* d) {
+        memcpy<K>(this->data, d);
+    }
+};
+
+template <>
+class TupleEntry<1> {
+public:
+    uintptr_t data = 0;
+
+    TupleEntry() noexcept = default;
+    TupleEntry(const TupleEntry& rhs) noexcept : data(rhs.data) { }
+    TupleEntry& operator=(const TupleEntry& rhs) noexcept {        
+        data = rhs.data;
+        return *this;
+    }
+
+    TupleEntry(uintptr_t* d) noexcept : data(*d) { }
+};
+
+// Tuple implementation
+template <size_t K1, size_t K2>
+class Tuple2 {
+public:
+    TupleEntry<K1> e1;
+    TupleEntry<K2> e2;
+    
+    Tuple2() noexcept = default;
+    Tuple2(const Tuple2& rhs) noexcept : e1(rhs.e1), e2(rhs.e2) { }
+    Tuple2& operator=(const Tuple2& rhs) noexcept {
+        e1 = rhs.e1;
+        e2 = rhs.e2;
+
+        return *this;
+    }
+
+    Tuple2(uintptr_t* d1, uintptr_t* d2) noexcept : e1(d1), e2(d2) { }
 };
 
 typedef uint64_t None;

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -131,7 +131,6 @@ public:
     TupleEntry(uintptr_t* d) noexcept : data(*d) { }
 };
 
-// Tuple implementation
 template <size_t K1, size_t K2>
 class Tuple2 {
 public:
@@ -147,7 +146,57 @@ public:
         return *this;
     }
 
-    Tuple2(uintptr_t* d1, uintptr_t* d2) noexcept : e1(d1), e2(d2) { }
+    template<typename T1, typename T2>
+    Tuple2(T1 d1, T2 d2) noexcept 
+        : e1(reinterpret_cast<uintptr_t*>(&d1)), e2(reinterpret_cast<uintptr_t*>(&d2)) { }
+};
+
+template <size_t K1, size_t K2, size_t K3>
+class Tuple3 {
+public:
+    TupleEntry<K1> e1;
+    TupleEntry<K2> e2;
+    TupleEntry<K3> e3;
+    
+    Tuple3() noexcept = default;
+    Tuple3(const Tuple3& rhs) noexcept : e1(rhs.e1), e2(rhs.e2), e3(rhs.e3) { }
+    Tuple3& operator=(const Tuple3& rhs) noexcept {
+        e1 = rhs.e1;
+        e2 = rhs.e2;
+        e3 = rhs.e3;
+
+        return *this;
+    }
+
+    template<typename T1, typename T2, typename T3>
+    Tuple3(T1 d1, T2 d2, T3 d3) noexcept 
+        : e1(reinterpret_cast<uintptr_t*>(&d1)), e2(reinterpret_cast<uintptr_t*>(&d2)),
+          e3(reinterpret_cast<uintptr_t*>(&d3)) { }
+};
+
+template <size_t K1, size_t K2, size_t K3, size_t K4>
+class Tuple4 {
+public:
+    TupleEntry<K1> e1;
+    TupleEntry<K2> e2;
+    TupleEntry<K3> e3;
+    TupleEntry<K4> e4;
+    
+    Tuple4() noexcept = default;
+    Tuple4(const Tuple4& rhs) noexcept : e1(rhs.e1), e2(rhs.e2), e3(rhs.e3), e4(rhs.e4) { }
+    Tuple4& operator=(const Tuple4& rhs) noexcept {
+        e1 = rhs.e1;
+        e2 = rhs.e2;
+        e3 = rhs.e3;
+        e4 = rhs.e4;
+
+        return *this;
+    }
+
+    template<typename T1, typename T2, typename T3, typename T4>
+    Tuple4(T1 d1, T2 d2, T3 d3, T4 d4) noexcept 
+        : e1(reinterpret_cast<uintptr_t*>(&d1)), e2(reinterpret_cast<uintptr_t*>(&d2)),
+          e3(reinterpret_cast<uintptr_t*>(&d3)), e4(reinterpret_cast<uintptr_t*>(&d4)) { }
 };
 
 typedef uint64_t None;

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -132,10 +132,6 @@ function emitResolvedTemplates(tk: Option<CPPAssembly::TypeKey>, ik: Option<CPPA
         else String::concat(ns, template);
 }
 
-%%
-%% TODO: Need to always call this if we are emitting a type signature instead of just calling emitTypeKey
-%%
-
 function emitTypeSignature(ts: CPPAssembly::TypeSignature, isParamField: Bool, ctx: Context): String {
     if(ts)@<CPPAssembly::EListTypeSignature> {
         let argssizes = $ts.entries.map<String>(fn(e) => {
@@ -515,7 +511,7 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
 
 function emitConstructorPrimarySpecialSomeExpression(cpsse: CPPAssembly::ConstructorPrimarySpecialSomeExpression, ctx: Context): String {
     let args = cpsse.args.args.map<String>(fn(arg) => emitExpression(arg.exp, ctx) );
-    let sometype = String::concat("Core::", emitTypeKey(cpsse.ctype.tkeystr, false, ctx));
+    let sometype = String::concat("Core::", emitTypeSignature(cpsse.ctype, false, ctx));
 
     return String::concat(sometype, "{ ", String::joinAll(", ", args), "}");
 }
@@ -542,7 +538,7 @@ function emitConstructorPrimarySpecialConstructableExpression(exp: CPPAssembly::
 %%
 function emitConstructorStdExpression(exp: CPPAssembly::ConstructorStdExpression, ctx: Context): String {
     let emitargs = emitArgumentList(exp.args, ctx); 
-    let name = emitTypeKey(exp.ctype.tkeystr, false, ctx);
+    let name = emitTypeSignature(exp.ctype, false, ctx);
     if(ctx.asm.typeinfos.get(exp.ctype.tkeystr).tag === CPPAssembly::Tag#Ref) {
         return String::concat("new ", name, "{ ", emitargs, " }"); %% We use new solely to keep the code compiling before GC integration
     }
@@ -550,6 +546,9 @@ function emitConstructorStdExpression(exp: CPPAssembly::ConstructorStdExpression
 }
 
 function emitConstructorEListExpression(exp: CPPAssembly::ConstructorEListExpression, ctx: Context): String {
+    if(exp.args.args.size() > 4n) {
+        abort; %% Tuples of size > 4 not supported yet
+    }
     let ceetype = emitTypeSignature(exp.etype, false, ctx);
     let args = emitArgumentList(exp.args, ctx);    
 
@@ -570,13 +569,13 @@ function emitIfExpression(exp: CPPAssembly::IfExpression, ctx: Context): String 
 %% We are only widening to options for now
 function emitWidenedTypeExpression(exp: CPPAssembly::CoerceWidenTypeExpression, ctx: Context): String {
     let fromtkey = exp.srctype.tkeystr;
-    let totkey = exp.trgttype.tkeystr;
+    let tottsig = exp.trgttype;
     let emitexp = emitExpression(exp.exp, ctx);
 
     let fromtkey_size = String::fromCString(ctx.asm.typeinfos.tryGet(fromtkey)@some.slotsize.toCString()); %% This is T
-    let name = String::concat("Core::", emitTypeKey(totkey, false, ctx));
+    let name = String::concat("Core::", emitTypeSignature(tottsig, false, ctx));
 
-    let ttype = String::concat(emitTypeKey(exp.srctype.tkeystr, false, ctx), "Type");
+    let ttype = String::concat(emitTypeSignature(exp.srctype, false, ctx), "Type");
 
     if(exp.exp?<CPPAssembly::LiteralNoneExpression>) {
         return String::concat(name, "{ &", removeCppPrefix(ttype) ," }");
@@ -762,7 +761,7 @@ function emitBodyImplementation(body: CPPAssembly::BodyImplementation, ctx: Cont
 
 function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context): String {
     let all_params = params.map<String>(fn(param) => {
-        let ptype = emitTypeKey(param.ptype.tkeystr, true, ctx);
+        let ptype = emitTypeSignature(param.ptype, true, ctx);
         let pident = emitIdentifier(param.pname);
 
         return String::concat(ptype, " ", pident);
@@ -787,7 +786,7 @@ function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::Typ
 
     let name = m.ikey.value.removePrefixString(declaredIn.value).removePrefixString('::');
     let params = emitParameters(m.params, nctx);
-    let rtype = emitTypeKey(m.resultType.tkeystr, false, ctx);
+    let rtype = emitTypeSignature(m.resultType, false, ctx);
     let this_type = emitThisType(declaredIn, nctx);    
     let specialName = emitSpecialTemplate(String::fromCString(name));
     
@@ -829,7 +828,7 @@ function emitFunctionDecl(func: CPPAssembly::AbstractInvokeDecl, ctx: Context, i
 
     let name = emitInvokeKey(ikey, nctx);
     let params = emitParameters(func.params, nctx);
-    let rtype = emitTypeKey(func.resultType.tkeystr, false, ctx); 
+    let rtype = emitTypeSignature(func.resultType, false, ctx); 
 
     let pre: String = String::concat(rtype, " ", name );
     let params_impl: String = String::concat("(", params, ") noexcept ");
@@ -838,7 +837,7 @@ function emitFunctionDecl(func: CPPAssembly::AbstractInvokeDecl, ctx: Context, i
 }
 
 function emitSaturatedFieldInfo(sfi: CPPAssembly::SaturatedFieldInfo, ctx: Context, indent: String): String {
-    let ftype = emitTypeKey(sfi.ftype.tkeystr, true, ctx);
+    let ftype = emitTypeSignature(sfi.ftype, true, ctx);
     let fname = emitIdentifier(sfi.fname);
     return String::concat(indent, ftype, " ", fname, ";%n;");
 }
@@ -893,7 +892,7 @@ function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CP
 
     if(m)@<CPPAssembly::MethodDeclStatic> {
         let pre = m.ikey.value.removePrefixString(declaredIn.value).removePrefixString('::');
-        let rtype = emitTypeKey(m.resultType.tkeystr, false, nctx);
+        let rtype = emitTypeSignature(m.resultType, false, nctx);
         let this_type = emitThisType(declaredIn, nctx);
         let params = emitParameters(m.params, nctx);
 
@@ -919,7 +918,7 @@ function emitFunctionForwardDeclaration(decl: CPPAssembly::AbstractInvokeDecl, c
     let nctx = ctx.updateCurrentNamespace(decl.declaredInNS, ns);
 
     let ikey = emitInvokeKey(decl.ikey, nctx);
-    let rtype = emitTypeKey(decl.resultType.tkeystr, false, nctx); 
+    let rtype = emitTypeSignature(decl.resultType, false, nctx); 
     let params = emitParameters(decl.params, nctx);
 
     let first = String::concat(ident, rtype, " ", ikey);
@@ -1006,7 +1005,7 @@ function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, 
 function emitSomeTypeDecl(std: CPPAssembly::SomeTypeDecl, ctx: Context, indent: String): String {
     let full_indent = String::concat("    ", indent);
     let sometype = emitTypeKey(std.tkey, false, ctx);
-    let ttype = emitTypeKey(std.oftype.tkeystr, true, ctx);
+    let ttype = emitTypeSignature(std.oftype, true, ctx);
 
     let std_tinfo = emitTypeInfo(ctx.asm.typeinfos.get(std.tkey), some(std), ctx, indent);
 
@@ -1030,7 +1029,7 @@ function emitPrimtiveConceptTypeDecl(pc: CPPAssembly::PrimitiveConceptTypeDecl, 
     let full_indent = String::concat("    ", indent);
     let tkey = emitTypeKey(pc.tkey, false, ctx);
     let k = String::fromCString((ctx.asm.typeinfos.get(pc.tkey).slotsize - 1n).toCString()); %% Slot size includes "2" ptr to typeinfo, so we ignore
-    let sometkey = emitTypeKey(pc@<CPPAssembly::OptionTypeDecl>.someType.tkeystr, false, ctx);
+    let sometkey = emitTypeSignature(pc@<CPPAssembly::OptionTypeDecl>.someType, false, ctx);
 
     let pc_tinfo = emitTypeInfo(ctx.asm.typeinfos.get(pc.tkey), some(pc), ctx, indent);
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -35,9 +35,6 @@ entity Context {
     method updateCurrentNamespace(new_ns: CPPAssembly::NamespaceKey, new_nsname: List<CString>): Context {
         return Context{ this.asm, new_ns, new_nsname };
     }
-    method updateInOption(new_inoption: Option<CPPAssembly::TypeSignature>): Context {
-        return Context{ this.asm, this.fullns_key, this.fullns_list };
-    }
 }
 
 function emitEnclosedParen(s: CString): String {
@@ -135,7 +132,28 @@ function emitResolvedTemplates(tk: Option<CPPAssembly::TypeKey>, ik: Option<CPPA
         else String::concat(ns, template);
 }
 
-recursive function emitTypeKey(tk: CPPAssembly::TypeKey, isParamField: Bool, ctx: Context): String {
+%%
+%% TODO: Need to always call this if we are emitting a type signature instead of just calling emitTypeKey
+%%
+
+function emitTypeSignature(ts: CPPAssembly::TypeSignature, isParamField: Bool, ctx: Context): String {
+    if(ts)@<CPPAssembly::EListTypeSignature> {
+        let argssizes = $ts.entries.map<String>(fn(e) => {
+            let tinfo = ctx.asm.typeinfos.get(e.tkeystr);
+            return if(tinfo.tag !== CPPAssembly::Tag#Ref) then String::fromCString(tinfo.slotsize.toCString())
+                else "1";
+        });
+        let argstemplate = String::concat("<", String::joinAll(", ", argssizes), ">");
+        let n = String::fromCString($ts.entries.size().toCString());
+
+        return String::concat("__CoreCpp::Tuple", n, argstemplate);
+    }
+    else {
+        return emitTypeKey(ts.tkeystr, isParamField, ctx);
+    }
+}
+
+function emitTypeKey(tk: CPPAssembly::TypeKey, isParamField: Bool, ctx: Context): String {
     let emit = emitResolvedNamespace(ctx.fullns_list, emitResolvedTemplates(some(tk), none, ctx)); 
 
     if(isParamField) {
@@ -421,6 +439,15 @@ function emitPostfixAccessFromName(op: CPPAssembly::PostfixAccessFromName, ctx: 
     }
 }
 
+%% For now we assume this is only used for accessing elist fields
+function emitPostfixAccessFromIndex(op: CPPAssembly::PostfixAccessFromIndex, acc: String, ctx: Context): String {
+    let accesstype = op.baseType@<CPPAssembly::EListTypeSignature>.entries.get(Nat::fromCString(op.idx));
+    let accessed = emitTypeSignature(accesstype, true, ctx);
+    let idx = String::fromCString(op.idx);
+
+    return String::concat(acc, ".access<", accessed, ", ", idx, ">()");
+}
+
 function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: String, ctx: Context): String {
     %% We don't want to do any resolution of these keys yet
     let ik = String::fromCString(op.resolvedTrgt.value);
@@ -473,10 +500,12 @@ function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSign
 
 function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
     let rootExp = emitExpression(pop.rootExp, ctx);
+    let rootType = emitTypeSignature(pop.rootExp.etype, false, ctx);
 
     return pop.ops.reduce<String>(rootExp, fn(acc, op) => {
         match(op)@ {
             CPPAssembly::PostfixAccessFromName => { return String::concat(acc, emitPostfixAccessFromName($op, ctx)); }
+            | CPPAssembly::PostfixAccessFromIndex => { return emitPostfixAccessFromIndex($op, acc, ctx); }
             | CPPAssembly::PostfixIsTest => { return String::concat(acc, emitITestAsTest($op.ttest, $op.baseType, ctx)); }
             | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, rootExp, ctx); } %% This will not chain method calls :(
             | CPPAssembly::PostfixBoolConstant => { return if($op.value === true) then "true" else "false"; }
@@ -521,17 +550,10 @@ function emitConstructorStdExpression(exp: CPPAssembly::ConstructorStdExpression
 }
 
 function emitConstructorEListExpression(exp: CPPAssembly::ConstructorEListExpression, ctx: Context): String {
-    let ceetype = emitTypeKey(exp.etype.tkeystr, false, ctx);
+    let ceetype = emitTypeSignature(exp.etype, false, ctx);
     let args = emitArgumentList(exp.args, ctx);    
 
-    let argssizes = exp.args.args.map<String>(fn(arg) => String::fromCString(ctx.asm.typeinfos.get(arg.exp.etype.tkeystr).slotsize.toCString()));
-    let argstemplate = String::concat("<", String::joinAll(", ", argssizes), ">");
-    let n = String::fromCString(exp.args.args.size().toCString());
-
-    let cppname = String::concat("__CoreCpp::Tuple", n, argstemplate);
-    let typedef = String::concat("typedef ", cppname, " ", ceetype, "%n;");
-
-    return String::concat(typedef, ceetype, "(", args, ")");
+    return String::concat(ceetype, "(", args, ")");
 }
 
 function emitIfExpression(exp: CPPAssembly::IfExpression, ctx: Context): String {
@@ -602,7 +624,7 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): String {
 
 function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitializationStatement, ctx: Context, indent: String): String {
     let name = emitIdentifier(stmt.name);
-    let stype = emitTypeKey(stmt.vtype.tkeystr, false, ctx);
+    let stype = emitTypeSignature(stmt.vtype, false, ctx);
     let resolved_stype = if(stype.startsWithString("Option") || stype.startsWithString("Some")) then String::concat("Core::", stype) else stype;
     let exp = emitExpression(stmt.exp, ctx);
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -77,9 +77,7 @@ function emitSpecialTemplate(name: String): String {
     let first = base.replaceAllStringOccurrences("<", "ᐸ");
     let second = first.replaceAllStringOccurrences(",", "ᐧ");
     let third = second.replaceAllStringOccurrences(">", "ᐳ");
-    let fourth = third.replaceAllStringOccurrences("(|", "ᗕ");
-    let fifth = fourth.replaceAllStringOccurrences("|)", "ᗒ");
-    let final = fifth.replaceAllStringOccurrences("::", "ᘏ");
+    let final = third.replaceAllStringOccurrences("::", "ᘏ");
 
     return final;
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -80,7 +80,9 @@ function emitSpecialTemplate(name: String): String {
     let first = base.replaceAllStringOccurrences("<", "ᐸ");
     let second = first.replaceAllStringOccurrences(",", "ᐧ");
     let third = second.replaceAllStringOccurrences(">", "ᐳ");
-    let final = third.replaceAllStringOccurrences("::", "ᘏ");
+    let fourth = third.replaceAllStringOccurrences("(|", "ᗕ");
+    let fifth = fourth.replaceAllStringOccurrences("|)", "ᗒ");
+    let final = fifth.replaceAllStringOccurrences("::", "ᘏ");
 
     return final;
 }
@@ -519,13 +521,17 @@ function emitConstructorStdExpression(exp: CPPAssembly::ConstructorStdExpression
 }
 
 function emitConstructorEListExpression(exp: CPPAssembly::ConstructorEListExpression, ctx: Context): String {
-    let emitargs = emitArgumentList(exp.args, ctx);    
+    let ceetype = emitTypeKey(exp.etype.tkeystr, false, ctx);
+    let args = emitArgumentList(exp.args, ctx);    
 
-    %%
-    %% Emit builtin tuple for args.size() <= 4
-    %%
+    let argssizes = exp.args.args.map<String>(fn(arg) => String::fromCString(ctx.asm.typeinfos.get(arg.exp.etype.tkeystr).slotsize.toCString()));
+    let argstemplate = String::concat("<", String::joinAll(", ", argssizes), ">");
+    let n = String::fromCString(exp.args.args.size().toCString());
 
-    return "";
+    let cppname = String::concat("__CoreCpp::Tuple", n, argstemplate);
+    let typedef = String::concat("typedef ", cppname, " ", ceetype, "%n;");
+
+    return String::concat(typedef, ceetype, "(", args, ")");
 }
 
 function emitIfExpression(exp: CPPAssembly::IfExpression, ctx: Context): String {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -95,6 +95,10 @@ function convertCStringList(l: List<CString>): List<String> {
 }
 
 function emitResolvedTemplates(tk: Option<CPPAssembly::TypeKey>, ik: Option<CPPAssembly::InvokeKey>, ctx: Context): String {
+    if(tk?some && tk@some.value.startsWithString('(|')) { %% Handle elists explicitly
+        return emitSpecialTemplate(String::fromCString(tk@some.value));
+    }
+    
     %% Handle Type Funcs explicitly as their InvokeKey is missing the "Core::" prefix
     let isTypeFunc = if(ik)@some then ctx.asm.typefuncs.has($ik) else false;
     
@@ -514,6 +518,16 @@ function emitConstructorStdExpression(exp: CPPAssembly::ConstructorStdExpression
     return String::concat(name, "{ ", emitargs, " }"); 
 }
 
+function emitConstructorEListExpression(exp: CPPAssembly::ConstructorEListExpression, ctx: Context): String {
+    let emitargs = emitArgumentList(exp.args, ctx);    
+
+    %%
+    %% Emit builtin tuple for args.size() <= 4
+    %%
+
+    return "";
+}
+
 function emitIfExpression(exp: CPPAssembly::IfExpression, ctx: Context): String {
     let texp = emitExpression(exp.texp, ctx);
     let thenexp = emitExpression(exp.thenexp, ctx);
@@ -572,6 +586,7 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): String {
         | CPPAssembly::PostfixOp => { return emitPostfixOp($e, ctx); }
         | CPPAssembly::ConstructorPrimarySpecialConstructableExpression => { return emitConstructorPrimarySpecialConstructableExpression($e, ctx); }
         | CPPAssembly::ConstructorStdExpression => { return emitConstructorStdExpression($e, ctx); }
+        | CPPAssembly::ConstructorEListExpression => { return emitConstructorEListExpression($e, ctx); }
         | CPPAssembly::IfExpression => { return emitIfExpression($e, ctx); }
         | CPPAssembly::CoerceWidenTypeExpression => { return emitWidenedTypeExpression($e, ctx); }
         | CPPAssembly::CoerceNarrowTypeExpression => { return emitNarrowedTypeExpression($e, ctx); }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -37,11 +37,6 @@ namespace CPPTransformNameManager {
         }
     }
 
-    function convertTypeSignature(tsig: BSQAssembly::TypeSignature): CPPAssembly::TypeSignature {
-        let tk = convertTypeKey(tsig.tkeystr);
-        return CPPAssembly::NominalTypeSignature{ tk };
-    }
-
     function convertIdentifier(ident: BSQAssembly::Identifier): CPPAssembly::Identifier {
         return CPPAssembly::Identifier::from(ident.value);
     }
@@ -135,6 +130,18 @@ namespace CPPTransformNameManager {
 entity CPPTransformer {
     field bsqasm: BSQAssembly::Assembly;
 
+    recursive method convertTypeSignature(tsig: BSQAssembly::TypeSignature): CPPAssembly::TypeSignature {
+        let tk = CPPTransformNameManager::convertTypeKey(tsig.tkeystr);
+        
+        if(tsig)@<BSQAssembly::EListTypeSignature> {
+            let args = $tsig.entries.map<CPPAssembly::TypeSignature>(fn(ts) => this.convertTypeSignature[recursive](ts));
+            return CPPAssembly::EListTypeSignature{ tk, args };
+        }
+        else {
+            return CPPAssembly::NominalTypeSignature{ tk };
+        }
+    }
+
     recursive method processBinaryArgs(lhs: BSQAssembly::Expression, rhs: BSQAssembly::Expression): CPPAssembly::Expression, CPPAssembly::Expression {
         let cpplhs = this.transformExpressionToCpp[recursive](lhs);
         let cpprhs = this.transformExpressionToCpp[recursive](rhs);
@@ -163,13 +170,13 @@ entity CPPTransformer {
     }
 
     method transformLiteralNoneExpression(expr: BSQAssembly::LiteralNoneExpression): CPPAssembly::LiteralNoneExpression {
-        let etype = CPPTransformNameManager::convertTypeSignature(expr.etype);
+        let etype = this.convertTypeSignature(expr.etype);
         return CPPAssembly::LiteralNoneExpression{ etype };
     }
 
     method transformLiteralSimpleExpression(expr: BSQAssembly::LiteralSimpleExpression): CPPAssembly::LiteralSimpleExpression {
         let val = expr.value;
-        let exprtype = CPPTransformNameManager::convertTypeSignature(expr.etype);
+        let exprtype = this.convertTypeSignature(expr.etype);
 
         %% May be cleaner to handle in cppemit
         if(val.endsWithString('i')) {
@@ -194,8 +201,8 @@ entity CPPTransformer {
 
     method transformAccessVariableExpression(expr: BSQAssembly::AccessVariableExpression): CPPAssembly::AccessVariableExpression {
         let vname = CPPTransformNameManager::convertVarIdentifier(expr.vname);
-        let vtype = CPPTransformNameManager::convertTypeSignature(expr.etype);
-        let layouttype = CPPTransformNameManager::convertTypeSignature(expr.layouttype);
+        let vtype = this.convertTypeSignature(expr.etype);
+        let layouttype = this.convertTypeSignature(expr.layouttype);
 
         return CPPAssembly::AccessVariableExpression { vtype, vname, layouttype };
     }
@@ -223,7 +230,7 @@ entity CPPTransformer {
     recursive method transformBinaryNumericCompareExpression(expr: BSQAssembly::BinaryNumericExpression): CPPAssembly::BinaryNumericExpression {
         let cpplhs, cpprhs = this.processBinaryArgs[recursive](expr.lhs, expr.rhs);
 
-        let cpptype = CPPTransformNameManager::convertTypeSignature(expr.etype);
+        let cpptype = this.convertTypeSignature(expr.etype);
         match(expr)@ {
             BSQAssembly::NumericEqExpression => { return CPPAssembly::NumericEqExpression { cpptype, cpplhs, cpprhs }; }
             | BSQAssembly::NumericNeqExpression => { return CPPAssembly::NumericNeqExpression{ cpptype, cpplhs, cpprhs }; }
@@ -236,7 +243,7 @@ entity CPPTransformer {
 
     recursive method transformBinLogicExpression(expr: BSQAssembly::BinLogicExpression): CPPAssembly::BinLogicExpression {
         let cpplhs, cpprhs = this.processBinaryArgs[recursive](expr.lhs, expr.rhs);
-        let cpptype = CPPTransformNameManager::convertTypeSignature(expr.etype);
+        let cpptype = this.convertTypeSignature(expr.etype);
 
         match(expr)@ {
             BSQAssembly::BinLogicAndExpression => { return CPPAssembly::BinLogicAndExpression{ cpptype, cpplhs, cpprhs }; }
@@ -248,14 +255,14 @@ entity CPPTransformer {
 
     recursive method transformLogicActionAndExpression(expr: BSQAssembly::LogicActionAndExpression): CPPAssembly::LogicActionAndExpression {
         let args = expr.args.map<CPPAssembly::Expression>(fn(e) => this.transformExpressionToCpp(e));
-        let cpptype = CPPTransformNameManager::convertTypeSignature(expr.etype);
+        let cpptype = this.convertTypeSignature(expr.etype);
 
         return CPPAssembly::LogicActionAndExpression{cpptype, args};
     }
 
     recursive method transformLogicActionOrExpression(expr: BSQAssembly::LogicActionOrExpression): CPPAssembly::LogicActionOrExpression {
         let args = expr.args.map<CPPAssembly::Expression>(fn(e) => this.transformExpressionToCpp(e));
-        let cpptype = CPPTransformNameManager::convertTypeSignature(expr.etype);
+        let cpptype = this.convertTypeSignature(expr.etype);
 
         return CPPAssembly::LogicActionOrExpression{cpptype, args};
     }
@@ -277,7 +284,7 @@ entity CPPTransformer {
     }
 
     method transformCallNamespaceFunctionExpression(expr: BSQAssembly::CallNamespaceFunctionExpression): CPPAssembly::CallNamespaceFunctionExpression {
-        let ts = CPPTransformNameManager::convertTypeSignature(expr.etype);
+        let ts = this.convertTypeSignature(expr.etype);
         let ikey = CPPTransformNameManager::convertInvokeKey(expr.ikey);
         let ns = CPPTransformNameManager::convertNamespaceKey(expr.ns);
         let args = this.transformArgumentList(expr.argsinfo.args);
@@ -287,7 +294,7 @@ entity CPPTransformer {
     }
 
     method transformCallTypeFunctionExpression(expr: BSQAssembly::CallTypeFunctionExpression): CPPAssembly::CallTypeFunctionExpression {
-        let ts = CPPTransformNameManager::convertTypeSignature(expr.etype);
+        let ts = this.convertTypeSignature(expr.etype);
         let ikey = CPPTransformNameManager::convertInvokeKey(expr.ikey);
         let ttype = CPPTransformNameManager::convertNominalTypeSignature(expr.ttype);
         let resolvedDeclType = CPPTransformNameManager::convertNominalTypeSignature(expr.resolvedDeclType);
@@ -297,7 +304,7 @@ entity CPPTransformer {
     }
 
     method transformITestType(it: BSQAssembly::ITestType, isnot: Bool): CPPAssembly::ITestType {
-        let ttype = CPPTransformNameManager::convertTypeSignature(it.ttype);
+        let ttype = this.convertTypeSignature(it.ttype);
         return CPPAssembly::ITestType{ isnot, ttype };    
     }
 
@@ -321,17 +328,17 @@ entity CPPTransformer {
     }
 
     method transformPostfixOpImpl(op: BSQAssembly::PostfixOperation): CPPAssembly::PostfixOperation {
-        let baseType = CPPTransformNameManager::convertTypeSignature(op.baseType);
+        let baseType = this.convertTypeSignature(op.baseType);
         match(op)@ {
             BSQAssembly::PostfixAccessFromName => {
                 let name = CPPTransformNameManager::convertIdentifier($op.name);
                 let declaredInType = CPPTransformNameManager::convertNominalTypeSignature($op.declaredInType);
-                let ftype = CPPTransformNameManager::convertTypeSignature($op.ftype);
+                let ftype = this.convertTypeSignature($op.ftype);
 
                 return CPPAssembly::PostfixAccessFromName{ baseType, name, declaredInType, ftype };
             }
             | BSQAssembly::PostfixProjectFromNames => { abort; }
-            | BSQAssembly::PostfixAccessFromIndex => { abort; }
+            | BSQAssembly::PostfixAccessFromIndex => { return CPPAssembly::PostfixAccessFromIndex{ baseType, $op.idx }; }
             | BSQAssembly::PostfixIsTest => { return CPPAssembly::PostfixIsTest{ baseType, this.transformITestAsTest($op.ttest) }; }
             | BSQAssembly::PostfixAsConvert => { abort; }
             | BSQAssembly::PostfixAssignFields => { abort; }
@@ -354,7 +361,7 @@ entity CPPTransformer {
     }
 
     method transformPostfixOp(pop: BSQAssembly::PostfixOp): CPPAssembly::PostfixOp {
-        let etype = CPPTransformNameManager::convertTypeSignature(pop.etype);
+        let etype = this.convertTypeSignature(pop.etype);
         let rootExp = this.transformExpressionToCpp(pop.rootExp);
         let ops = pop.ops.map<CPPAssembly::PostfixOperation>(fn(op) => {
             return this.transformPostfixOpImpl(op);
@@ -364,7 +371,7 @@ entity CPPTransformer {
     }
 
     method transformConstructorExpressionBase(ce: BSQAssembly::ConstructorExpression): (| CPPAssembly::TypeSignature, CPPAssembly::ArgumentList |) {
-        let etype = CPPTransformNameManager::convertTypeSignature(ce.etype);
+        let etype = this.convertTypeSignature(ce.etype);
         let args = this.transformArgumentList(ce.args);
 
         return (| etype, args |);
@@ -380,7 +387,7 @@ entity CPPTransformer {
 
     method transformConstructorPrimarySpecialSomeExpression(cpsse: BSQAssembly::ConstructorPrimarySpecialSomeExpression): CPPAssembly::ConstructorPrimarySpecialSomeExpression {
         let base = this.transformConstructorPrimaryExpressionBase(cpsse@<BSQAssembly::ConstructorPrimaryExpression>);
-        let ofttype = CPPTransformNameManager::convertTypeSignature(cpsse.ofttype);
+        let ofttype = this.convertTypeSignature(cpsse.ofttype);
 
         return CPPAssembly::ConstructorPrimarySpecialSomeExpression{ base.0, base.1, base.2, ofttype };
     }
@@ -408,13 +415,13 @@ entity CPPTransformer {
     } 
 
     method transformConstructorEListExpression(cee: BSQAssembly::ConstructorEListExpression): CPPAssembly::ConstructorEListExpression {
-        let base = this.transformConstructorExpressionBase(cee@<BSQAssembly::ConstructorExpression>);        
+        let base = this.transformConstructorExpressionBase(cee@<BSQAssembly::ConstructorExpression>);
 
         return CPPAssembly::ConstructorEListExpression{ base.0, base.1 };
     }
 
     method transformIfExpression(exp: BSQAssembly::IfExpression): CPPAssembly::IfExpression {
-        let etype = CPPTransformNameManager::convertTypeSignature(exp.etype);
+        let etype = this.convertTypeSignature(exp.etype);
         let texp = this.transformExpressionToCpp(exp.texp);
 
         let thenexp = this.transformExpressionToCpp(exp.thenexp);
@@ -427,7 +434,7 @@ entity CPPTransformer {
     }
 
     method transformCoerceWidenTypeExpression(exp: BSQAssembly::CoerceWidenTypeExpression): CPPAssembly::CoerceWidenTypeExpression {
-        let etype = CPPTransformNameManager::convertTypeSignature(exp.etype);
+        let etype = this.convertTypeSignature(exp.etype);
         let expr = this.transformExpressionToCpp(exp.exp);
         let srctype = CPPTransformNameManager::convertNominalTypeSignature(exp.srctype);
         let trgttype = CPPTransformNameManager::convertNominalTypeSignature(exp.trgttype);
@@ -436,7 +443,7 @@ entity CPPTransformer {
     }
 
     method transformCoerceNarrowTypeExpression(exp: BSQAssembly::CoerceNarrowTypeExpression): CPPAssembly::CoerceNarrowTypeExpression {
-        let etype = CPPTransformNameManager::convertTypeSignature(exp.etype);
+        let etype = this.convertTypeSignature(exp.etype);
         let expr = this.transformExpressionToCpp(exp.exp);
         let srctype = CPPTransformNameManager::convertNominalTypeSignature(exp.srctype);
         let trgttype = CPPTransformNameManager::convertNominalTypeSignature(exp.trgttype);
@@ -445,7 +452,7 @@ entity CPPTransformer {
     }
 
     method transformSafeConvertExpression(exp: BSQAssembly::SafeConvertExpression): CPPAssembly::SafeConvertExpression {
-        let etype = CPPTransformNameManager::convertTypeSignature(exp.etype);
+        let etype = this.convertTypeSignature(exp.etype);
         let expr = this.transformExpressionToCpp(exp.exp);
         let srctype = CPPTransformNameManager::convertNominalTypeSignature(exp.srctype);
         let trgttype = CPPTransformNameManager::convertNominalTypeSignature(exp.trgttype);
@@ -454,7 +461,7 @@ entity CPPTransformer {
     }
 
     method transformCreateDirectExpression(exp: BSQAssembly::CreateDirectExpression): CPPAssembly::CreateDirectExpression {
-        let etype = CPPTransformNameManager::convertTypeSignature(exp.etype);
+        let etype = this.convertTypeSignature(exp.etype);
         let expr = this.transformExpressionToCpp(exp.exp);
         let srctype = CPPTransformNameManager::convertNominalTypeSignature(exp.srctype);
         let trgttype = CPPTransformNameManager::convertNominalTypeSignature(exp.trgttype);
@@ -489,7 +496,7 @@ entity CPPTransformer {
     }
 
     recursive method transformReturnSingleStatementToCpp(ret: BSQAssembly::ReturnSingleStatement): CPPAssembly::ReturnSingleStatement {
-        let rtype = CPPTransformNameManager::convertTypeSignature(ret.rtype); 
+        let rtype = this.convertTypeSignature(ret.rtype); 
         let rexp = this.transformExpressionToCpp[recursive](ret.value);
 
         return CPPAssembly::ReturnSingleStatement{rtype, rexp};
@@ -497,7 +504,7 @@ entity CPPTransformer {
 
     recursive method transformVariableInitializationStatementToCpp(stmt: BSQAssembly::VariableInitializationStatement): CPPAssembly::VariableInitializationStatement {
         let name = CPPTransformNameManager::convertIdentifier(stmt.name);
-        let stype = CPPTransformNameManager::convertTypeSignature(stmt.vtype);
+        let stype = this.convertTypeSignature(stmt.vtype);
         let cppexpr = this.transformExpressionToCpp[recursive](stmt.exp);
 
         return CPPAssembly::VariableInitializationStatement{ name, stype, cppexpr };
@@ -593,7 +600,7 @@ entity CPPTransformer {
         return decl.map<CPPAssembly::ParameterDecl>(fn(pdecl) => {
             return CPPAssembly::ParameterDecl{ 
                 CPPTransformNameManager::convertIdentifier(pdecl.pname), 
-                CPPTransformNameManager::convertTypeSignature(pdecl.ptype),
+                this.convertTypeSignature(pdecl.ptype),
                 this.transformDefaultVal(pdecl.defaultval)
             };
         });
@@ -615,7 +622,7 @@ entity CPPTransformer {
         return
             (|CPPTransformNameManager::convertNamespaceKey(decl.declaredInNS), decl.fullns, decl.name.value, 
             CPPTransformNameManager::convertInvokeKey(decl.ikey), this.transformParameterDecl(decl.params),
-            CPPTransformNameManager::convertTypeSignature(decl.resultType), this.transformBodyToCpp(decl.body)|);
+            this.convertTypeSignature(decl.resultType), this.transformBodyToCpp(decl.body)|);
     }
 
     method transformStaticMethodDecl(m: BSQAssembly::MethodDeclStatic): CPPAssembly::MethodDeclStatic {
@@ -655,7 +662,7 @@ entity CPPTransformer {
             let declaredInNS = CPPTransformNameManager::convertNamespaceKey(m.declaredInNS);
             let name = CPPTransformNameManager::convertIdentifier(f.fname);
             let declaredInType = CPPTransformNameManager::convertNominalTypeSignature(f.declaredInType);
-            let declaredType = CPPTransformNameManager::convertTypeSignature(f.ftype);
+            let declaredType = this.convertTypeSignature(f.ftype);
             var defaultval: Option<CPPAssembly::Expression>;
             if(f.hasdefault && ii < mfields.size()) {
                 let tmp = mfields.get(ii).defaultValue;
@@ -811,7 +818,7 @@ entity CPPTransformer {
 
     method transformSaturatedFieldInfo(sfi: BSQAssembly::SaturatedFieldInfo): CPPAssembly::SaturatedFieldInfo {
         return CPPAssembly::SaturatedFieldInfo { CPPTransformNameManager::convertNominalTypeSignature(sfi.declaredInType), 
-            CPPTransformNameManager::convertIdentifier(sfi.fname), CPPTransformNameManager::convertTypeSignature(sfi.ftype), sfi.hasdefault };
+            CPPTransformNameManager::convertIdentifier(sfi.fname), this.convertTypeSignature(sfi.ftype), sfi.hasdefault };
     }
 
     method transformAbstractNominalTypeDeclBase(ant: BSQAssembly::AbstractNominalTypeDecl): (|CPPAssembly::NamespaceKey, List<CString>, CPPAssembly::TypeKey, 
@@ -860,7 +867,7 @@ entity CPPTransformer {
     method transformSomeTypeDecl(std: BSQAssembly::SomeTypeDecl): CPPAssembly::SomeTypeDecl {
         let base = this.transformAbstractNominalTypeDeclBase(std@<BSQAssembly::AbstractNominalTypeDecl>);
         return CPPAssembly::SomeTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9, 
-            CPPTransformNameManager::convertTypeSignature(std.oftype) }; 
+            this.convertTypeSignature(std.oftype) }; 
     }
 
     method transformMapEntryTypeDecl(metd: BSQAssembly::MapEntryTypeDecl): CPPAssembly::MapEntryTypeDecl {
@@ -884,8 +891,8 @@ entity CPPTransformer {
 
     method transformOptionTypeDecl(opt: BSQAssembly::OptionTypeDecl): CPPAssembly::OptionTypeDecl {
         let base = this.transformAbstractConceptTypeDeclBase(opt@<BSQAssembly::AbstractConceptTypeDecl>);
-        let ttype = CPPTransformNameManager::convertTypeSignature(opt.oftype);
-        let someType = CPPTransformNameManager::convertTypeSignature(opt.someType);
+        let ttype = this.convertTypeSignature(opt.oftype);
+        let someType = this.convertTypeSignature(opt.someType);
 
         return CPPAssembly::OptionTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9, base.10, ttype, someType };
     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -719,6 +719,9 @@ entity CPPTransformer {
         });
     }
 
+    %%
+    %% TODO: will need to explicitly handle the tuple as field case
+    %%
     recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat, bsqasm: BSQAssembly::Assembly): CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> { 
         let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -720,7 +720,7 @@ entity CPPTransformer {
     }
 
     %%
-    %% TODO: will need to explicitly handle the tuple as field case
+    %% TODO: Need to explicitly handle the tuple case
     %%
     recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat, bsqasm: BSQAssembly::Assembly): CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> { 
         let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -363,13 +363,19 @@ entity CPPTransformer {
         return CPPAssembly::PostfixOp{ etype, rootExp, ops };
     }
 
+    method transformConstructorExpressionBase(ce: BSQAssembly::ConstructorExpression): (| CPPAssembly::TypeSignature, CPPAssembly::ArgumentList |) {
+        let etype = CPPTransformNameManager::convertTypeSignature(ce.etype);
+        let args = this.transformArgumentList(ce.args);
+
+        return (| etype, args |);
+    }
+
     method transformConstructorPrimaryExpressionBase(cpe: BSQAssembly::ConstructorPrimaryExpression): (| CPPAssembly::TypeSignature,
         CPPAssembly::ArgumentList, CPPAssembly::NominalTypeSignature |) {
-            let etype = CPPTransformNameManager::convertTypeSignature(cpe.etype);
-            let args = this.transformArgumentList(cpe.args);
+            let base = this.transformConstructorExpressionBase(cpe@<BSQAssembly::ConstructorExpression>);
             let ctype = CPPTransformNameManager::convertNominalTypeSignature(cpe.ctype);
 
-            return (| etype, args, ctype|);
+            return (| base.0, base.1, ctype |);
     }
 
     method transformConstructorPrimarySpecialSomeExpression(cpsse: BSQAssembly::ConstructorPrimarySpecialSomeExpression): CPPAssembly::ConstructorPrimarySpecialSomeExpression {
@@ -400,6 +406,12 @@ entity CPPTransformer {
         let args = this.transformArgumentList(e.args);
         return CPPAssembly::ConstructorStdExpression{ base.0, args, base.2, e.fullns };
     } 
+
+    method transformConstructorEListExpression(cee: BSQAssembly::ConstructorEListExpression): CPPAssembly::ConstructorEListExpression {
+        let base = this.transformConstructorExpressionBase(cee@<BSQAssembly::ConstructorExpression>);        
+
+        return CPPAssembly::ConstructorEListExpression{ base.0, base.1 };
+    }
 
     method transformIfExpression(exp: BSQAssembly::IfExpression): CPPAssembly::IfExpression {
         let etype = CPPTransformNameManager::convertTypeSignature(exp.etype);
@@ -466,6 +478,7 @@ entity CPPTransformer {
             | BSQAssembly::PostfixOp => { return this.transformPostfixOp($expr); }
             | BSQAssembly::ConstructorPrimarySpecialConstructableExpression => { return this.transformConstructorPrimarySpecialConstructableExpression($expr); }
             | BSQAssembly::ConstructorStdExpression => { return this.transformConstructorStdExpression($expr); }
+            | BSQAssembly::ConstructorEListExpression => { return this.transformConstructorEListExpression($expr); }
             | BSQAssembly::IfExpression => { return this.transformIfExpression($expr); }
             | BSQAssembly::CoerceWidenTypeExpression => { return this.transformCoerceWidenTypeExpression($expr); }   
             | BSQAssembly::CoerceNarrowTypeExpression => { return this.transformCoerceNarrowTypeExpression($expr); }

--- a/test/cppoutput/elist/elist_const_access.test.js
+++ b/test/cppoutput/elist/elist_const_access.test.js
@@ -1,0 +1,19 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";
+
+describe ("Exec -- elist decl and access", () => {
+    it("should exec simple elist", function () {
+        runMainCode('public function main(): Int { return (|2i, true|).0; }', "2i"); 
+        runMainCode('public function main(): Bool { return (|2i, true|).1; }', "true"); 
+
+        runMainCode('public function main(): Bool { let x = (|2i, true|); return x.1; }', "true"); 
+    });
+
+/*
+    it("should exec option elist", function () {
+        runMainCode('public function main(): Int { let x: Option<(|Int, Bool|)> = some((|2i, true|)); return x@some.0; }', "2i"); 
+    });
+*/
+});

--- a/test/cppoutput/elist/elist_const_access.test.js
+++ b/test/cppoutput/elist/elist_const_access.test.js
@@ -5,7 +5,7 @@ import { describe, it } from "node:test";
 
 describe ("Exec -- elist decl and access", () => {
     it("should exec simple elist", function () {
-        runMainCode('public function main(): Int { return (|2i, true|).0; }', "2i"); 
+        runMainCode('public function main(): Int { return (|2i, true|).0; }', "2_i"); 
         runMainCode('public function main(): Bool { return (|2i, true|).1; }', "true"); 
 
         runMainCode('public function main(): Bool { let x = (|2i, true|); return x.1; }', "true"); 


### PR DESCRIPTION
Added support for cpp emission of tuples. They have 3 predefined types in `cppruntime.hpp` for cases of sizes 2 -> 4. For now, sizes not in this rage will abort.

Some bosque code like so
```
entity Foo {
    field x: Int;
    field y: Int;
}

entity Bar {
    field foo: Foo;
    field x: Nat;
}

public function main(): Int {
    let x = (| 3i, 2i, Foo{ 1i, 2i}, Bar{ Foo{3i, 4i}, 0n} |);
    let y = (| 2n, 3i |);
    return x.2.y + y.1;
}
```
Will emit in cpp
```
// Primitive typeinfos would be here
//
// Ref and Tagged Type Forward Declarations
//
namespace Main {
    struct Bar;
}
namespace Main {
//
// Value Type Definitions
//
    enum Foo_entries {
        Foo_x,
        Foo_y
    };
    const __CoreCpp::FieldOffsetInfo Foo_vtable[] = {
        { 4, Foo_entries::Foo_x, 0 },
        { 4, Foo_entries::Foo_y, 8 }
    };
    __CoreCpp::TypeInfoBase FooType = {
        .type_id = 5,
        .type_size = 16, 
        .slot_size = 2,
        .ptr_mask = "00",
        .typekey = "Main::Foo",
        .vtable = Foo_vtable
    };
    struct Foo { 
        __CoreCpp::Int x;
        __CoreCpp::Int y;
    };
    //
// Ref and Tagged Type Definitions
//
    enum Bar_entries {
        Bar_foo,
        Bar_x
    };
    const __CoreCpp::FieldOffsetInfo Bar_vtable[] = {
        { 5, Bar_entries::Bar_foo, 0 },
        { 3, Bar_entries::Bar_x, 8 }
    };
    __CoreCpp::TypeInfoBase BarType = {
        .type_id = 6,
        .type_size = 24, 
        .slot_size = 3,
        .ptr_mask = "000",
        .typekey = "Main::Bar",
        .vtable = Bar_vtable
    };
    struct Bar { 
        Foo foo;
        __CoreCpp::Nat x;
    };
    }
//
// Emitted Functions
//
namespace Main {
    __CoreCpp::Int main() noexcept;
    __CoreCpp::Int main() noexcept  {
        __CoreCpp::Tuple4<1, 1, 2, 1> x = __CoreCpp::Tuple4<1, 1, 2, 1>(3_i, 2_i, Foo{ 1_i, 2_i }, new Bar{ Foo{ 3_i, 4_i }, 0_n });
        __CoreCpp::Tuple2<1, 1> y = __CoreCpp::Tuple2<1, 1>(2_n, 3_i);
        return (x.access<Foo, 2>().y + y.access<__CoreCpp::Int, 1>());
    }
}
```