### PR TITLE
Cpp Emit Enum Assert

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -158,6 +158,11 @@ entity AccessVariableExpression provides Expression {
     field layouttype: TypeSignature;
 }
 
+entity AccessEnumExpression provides Expression {
+    field stype: NominalTypeSignature;
+    field name: CString;
+}
+
 entity LiteralNoneExpression provides Expression {
 }
 
@@ -207,6 +212,34 @@ BinAddExpression { }
 | BinSubExpression { }
 | BinDivExpression { }
 | BinMultExpression { }
+;
+
+datatype BinaryKeyEqExpression provides Expression using {
+    field opertype: TypeSignature;
+}
+of
+BinKeyEqNoneExpression { 
+    field exp: Expression;
+}
+| BinKeyNotEqNoneExpression { 
+    field exp: Expression;
+}
+| BinKeySomeEqExpression {
+    field eqoption: Expression;
+    field eqval: Expression;
+}
+| BinKeyNotSomeEqExpression {
+    field neoption: Expression;
+    field neval: Expression;
+}
+| BinKeyEqExpression {
+    field lhs: Expression;
+    field rhs: Expression;
+}
+| BinKeyNotEqExpression {
+    field lhs: Expression;
+    field rhs: Expression;
+}
 ;
 
 datatype BinaryNumericExpression provides Expression using {

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -203,6 +203,10 @@ IfSimpleExpression { }
 }
 ;
 
+entity AssertStatement provides Statement {
+    field cond: Expression;
+}
+
 datatype BinaryArithExpression provides Expression using {
     field lhs: Expression;
     field rhs: Expression;

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -90,6 +90,10 @@ SomeTypeDecl { field oftype: TypeSignature; }
 entity PrimitiveEntityTypeDecl provides AbstractEntityTypeDecl {
 }
 
+entity EnumTypeDecl provides AbstractEntityTypeDecl {
+    field members: List<CString>;
+}
+
 entity DatatypeMemberEntityTypeDecl provides AbstractEntityTypeDecl {
     field fields: List<MemberFieldDecl>;
     field parentTypeDecl: NominalTypeSignature;
@@ -197,6 +201,8 @@ entity NamespaceDecl {
     field absmethods: List<(|InvokeKey, TypeKey|)>;
     field overmethods: List<(|InvokeKey, TypeKey|)>; 
 
+    field enums: List<TypeKey>;
+
     field alltypes: List<TypeKey>; %%Very useful in emission
 }
 
@@ -212,6 +218,8 @@ entity Assembly {
     field virtmethods: Map<InvokeKey, MethodDeclVirtual>;
     field absmethods: Map<InvokeKey, MethodDeclAbstract>;
     field overmethods: Map<InvokeKey, MethodDeclOverride>;
+
+    field enums: Map<TypeKey, EnumTypeDecl>;
 
     field primitives: Map<TypeKey, PrimitiveEntityTypeDecl>;
     field constructables: Map<TypeKey, ConstructableTypeDecl>;
@@ -246,6 +254,9 @@ entity Assembly {
         }
         elif(this.constructables.has(tkey)) {
             return this.constructables.get(tkey);
+        }
+        elif(this.enums.has(tkey)) {
+            return this.enums.get(tkey);
         }
         else {
             abort; %% Non suported typekey!

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -6,6 +6,8 @@
 #include <csetjmp>
 #include <variant> // TODO: Need to remove dependency!
 
+#define 𝐚𝐬𝐬𝐞𝐫𝐭(E) if(!(E)) { std::longjmp(__CoreCpp::info.error_handler, true); }
+
 namespace __CoreCpp {
 
 class ThreadLocalInfo {

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -1,6 +1,7 @@
 int main() {
-    if(setjmp(__CoreCpp::info.error_handler)) {
-        std::cout << "Over/underflow detected!" << std::endl;
+    if(setjmp(__CoreCpp::info.error_handler)) { 
+        // We may want to pass in some source info here and perhaps expression causing failure
+        std::cout << "Assertion failed! Or perhaps over/underflow?" << std::endl;
         return EXIT_FAILURE;
     }
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -553,6 +553,20 @@ function emitConstructorEListExpression(exp: CPPAssembly::ConstructorEListExpres
     return String::concat(ceetype, "(", args, ")");
 }
 
+function emitConstructorPrimaryExpression(exp: CPPAssembly::ConstructorPrimaryExpression, ctx: Context): String {
+    match(exp)@ {
+        CPPAssembly::ConstructorStdExpression => { return emitConstructorStdExpression($exp, ctx); }
+        | CPPAssembly::ConstructorPrimarySpecialConstructableExpression => { return emitConstructorPrimarySpecialConstructableExpression($exp, ctx); }
+    }
+}
+
+function emitConstructorExpression(exp: CPPAssembly::ConstructorExpression, ctx: Context): String {
+    match(exp)@ {
+        CPPAssembly::ConstructorPrimaryExpression => { return emitConstructorPrimaryExpression($exp, ctx); }
+        | CPPAssembly::ConstructorEListExpression => { return emitConstructorEListExpression($exp, ctx); }
+    }
+}
+
 function emitIfExpression(exp: CPPAssembly::IfExpression, ctx: Context): String {
     let texp = emitExpression(exp.texp, ctx);
     let thenexp = emitExpression(exp.thenexp, ctx);
@@ -595,27 +609,83 @@ function emitCreateDirectExpression(exp: CPPAssembly::CreateDirectExpression, ct
    return emitExpression(exp.exp, ctx); 
 }
 
+function emitAccessEnumExpression(exp: CPPAssembly::AccessEnumExpression, ctx: Context): String {
+    let enumtype = emitTypeSignature(exp.etype, false, ctx);
+    let name = String::fromCString(exp.name);
+
+    return String::concat(enumtype, "::", name);
+}
+
+function emitBinKeyEqExpression(exp: CPPAssembly::BinKeyEqExpression, opertype: String, ctx: Context): String {
+    let lhs = emitExpression(exp.lhs, ctx);
+    let rhs = emitExpression(exp.rhs, ctx);
+
+    return String::concat(lhs, " == ", rhs);
+}
+
+function emitBinKeyNotEqExpression(exp: CPPAssembly::BinKeyNotEqExpression, opertype: String, ctx: Context): String {
+    let lhs = emitExpression(exp.lhs, ctx);
+    let rhs = emitExpression(exp.rhs, ctx);
+
+    return String::concat(lhs, " != ", rhs);
+}
+
+function emitBinaryKeyEqExpression(exp: CPPAssembly::BinaryKeyEqExpression, ctx: Context): String {
+    let opertype = emitTypeSignature(exp.opertype, false, ctx);
+    match(exp)@ {
+        CPPAssembly::BinKeyEqNoneExpression => { abort; }
+        | CPPAssembly::BinKeyNotEqNoneExpression => { abort; }
+        | CPPAssembly::BinKeySomeEqExpression => { abort; }
+        | CPPAssembly::BinKeyEqExpression => { return emitBinKeyEqExpression($exp, opertype, ctx); }
+        | CPPAssembly::BinKeyNotEqExpression => { return emitBinKeyNotEqExpression($exp, opertype, ctx); }
+    }
+}
+
 function emitExpression(e: CPPAssembly::Expression, ctx: Context): String {
     match(e)@ {
-        CPPAssembly::BinaryArithExpression => { return emitBinaryArithExpression[recursive]($e, ctx); }
-        | CPPAssembly::BinaryNumericExpression => { return emitBinaryNumericExpression[recursive]($e, ctx); }
-        | CPPAssembly::UnaryExpression => { return emitUnaryExpression[recursive]($e, ctx); }
-        | CPPAssembly::BinLogicExpression => { return emitBinLogicExpression[recursive]($e, ctx); }
-        | CPPAssembly::LogicActionAndExpression => { return emitLogicActionAndExpression[recursive]($e, ctx); }
-        | CPPAssembly::LogicActionOrExpression => { return emitLogicActionOrExpression[recursive]($e, ctx); }
-        | CPPAssembly::LiteralNoneExpression => { return emitLiteralNoneExpression($e, ctx); }
+        CPPAssembly::LiteralNoneExpression => { return emitLiteralNoneExpression($e, ctx); }
         | CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($e); }
+        %%| CPPAssembly::LiteralCCharExpression => { abort; }
+        %%| CPPAssembly::LiteralUnicodeCharExpression => { abort; }
+        %%| CPPAssembly::LiteralCStringExpression => { abort; }
+        %%| CPPAssembly::LiteralStringExpression => { abort; }
+        %%| CPPAssembly::LiteralCRegexExpression => { abort; }
+        %%| CPPAssembly::LiteralRegexExpression => { abort; }
+        %%| CPPAssembly::LiteralTypeDeclValueExpression => { abort; }
+        %%| CPPAssembly::AccessNamespaceConstantExpression => { abort; }
+        %%| CPPAssembly::AccessStaticFieldExpression => { abort; } 
+        | CPPAssembly::AccessEnumExpression => { return emitAccessEnumExpression($e, ctx); }
         | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e); }
+        %%| CPPAssembly::AccessCapturedVariableExpression => { abort; }
+        | CPPAssembly::ConstructorExpression => { return emitConstructorExpression($e, ctx); }
+        | CPPAssembly::ConstructorPrimaryExpression => { return emitConstructorPrimaryExpression($e, ctx); }
+        %%| CPPAssembly::ConstructorPrimaryCollectionSingletonsExpression => { abort; } 
+        %%| CPPAssembly::ConstructorTypeDeclExpression => { abort; }
+        %%| CPPAssembly::ConstructorTypeDeclStringExpression => { abort; } 
+        %%| CPPAssembly::ConstructorLambdaExpression => { abort; }
+        %%| CPPAssembly::LetExpression => { abort; }
+        %%| CPPAssembly::LambdaInvokeExpression => { abort; } 
         | CPPAssembly::CallNamespaceFunctionExpression => { return emitCallNamespaceFunctionExpression($e, ctx); }
-        | CPPAssembly::CallTypeFunctionExpression => { return emitCallTypeFunctionExpression($e, ctx); }
-        | CPPAssembly::PostfixOp => { return emitPostfixOp($e, ctx); }
-        | CPPAssembly::ConstructorPrimarySpecialConstructableExpression => { return emitConstructorPrimarySpecialConstructableExpression($e, ctx); }
-        | CPPAssembly::ConstructorStdExpression => { return emitConstructorStdExpression($e, ctx); }
-        | CPPAssembly::ConstructorEListExpression => { return emitConstructorEListExpression($e, ctx); }
-        | CPPAssembly::IfExpression => { return emitIfExpression($e, ctx); }
+        | CPPAssembly::CallTypeFunctionExpression => { return emitCallTypeFunctionExpression($e, ctx); }      
+        %%| CPPAssembly::CallRefInvokeStaticResolveExpression => { abort; }
+        %%| CPPAssembly::CallRefInvokeVirtualExpression => { abort; } 
+        | CPPAssembly::LogicActionAndExpression => { return emitLogicActionAndExpression[recursive]($e, ctx); }
+        | CPPAssembly::LogicActionOrExpression => { return emitLogicActionOrExpression[recursive]($e, ctx); }       
+        %%| CPPAssembly::TypeDeclPrimitiveFieldAccessExpression => { abort; }
         | CPPAssembly::CoerceWidenTypeExpression => { return emitWidenedTypeExpression($e, ctx); }
         | CPPAssembly::CoerceNarrowTypeExpression => { return emitNarrowedTypeExpression($e, ctx); }
-        | _ => { abort; }
+        | CPPAssembly::SafeConvertExpression => { abort; }
+        | CPPAssembly::CreateDirectExpression => { abort; }
+        | CPPAssembly::PostfixOp => { return emitPostfixOp($e, ctx); }
+        | CPPAssembly::UnaryExpression => { return emitUnaryExpression[recursive]($e, ctx); }
+        | CPPAssembly::BinaryArithExpression => { return emitBinaryArithExpression[recursive]($e, ctx); }
+        | CPPAssembly::BinaryKeyEqExpression => { return emitBinaryKeyEqExpression($e, ctx); }
+        %%| CPPAssembly::BinaryKeyCmpEqualExpression => { abort; }
+        %%| CPPAssembly::BinaryKeyCmpLessExpression => { abort; }
+        | CPPAssembly::BinaryNumericExpression => { return emitBinaryNumericExpression[recursive]($e, ctx); }
+        | CPPAssembly::BinLogicExpression => { return emitBinLogicExpression[recursive]($e, ctx); }
+        %%| CPPAssembly::MapEntryConstructorExpression => { abort; }
+        | CPPAssembly::IfExpression => { return emitIfExpression($e, ctx); }
     }
 }
 
@@ -878,6 +948,18 @@ function emitDatatypeMemberEntityDecl(dm: CPPAssembly::DatatypeMemberEntityTypeD
     return String::concat(fields, indent, "};%n;", dm_methods);
 }
 
+function emitEnumTypeDecl(etd: CPPAssembly::EnumTypeDecl, ctx: Context, indent: String): String {
+    let full_indent = String::concat("    ", indent);
+
+    let etd_tinfo = emitTypeInfo(ctx.asm.typeinfos.get(etd.tkey), some(etd), ctx, indent);
+
+    let base = String::concat(indent, "enum class ", String::fromCString(etd.name), " {%n;");
+    let entries = etd.members.map<String>(fn(e) => String::concat(full_indent, String::fromCString(e)));
+    let wentries = String::concat(base, String::joinAll(",%n;", entries), "%n;", indent, "};%n;");
+
+    return wentries;
+}
+
 function emitAbstractNominalForwardDeclaration(e: CPPAssembly::AbstractNominalTypeDecl, ctx: Context, indent: String): String {
     let nctx = ctx.updateCurrentNamespace(e.declaredInNS, e.fullns);
     let tkey = emitTypeKey(e.tkey, false, nctx);
@@ -991,11 +1073,12 @@ function emitTypeInfo(info: CPPAssembly::TypeInfo, ant: Option<CPPAssembly::Abst
 function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
     %% The entries who need a vtable should manually do it
     match(ant)@ {
-        CPPAssembly::EntityTypeDecl => { return emitEntityTypeDecl(ant@<CPPAssembly::EntityTypeDecl>, declaredIn, ctx, indent); }
-        | CPPAssembly::DatatypeMemberEntityTypeDecl => { return emitDatatypeMemberEntityDecl(ant@<CPPAssembly::DatatypeMemberEntityTypeDecl>, declaredIn, ctx, indent); }
-        | CPPAssembly::PrimitiveConceptTypeDecl => { return emitPrimtiveConceptTypeDecl(ant@<CPPAssembly::PrimitiveConceptTypeDecl>, ctx, indent); }
-        | CPPAssembly::ConstructableTypeDecl => { return emitConstructableTypeDecl(ant@<CPPAssembly::ConstructableTypeDecl>, ctx, indent); }
+        CPPAssembly::EntityTypeDecl => { return emitEntityTypeDecl($ant, declaredIn, ctx, indent); }
+        | CPPAssembly::DatatypeMemberEntityTypeDecl => { return emitDatatypeMemberEntityDecl($ant, declaredIn, ctx, indent); }
+        | CPPAssembly::PrimitiveConceptTypeDecl => { return emitPrimtiveConceptTypeDecl($ant, ctx, indent); }
+        | CPPAssembly::ConstructableTypeDecl => { return emitConstructableTypeDecl($ant, ctx, indent); }
         | CPPAssembly::DatatypeTypeDecl => { return ""; } %% Dont emit anything for datatype - the members contain what we care about
+        | CPPAssembly::EnumTypeDecl => { return emitEnumTypeDecl($ant, ctx, indent); }
         | _ => { abort; }
     }
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -58,7 +58,7 @@ function emitVarIdentifierValue(vi: CPPAssembly::VarIdentifier): String {
 }
 
 function emitSpecialThis(): String {
-    return "tᖺis";
+    return "𝐭𝐡𝐢𝐬";
 }    
 
 function removeCommonPrefix(name: String, prefix: String): String {
@@ -789,18 +789,41 @@ function emitIfElifElseStatement(stmt: CPPAssembly::IfElifElseStatement, ctx: Co
     return String::concat(ifcond, ifbody, elifs, elseblock);
 }
 
+function emitAssertStatement(stmt: CPPAssembly::AssertStatement, ctx: Context, indent: String): String {
+    let cond = emitExpression(stmt.cond, ctx);
+
+    return String::concat(indent, "𝐚𝐬𝐬𝐞𝐫𝐭(", cond, ");");
+} 
+
 function emitStatement(stmt: CPPAssembly::Statement, ctx: Context, indent: String): String {
     match(stmt)@ {
         CPPAssembly::EmptyStatement => { return ""; }
+        %%| CPPAssembly::VariableDeclarationStatement => { abort; }
+        %%| CPPAssembly::VariableMultiDeclarationStatement => { abort; }
         | CPPAssembly::VariableInitializationStatement => { return emitVariableInitializationStatement($stmt, ctx, indent); }
+        %%| CPPAssembly::VariableMultiInitializationExplicitStatement => { abort; }
+        %%| CPPAssembly::VariableMultiInitializationImplicitStatement => { abort; }
+        %%| CPPAssembly::VariableAssignmentStatement => { abort; }
+        %%| CPPAssembly::VariableMultiInitializationExplicitStatement => { abort; }
+        %%| CPPAssembly::VariableMultiAssignmentImplicitStatement => { abort; }
+        %%| CPPAssembly::VariableRetypeStatement => { abort; }
+        %%| CPPAssembly::ReturnVoidStatement => { abort; }
         | CPPAssembly::ReturnSingleStatement => { return emitReturnSingleStatement($stmt, ctx, indent); }
+        %%| CPPAssembly::ReturnMultiStatement => { abort; }
         | CPPAssembly::IfStatement => { return emitIfStatement($stmt, ctx, indent); }
         | CPPAssembly::IfElseStatement => { return emitIfElseStatement($stmt, ctx, indent); }
         | CPPAssembly::IfElifElseStatement => { return emitIfElifElseStatement($stmt, ctx, indent); }
-        | CPPAssembly::EmptyStatement => { return ""; }
+        %%| CPPAssembly::SwitchStatement => { abort; }
+        %%| CPPAssembly::MatchStatement => { abort; }
+        %%| CPPAssembly::AbortStatement => { abort; }
+        | CPPAssembly::AssertStatement => { return emitAssertStatement($stmt, ctx, indent); }
+        %%| CPPAssembly::ValidateStatement => { abort; }
+        %%| CPPAssembly::DebugStatement => { abort; }
+        %%| CPPAssembly::VoidRefCallStatement => { abort; }
+        %%| CPPAssembly::UpdateDirectStatement => { abort; }
+        %%| CPPAssembly::UpdateIndirectStatement => { abort; }
         | CPPAssembly::BlockStatement => { return emitBlockStatement($stmt, ctx, indent); }
-        | _ => { abort; }
-    }
+     }
 }
 
 function emitBuiltinBodyImplementation(body: CPPAssembly::BuiltinBodyImplementation, ctx: Context, indent: String): String {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -790,9 +790,10 @@ function emitIfElifElseStatement(stmt: CPPAssembly::IfElifElseStatement, ctx: Co
 }
 
 function emitAssertStatement(stmt: CPPAssembly::AssertStatement, ctx: Context, indent: String): String {
+    let full_indent = String::concat("    ", indent);
     let cond = emitExpression(stmt.cond, ctx);
 
-    return String::concat(indent, "𝐚𝐬𝐬𝐞𝐫𝐭(", cond, ");");
+    return String::concat(full_indent, "𝐚𝐬𝐬𝐞𝐫𝐭(", cond, ");");
 } 
 
 function emitStatement(stmt: CPPAssembly::Statement, ctx: Context, indent: String): String {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -620,14 +620,14 @@ function emitBinKeyEqExpression(exp: CPPAssembly::BinKeyEqExpression, opertype: 
     let lhs = emitExpression(exp.lhs, ctx);
     let rhs = emitExpression(exp.rhs, ctx);
 
-    return String::concat(lhs, " == ", rhs);
+    return String::concat("(", lhs, " == ", rhs, ")");
 }
 
 function emitBinKeyNotEqExpression(exp: CPPAssembly::BinKeyNotEqExpression, opertype: String, ctx: Context): String {
     let lhs = emitExpression(exp.lhs, ctx);
     let rhs = emitExpression(exp.rhs, ctx);
 
-    return String::concat(lhs, " != ", rhs);
+    return String::concat("(", lhs, " != ", rhs, ")");
 }
 
 function emitBinaryKeyEqExpression(exp: CPPAssembly::BinaryKeyEqExpression, ctx: Context): String {
@@ -980,7 +980,7 @@ function emitEnumTypeDecl(etd: CPPAssembly::EnumTypeDecl, ctx: Context, indent: 
     let entries = etd.members.map<String>(fn(e) => String::concat(full_indent, String::fromCString(e)));
     let wentries = String::concat(base, String::joinAll(",%n;", entries), "%n;", indent, "};%n;");
 
-    return wentries;
+    return String::concat(etd_tinfo, wentries);
 }
 
 function emitAbstractNominalForwardDeclaration(e: CPPAssembly::AbstractNominalTypeDecl, ctx: Context, indent: String): String {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -62,10 +62,11 @@ namespace CPPTransformNameManager {
         let virtmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>{};
         let absmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>{};
         let overmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>{};
+        let enums = List<CPPAssembly::TypeKey>{};
         let alltypes = List<CPPAssembly::TypeKey>{};
 
         return CPPAssembly::NamespaceDecl{ name, subns, nsfuncs, typefuncs, constructables, entities, 
-            datamembers, datatypes, pconcepts, staticmethods, virtmethods, absmethods, overmethods, alltypes };
+            datamembers, datatypes, pconcepts, staticmethods, virtmethods, absmethods, overmethods, enums, alltypes };
     }
 
     %% If ns decl does not exist for name insert, otherwise continue recursing until fullns is empty
@@ -88,7 +89,8 @@ namespace CPPTransformNameManager {
         %% Recursively process remaining names
         let subns = getNamespaceDeclMapping[recursive](remaining_ns_names, cur_nsdecl.subns, insertion);
         let updated_nsdecl = CPPAssembly::NamespaceDecl { ns_name, subns, cur_nsdecl.nsfuncs, cur_nsdecl.typefuncs, cur_nsdecl.constructables, cur_nsdecl.entities, 
-            cur_nsdecl.datamembers, cur_nsdecl.datatypes, cur_nsdecl.pconcepts, cur_nsdecl.staticmethods, cur_nsdecl.virtmethods, cur_nsdecl.absmethods, cur_nsdecl.overmethods, cur_nsdecl.alltypes };
+            cur_nsdecl.datamembers, cur_nsdecl.datatypes, cur_nsdecl.pconcepts, cur_nsdecl.staticmethods, cur_nsdecl.virtmethods, cur_nsdecl.absmethods, 
+            cur_nsdecl.overmethods, cur_nsdecl.enums, cur_nsdecl.alltypes };
 
         if(remaining_ns_names.empty()) { %% Insert at most nested possible depth
             if(!nsdecls.has(ns_name)) {
@@ -469,29 +471,84 @@ entity CPPTransformer {
         return CPPAssembly::CreateDirectExpression{ etype, expr, srctype, trgttype };
     }
 
+    method transformAccessEnumExpression(exp: BSQAssembly::AccessEnumExpression): CPPAssembly::AccessEnumExpression {
+        let etype = this.convertTypeSignature(exp.etype);
+        let stype = CPPTransformNameManager::convertNominalTypeSignature(exp.stype);
+
+        return CPPAssembly::AccessEnumExpression{ etype, stype, exp.name };   
+    }
+
+    method transformBinaryKeyEqExpression(exp: BSQAssembly::BinaryKeyEqExpression): CPPAssembly::BinaryKeyEqExpression {
+        let etype = this.convertTypeSignature(exp.etype);
+        let opertype = this.convertTypeSignature(exp.opertype);
+        
+        match(exp)@ {
+            BSQAssembly::BinKeyEqNoneExpression => { return CPPAssembly::BinKeyEqNoneExpression{ etype, opertype, this.transformExpressionToCpp($exp.exp) }; }
+            | BSQAssembly::BinKeyNotEqNoneExpression => { return CPPAssembly::BinKeyNotEqNoneExpression{ etype, opertype, this.transformExpressionToCpp($exp.exp) }; }
+            | BSQAssembly::BinKeySomeEqExpression => { 
+                return CPPAssembly::BinKeySomeEqExpression{ 
+                    etype, opertype, this.transformExpressionToCpp($exp.eqoption), this.transformExpressionToCpp($exp.eqval) }; }
+            | BSQAssembly::BinKeyNotSomeEqExpression => { 
+                return CPPAssembly::BinKeyNotSomeEqExpression{ 
+                    etype, opertype, this.transformExpressionToCpp($exp.neoption), this.transformExpressionToCpp($exp.neval) }; }
+            | BSQAssembly::BinKeyEqExpression => { 
+                return CPPAssembly::BinKeyEqExpression{ 
+                    etype, opertype, this.transformExpressionToCpp($exp.lhs), this.transformExpressionToCpp($exp.rhs) }; }
+            | BSQAssembly::BinKeyNotEqExpression => { 
+                return CPPAssembly::BinKeyNotEqExpression{ 
+                    etype, opertype, this.transformExpressionToCpp($exp.lhs), this.transformExpressionToCpp($exp.rhs) }; }
+        }
+    }
+
     recursive method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
         match(expr)@ {
-            BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpression[recursive]($expr); }
-            | BSQAssembly::BinaryNumericExpression => { return this.transformBinaryNumericCompareExpression[recursive]($expr); }
-            | BSQAssembly::LiteralNoneExpression => { return this.transformLiteralNoneExpression($expr); }
+            BSQAssembly::LiteralNoneExpression => { return this.transformLiteralNoneExpression($expr); }
             | BSQAssembly::LiteralSimpleExpression => { return this.transformLiteralSimpleExpression($expr); }
-            | BSQAssembly::UnaryExpression => { return this.transformUnaryExpression[recursive]($expr); }
-            | BSQAssembly::BinLogicExpression => { return this.transformBinLogicExpression[recursive]($expr); }
-            | BSQAssembly::LogicActionAndExpression => { return this.transformLogicActionAndExpression[recursive]($expr); }
-            | BSQAssembly::LogicActionOrExpression => { return this.transformLogicActionOrExpression[recursive]($expr); }
+            | BSQAssembly::LiteralCCharExpression => { abort; }
+            | BSQAssembly::LiteralUnicodeCharExpression => { abort; }
+            | BSQAssembly::LiteralCStringExpression => { abort; }
+            | BSQAssembly::LiteralStringExpression => { abort; }
+            | BSQAssembly::LiteralCRegexExpression => { abort; }
+            | BSQAssembly::LiteralRegexExpression => { abort; }
+            | BSQAssembly::LiteralTypeDeclValueExpression => { abort; }
+            | BSQAssembly::AccessNamespaceConstantExpression => { abort; }
+            | BSQAssembly::AccessStaticFieldExpression => { abort; }
+            | BSQAssembly::AccessEnumExpression => { return this.transformAccessEnumExpression($expr); }
             | BSQAssembly::AccessVariableExpression => { return this.transformAccessVariableExpression($expr); }
-            | BSQAssembly::CallNamespaceFunctionExpression => { return this.transformCallNamespaceFunctionExpression($expr); } 
-            | BSQAssembly::CallTypeFunctionExpression => { return this.transformCallTypeFunctionExpression($expr); }
-            | BSQAssembly::PostfixOp => { return this.transformPostfixOp($expr); }
+            | BSQAssembly::AccessCapturedVariableExpression => { abort; }
+            | BSQAssembly::ConstructorExpression => { abort; }
+            | BSQAssembly::ConstructorPrimaryExpression => { abort; }
+            | BSQAssembly::ConstructorPrimaryCollectionSingletonsExpression => { abort; }
             | BSQAssembly::ConstructorPrimarySpecialConstructableExpression => { return this.transformConstructorPrimarySpecialConstructableExpression($expr); }
+            | BSQAssembly::ConstructorTypeDeclExpression => { abort; }
+            | BSQAssembly::ConstructorTypeDeclStringExpression => { abort; }
             | BSQAssembly::ConstructorStdExpression => { return this.transformConstructorStdExpression($expr); }
             | BSQAssembly::ConstructorEListExpression => { return this.transformConstructorEListExpression($expr); }
-            | BSQAssembly::IfExpression => { return this.transformIfExpression($expr); }
+            | BSQAssembly::ConstructorLambdaExpression => { abort; }
+            | BSQAssembly::LetExpression => { abort; }
+            | BSQAssembly::LambdaInvokeExpression => { abort; }
+            | BSQAssembly::CallNamespaceFunctionExpression => { return this.transformCallNamespaceFunctionExpression($expr); } 
+            | BSQAssembly::CallTypeFunctionExpression => { return this.transformCallTypeFunctionExpression($expr); }
+            | BSQAssembly::CallTypeFunctionSpecialExpression => { abort; }
+            | BSQAssembly::CallRefInvokeStaticResolveExpression => { abort; }
+            | BSQAssembly::CallRefInvokeVirtualExpression => { abort; }
+            | BSQAssembly::LogicActionAndExpression => { return this.transformLogicActionAndExpression[recursive]($expr); }
+            | BSQAssembly::LogicActionOrExpression => { return this.transformLogicActionOrExpression[recursive]($expr); }
+            | BSQAssembly::TypeDeclPrimitiveFieldAccessExpression => { abort; }
             | BSQAssembly::CoerceWidenTypeExpression => { return this.transformCoerceWidenTypeExpression($expr); }   
             | BSQAssembly::CoerceNarrowTypeExpression => { return this.transformCoerceNarrowTypeExpression($expr); }
             | BSQAssembly::SafeConvertExpression => { return this.transformSafeConvertExpression($expr); }
             | BSQAssembly::CreateDirectExpression => { return this.transformCreateDirectExpression($expr); }
-            | _ => { abort; }
+            | BSQAssembly::PostfixOp => { return this.transformPostfixOp($expr); }
+            | BSQAssembly::UnaryExpression => { return this.transformUnaryExpression[recursive]($expr); }
+            | BSQAssembly::BinaryArithExpression => { return this.transformBinaryArithExpression[recursive]($expr); }
+            | BSQAssembly::BinaryKeyEqExpression => { return this.transformBinaryKeyEqExpression($expr); }
+            | BSQAssembly::KeyCmpEqualExpression => { abort; }
+            | BSQAssembly::KeyCmpLessExpression => { abort; }
+            | BSQAssembly::BinaryNumericExpression => { return this.transformBinaryNumericCompareExpression[recursive]($expr); }
+            | BSQAssembly::BinLogicExpression => { return this.transformBinLogicExpression[recursive]($expr); }
+            | BSQAssembly::MapEntryConstructorExpression => { abort; }
+            | BSQAssembly::IfExpression => { return this.transformIfExpression($expr); }
         }
     }
 
@@ -777,6 +834,10 @@ entity CPPTransformer {
                 }
                 abort;
             }
+            elif(bsqasm.enums.has(typekey)) { %% For now we will assume our enums cannot exceed 8 bytes 
+                let etdtinfo = CPPAssembly::TypeInfo{ next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value };
+                return (| etdtinfo, tinfos.insert(cpptkey, etdtinfo) |);
+            }
             else {
                 abort; %% TODO: Type not supported for typeinfo emission!
             }
@@ -937,7 +998,7 @@ entity CPPTransformer {
                         let new_nsfuncs = decl.nsfuncs.pushBack(cppfunc.ikey);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, new_nsfuncs, decl.typefuncs, decl.constructables, decl.entities, 
                             decl.datamembers, decl.datatypes, decl.pconcepts, decl.staticmethods, decl.virtmethods, decl.absmethods, decl.overmethods,
-                            decl.alltypes };
+                            decl.enums, decl.alltypes };
                     });
         });
 
@@ -955,7 +1016,7 @@ entity CPPTransformer {
                         let new_typefuncs = decl.typefuncs.pushBack(ikey);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, new_typefuncs, decl.constructables, decl.entities, 
                             decl.datamembers, decl.datatypes, decl.pconcepts, decl.staticmethods, decl.virtmethods, decl.absmethods, decl.overmethods,
-                            decl.alltypes };
+                            decl.enums, decl.alltypes };
                     });
         });
 
@@ -979,7 +1040,7 @@ entity CPPTransformer {
                         let new_alltypes = decl.alltypes.pushBack(cpptk);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, decl.typefuncs, decl.constructables, new_entities,
                             decl.datamembers, decl.datatypes, decl.pconcepts, cppstaticmethods, cppvirtmethods, cppabsmethods, cppovermethods,
-                            new_alltypes };
+                            decl.enums, new_alltypes };
                     });
         });
 
@@ -1002,7 +1063,7 @@ entity CPPTransformer {
                         let new_alltypes = decl.alltypes.pushBack(cpptk);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, decl.typefuncs, decl.constructables, decl.entities,
                             new_datamembers, decl.datatypes, decl.pconcepts, cppstaticmethods, cppvirtmethods, cppabsmethods, cppovermethods,
-                            new_alltypes };
+                            decl.enums, new_alltypes };
                     });                     
             });
 
@@ -1025,7 +1086,7 @@ entity CPPTransformer {
                         let new_alltypes = decl.alltypes.pushBack(cpptk);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, decl.typefuncs, decl.constructables, decl.entities,
                             decl.datamembers, new_datatypes, decl.pconcepts, cppstaticmethods, cppvirtmethods, cppabsmethods, cppovermethods,
-                            new_alltypes };
+                            decl.enums, new_alltypes };
                     });                     
             });
 
@@ -1044,7 +1105,7 @@ entity CPPTransformer {
                         let new_alltypes = decl.alltypes.pushBack(cpptk);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, decl.typefuncs, decl.constructables, decl.entities,
                             decl.datamembers, decl.datatypes, new_pconcepts, decl.staticmethods, decl.virtmethods, decl.absmethods, decl.overmethods,
-                            new_alltypes };
+                            decl.enums, new_alltypes };
                     });                     
             }); 
 
@@ -1062,7 +1123,7 @@ entity CPPTransformer {
                         let new_alltypes = decl.alltypes.pushBack(cpptk);
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, decl.typefuncs, new_constructables, decl.entities,
                             decl.datamembers, decl.datatypes, decl.pconcepts, decl.staticmethods, decl.virtmethods, decl.absmethods, decl.overmethods,
-                            new_alltypes };
+                            decl.enums, new_alltypes };
                     });                     
             }); 
 
@@ -1082,7 +1143,25 @@ entity CPPTransformer {
                 abort; 
             }
         });
-    
+
+        let transformer_enums = bsqasm.enums.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::EnumTypeDecl>>(
+            Map<CPPAssembly::TypeKey, CPPAssembly::EnumTypeDecl>{}, fn(acc, tk, etd) => {
+                let base = transformer.transformAbstractNominalTypeDeclBase(bsqasm.enums.get(tk)@<BSQAssembly::AbstractNominalTypeDecl>);
+                return acc.insert(base.2, CPPAssembly::EnumTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9, etd.members });
+        });
+
+        let transformer_nsdecls_enums = transformer_enums.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
+            transformer_nsdecls_constructables, fn(acc, cpptk, cppetd) => {
+                return CPPTransformNameManager::getNamespaceDeclMapping(cppetd.fullns, acc,
+                    fn(decl) => {
+                        let new_enums = decl.enums.pushBack(cpptk);
+                        let new_alltypes = decl.alltypes.pushBack(cpptk);
+                        return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, decl.typefuncs, decl.constructables, decl.entities,
+                            decl.datamembers, decl.datatypes, decl.pconcepts, decl.staticmethods, decl.virtmethods, decl.absmethods, decl.overmethods,
+                            new_enums, new_alltypes };
+                    });                     
+            }); 
+
         let transformer_primitives = bsqasm.primtives.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveEntityTypeDecl>>(
             Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveEntityTypeDecl>{}, fn(acc, tkey, pe) => {
                 let base = transformer.transformAbstractNominalTypeDeclBase(bsqasm.primtives.get(tkey)@<BSQAssembly::AbstractNominalTypeDecl>);
@@ -1126,7 +1205,7 @@ entity CPPTransformer {
             });
 
         return CPPAssembly::Assembly {
-            nsdecls = transformer_nsdecls_constructables,
+            nsdecls = transformer_nsdecls_enums,
             allfuncs = transformer_allfuncs,
             nsfuncs = transformer_nsfuncs,
             typefuncs = transformer_typefuncs,
@@ -1134,6 +1213,7 @@ entity CPPTransformer {
             virtmethods = transformer_virtmethods,
             absmethods = transformer_absmethods, %% Not fully implemented
             overmethods = transformer_overmethods, %% Not fully implemented
+            enums = transformer_enums,
             primitives = transformer_primitives,
             constructables = transformer_constructables,
             entities = transformer_entities,

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -422,6 +422,20 @@ entity CPPTransformer {
         return CPPAssembly::ConstructorEListExpression{ base.0, base.1 };
     }
 
+    method transformConstructorPrimaryExpression(cpe: BSQAssembly::ConstructorPrimaryExpression): CPPAssembly::ConstructorPrimaryExpression {
+        match(cpe)@ {
+            BSQAssembly::ConstructorStdExpression => { return this.transformConstructorStdExpression($cpe); }
+            | BSQAssembly::ConstructorPrimarySpecialConstructableExpression => { return this.transformConstructorPrimarySpecialConstructableExpression($cpe); }
+        }
+    }
+
+    method transformConstructorExpression(ce: BSQAssembly::ConstructorExpression): CPPAssembly::ConstructorExpression {
+        match(ce)@ {
+            BSQAssembly::ConstructorPrimaryExpression => { return this.transformConstructorPrimaryExpression($ce); }
+            | BSQAssembly::ConstructorEListExpression => { return this.transformConstructorEListExpression($ce); }
+        }
+    }
+
     method transformIfExpression(exp: BSQAssembly::IfExpression): CPPAssembly::IfExpression {
         let etype = this.convertTypeSignature(exp.etype);
         let texp = this.transformExpressionToCpp(exp.texp);
@@ -516,14 +530,11 @@ entity CPPTransformer {
             | BSQAssembly::AccessEnumExpression => { return this.transformAccessEnumExpression($expr); }
             | BSQAssembly::AccessVariableExpression => { return this.transformAccessVariableExpression($expr); }
             | BSQAssembly::AccessCapturedVariableExpression => { abort; }
-            | BSQAssembly::ConstructorExpression => { abort; }
-            | BSQAssembly::ConstructorPrimaryExpression => { abort; }
+            | BSQAssembly::ConstructorExpression => { return this.transformConstructorExpression($expr); }
+            | BSQAssembly::ConstructorPrimaryExpression => { return this.transformConstructorPrimaryExpression($expr); }
             | BSQAssembly::ConstructorPrimaryCollectionSingletonsExpression => { abort; }
-            | BSQAssembly::ConstructorPrimarySpecialConstructableExpression => { return this.transformConstructorPrimarySpecialConstructableExpression($expr); }
             | BSQAssembly::ConstructorTypeDeclExpression => { abort; }
             | BSQAssembly::ConstructorTypeDeclStringExpression => { abort; }
-            | BSQAssembly::ConstructorStdExpression => { return this.transformConstructorStdExpression($expr); }
-            | BSQAssembly::ConstructorEListExpression => { return this.transformConstructorEListExpression($expr); }
             | BSQAssembly::ConstructorLambdaExpression => { abort; }
             | BSQAssembly::LetExpression => { abort; }
             | BSQAssembly::LambdaInvokeExpression => { abort; }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -617,6 +617,12 @@ entity CPPTransformer {
         return CPPAssembly::IfElifElseStatement{ ifcond, ifflow, condflow, elseflow };
     }
 
+    method transformAssertStatement(stmt: BSQAssembly::AssertStatement): CPPAssembly::AssertStatement {
+        let exp = this.transformExpressionToCpp(stmt.cond);
+
+        return CPPAssembly::AssertStatement{ exp };
+    }
+
     method transformStatementToCpp(stmt: BSQAssembly::Statement): CPPAssembly::Statement {
         match(stmt)@ {
             BSQAssembly::EmptyStatement => { return CPPAssembly::EmptyStatement{ }; }
@@ -638,14 +644,13 @@ entity CPPTransformer {
             | BSQAssembly::SwitchStatement => { abort; }
             | BSQAssembly::MatchStatement => { abort; }
             | BSQAssembly::AbortStatement => { abort; }
-            | BSQAssembly::AssertStatement => { abort; } 
+            | BSQAssembly::AssertStatement => { return this.transformAssertStatement($stmt); } 
             | BSQAssembly::ValidateStatement => { abort; }
             | BSQAssembly::DebugStatement => { abort; }
             | BSQAssembly::VoidRefCallStatement => { abort; }
             | BSQAssembly::UpdateDirectStatement => { abort; }
             | BSQAssembly::UpdateIndirectStatement => { abort; }
             | BSQAssembly::BlockStatement => { return this.transformBlockStatement($stmt); }
-            | _ => { abort; }
         }
     }
 

--- a/src/bsqir/asm/body.bsq
+++ b/src/bsqir/asm/body.bsq
@@ -351,7 +351,7 @@ BinAddExpression { }
 | BinDivExpression { }
 ;
 
-datatype BinaryKeyEqExpression provides Expression  using {
+datatype BinaryKeyEqExpression provides Expression using {
     field opertype: TypeSignature;
 }
 of

--- a/test/cppoutput/asserts/assert.test.js
+++ b/test/cppoutput/asserts/assert.test.js
@@ -1,0 +1,39 @@
+"use strict";
+
+import { runMainCode, runMainCodeError } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+/*
+describe ("Exec -- simple abort", () => {
+    it("should exec simple abort", function () {
+        runMainCode("public function main(): Int { if(false) { abort; } return 1i; }", "1i");
+
+        runMainCodeError("public function main(): Int { if(true) { abort; } return 1i; }", "Error -- abort @ test.bsq:3");
+    });
+});
+*/
+
+describe ("Cpp Emit Evaluate -- simple assert", () => {
+    it("should exec simple assert", function () {
+        runMainCode("public function main(): Int { assert true; return 1i; }", "1_i");
+        // runMainCode("public function main(): Int { assert debug false; return 1i; }", "1i");
+    });
+
+    it("should exec error assert", function () {
+        runMainCodeError("public function main(): Int { assert 1i > (1i + 2i); return 1i; }", "Assertion failed! Or perhaps over/underflow?\n");
+        // runMainCodeError("public function main(): Int { assert test false; return 1i; }", "Assertion failed! Or perhaps over/underflow?\n");
+    });
+});
+
+/*
+describe ("Exec -- simple validate", () => {
+    it("should exec simple validate", function () {
+        runMainCode("public function main(): Int { validate true; return 1i; }", "1i");
+    });
+
+    it("should exec error validate", function () {
+        runMainCodeError("public function main(): Int { validate 1i > (1i + 2i) || false; return 1i; }", "Error -- (1i > (1i + 2i)) || false @ test.bsq:3");
+        runMainCodeError("public function main(): Int { validate['ec-0'] false; return 1i; }", "Error -- false['ec-0'] @ test.bsq:3");
+    });
+});
+*/

--- a/test/cppoutput/bin_exps/addition.test.js
+++ b/test/cppoutput/bin_exps/addition.test.js
@@ -12,9 +12,9 @@ describe( "CPP Emit Evaluate --- Simple addition", () => {
         runMainCode("public function main(): Bool { return (1.0f + 1.0f) > 1.0f; }", "true");
     });
     it("should addition error (overflow or undefined behaviour)", function () {
-        runMainCodeError(`public function main(): Nat { return ${bsq_max_nat}n + 1n; }`, "Over/underflow detected!\n");
-        runMainCodeError(`public function main(): Int { return ${bsq_max_int}i + 1i; }`, "Over/underflow detected!\n");
-        runMainCodeError(`public function main(): BigNat { return ${bsq_max_bignat}N + 1N; }`, "Over/underflow detected!\n");
-        runMainCodeError(`public function main(): BigInt { return ${bsq_max_bigint}I + 1I; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): Nat { return ${bsq_max_nat}n + 1n; }`, "Assertion failed! Or perhaps over/underflow?\n");
+        runMainCodeError(`public function main(): Int { return ${bsq_max_int}i + 1i; }`, "Assertion failed! Or perhaps over/underflow?\n");
+        runMainCodeError(`public function main(): BigNat { return ${bsq_max_bignat}N + 1N; }`, "Assertion failed! Or perhaps over/underflow?\n");
+        runMainCodeError(`public function main(): BigInt { return ${bsq_max_bigint}I + 1I; }`, "Assertion failed! Or perhaps over/underflow?\n");
     });
 });

--- a/test/cppoutput/bin_exps/division.test.js
+++ b/test/cppoutput/bin_exps/division.test.js
@@ -12,10 +12,10 @@ describe( "CPP Emit Evaluate --- Simple Division", () => {
         runMainCode("public function main(): Bool { return (2.0f // 1.0f) > 1.0f; }", "true");
     });
     it("should division error (undefined behaviour)", function () {
-        runMainCodeError(`public function main(): Nat { return 2n // 0n; }`, "Over/underflow detected!\n");
-        runMainCodeError(`public function main(): Int { return 2i // 0i; }`, "Over/underflow detected!\n");
-        runMainCodeError(`public function main(): BigNat { return 3N // 0N; }`, "Over/underflow detected!\n");
-        runMainCodeError(`public function main(): BigInt { return 1I // 0I; }`, "Over/underflow detected!\n");
-        runMainCodeError(`public function main(): Float { return 1.0f // 0.0f; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): Nat { return 2n // 0n; }`, "Assertion failed! Or perhaps over/underflow?\n");
+        runMainCodeError(`public function main(): Int { return 2i // 0i; }`, "Assertion failed! Or perhaps over/underflow?\n");
+        runMainCodeError(`public function main(): BigNat { return 3N // 0N; }`, "Assertion failed! Or perhaps over/underflow?\n");
+        runMainCodeError(`public function main(): BigInt { return 1I // 0I; }`, "Assertion failed! Or perhaps over/underflow?\n");
+        runMainCodeError(`public function main(): Float { return 1.0f // 0.0f; }`, "Assertion failed! Or perhaps over/underflow?\n");
     });
 });

--- a/test/cppoutput/bin_exps/multipication.test.js
+++ b/test/cppoutput/bin_exps/multipication.test.js
@@ -13,9 +13,9 @@ describe( "CPP Emit Evaluate --- Simple Multiplication", () => {
         runMainCode("public function main(): Bool { return (2.0f * 2.0f) > 3.0f; }", "true");
     });
     it("should multiplication error (overflow or undefined behaviour)", function () {
-        runMainCodeError(`public function main(): Nat { return ${bsq_max_nat}n + 1n; }`, "Over/underflow detected!\n");
-        runMainCodeError(`public function main(): Int { return ${bsq_max_int}i + 1i; }`, "Over/underflow detected!\n");
-        runMainCodeError(`public function main(): BigNat { return ${bsq_max_bignat}N + 1N; }`, "Over/underflow detected!\n");
-        runMainCodeError(`public function main(): BigInt { return ${bsq_max_bigint}I + 1I; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): Nat { return ${bsq_max_nat}n + 1n; }`, "Assertion failed! Or perhaps over/underflow?\n");
+        runMainCodeError(`public function main(): Int { return ${bsq_max_int}i + 1i; }`, "Assertion failed! Or perhaps over/underflow?\n");
+        runMainCodeError(`public function main(): BigNat { return ${bsq_max_bignat}N + 1N; }`, "Assertion failed! Or perhaps over/underflow?\n");
+        runMainCodeError(`public function main(): BigInt { return ${bsq_max_bigint}I + 1I; }`, "Assertion failed! Or perhaps over/underflow?\n");
     });
 });

--- a/test/cppoutput/bin_exps/subtraction.test.js
+++ b/test/cppoutput/bin_exps/subtraction.test.js
@@ -12,9 +12,9 @@ describe( "CPP Emit Evaluate --- Simple Subtraction", () => {
         runMainCode("public function main(): Bool { return (1.0f - 2.0f) < 0.0f; }", "true");
     });
     it("should subtraction error (underflow or undefined behaviour)", function () {
-        runMainCodeError(`public function main(): Nat { return 1n - 2n; }`, "Over/underflow detected!\n");
-        runMainCodeError(`public function main(): BigNat { return 1N - 2N; }`, "Over/underflow detected!\n");
-        runMainCodeError(`public function main(): Int { return ${bsq_min_int}i - 1i; }`, "Over/underflow detected!\n");
-        runMainCodeError(`public function main(): BigInt { return ${bsq_min_bigint}I - 1I; }`, "Over/underflow detected!\n");
+        runMainCodeError(`public function main(): Nat { return 1n - 2n; }`, "Assertion failed! Or perhaps over/underflow?\n");
+        runMainCodeError(`public function main(): BigNat { return 1N - 2N; }`, "Assertion failed! Or perhaps over/underflow?\n");
+        runMainCodeError(`public function main(): Int { return ${bsq_min_int}i - 1i; }`, "Assertion failed! Or perhaps over/underflow?\n");
+        runMainCodeError(`public function main(): BigInt { return ${bsq_min_bigint}I - 1I; }`, "Assertion failed! Or perhaps over/underflow?\n");
     });
 });

--- a/test/cppoutput/compare_ops/equality.test.js
+++ b/test/cppoutput/compare_ops/equality.test.js
@@ -16,3 +16,13 @@ describe("CPP Emit Evalutate -- basic !equals", () => {
         runMainCode("public function main(): Bool { return +2i != 2i; }", "false");
     })
 });
+
+describe ("CPP Emit Evaluate -- enum strict equals", () => {
+    it("should exec enum strict equals operations", function () {
+        runMainCode("enum Foo { f, g } public function main(): Bool { return Foo#f === Foo#f; }", "true");
+        runMainCode("enum Foo { f, g } public function main(): Bool { return Foo#f !== Foo#f; }", "false");
+
+        runMainCode("enum Foo { f, g } public function main(): Bool { return Foo#f === Foo#g; }", "false");
+        runMainCode("enum Foo { f, g } public function main(): Bool { return Foo#f !== Foo#g; }", "true");
+    });
+});


### PR DESCRIPTION
Added support for emitting `enum` and `assert` in cpp. The `assert` is a simple macro that tests whether our condition is false, if so we call `std::longjmp`.

Some bosque code like so
```
enum Foo { f, g } 

public function main(): Bool { 
    assert(0i > 0i);
    let x = (| 1i, Foo#f |);
    return x.1 === Foo#f; 
}
```
Emits in cpp
```
//
// Ref and Tagged Type Forward Declarations
//
namespace Main {
}
namespace Main {
//
// Value Type Definitions
//
    __CoreCpp::TypeInfoBase FooType = {
        .type_id = 4,
        .type_size = 8, 
        .slot_size = 1,
        .ptr_mask = "0",
        .typekey = "Main::Foo",
        .vtable = nullptr
    };
    enum class Foo {
        f,
        g
    };
//
// Ref and Tagged Type Definitions
//
}
//
// Emitted Functions
//
namespace Main {
    bool main() noexcept;
    bool main() noexcept  {
        𝐚𝐬𝐬𝐞𝐫𝐭((0_i > 0_i));
        __CoreCpp::Tuple2<1, 1> x = __CoreCpp::Tuple2<1, 1>(1_i, Foo::f);
        return (x.access<Foo, 1>() == Foo::f);
    }
}
```