### PR TITLE
Fixes and tests

### DIFF
--- a/src/backend/smtcore/transformer/smttransform.bsq
+++ b/src/backend/smtcore/transformer/smttransform.bsq
@@ -752,20 +752,48 @@ entity SMTTransformer {
         return nctx, this.wrapOperationResult(SMTTransformer::booltype, testop, obinds);
     }
 
-    method transformITestTypeAsSafeConvertOptions(srctype: BSQAssembly::TypeSignature, itest: BSQAssembly::ITestType, onarg: SMTAssembly::SafeExpression): SMTAssembly::SafeExpression, SMTAssembly::SafeExpression {
-        if(!itest.isnot) {
-            let topt: SMTAssembly::SafeExpression = if(this.assembly.isTypeConcrete(itest.ttype)) 
-                then SMTAssembly::UntermifyExpression{ onarg, this.transformStdTypeToSMT(srctype), this.transformStdTypeToSMT(itest.ttype) } 
+    method transformITestTypeAsSafeConvertOptionsStd(srctype: BSQAssembly::TypeSignature, isnot: Bool, ttype: BSQAssembly::TypeSignature, onarg: SMTAssembly::SafeExpression): SMTAssembly::SafeExpression, SMTAssembly::SafeExpression {
+        if(!isnot) {
+            let topt: SMTAssembly::SafeExpression = if(this.assembly.isTypeConcrete(ttype)) 
+                then SMTAssembly::UntermifyExpression{ onarg, this.transformStdTypeToSMT(srctype), this.transformStdTypeToSMT(ttype) } 
                 else onarg
             ;
             return topt, onarg;
         }
         else {
-            let topt: SMTAssembly::SafeExpression = if(this.assembly.isTypeConcrete(itest.ttype)) 
-                then SMTAssembly::UntermifyExpression{ onarg, this.transformStdTypeToSMT(srctype), this.transformStdTypeToSMT(itest.ttype) } 
+            let topt: SMTAssembly::SafeExpression = if(this.assembly.isTypeConcrete(ttype)) 
+                then SMTAssembly::UntermifyExpression{ onarg, this.transformStdTypeToSMT(srctype), this.transformStdTypeToSMT(ttype) } 
                 else onarg
             ;
             return onarg, topt;
+        }
+    }
+
+    method transformITestTypeAsSafeConvertOptionsDatatype2Split(srctype: BSQAssembly::TypeSignature, isnot: Bool, tmatch: BSQAssembly::TypeSignature, mtypes: List<BSQAssembly::NominalTypeSignature>, onarg: SMTAssembly::SafeExpression): SMTAssembly::SafeExpression, SMTAssembly::SafeExpression {
+        let otype = mtypes.find(pred(mtype) => mtype.tkeystr !== tmatch.tkeystr);
+        let topt = SMTAssembly::UntermifyExpression{ onarg, this.transformStdTypeToSMT(srctype), this.transformStdTypeToSMT(tmatch) };
+        let fopt = SMTAssembly::UntermifyExpression{ onarg, this.transformStdTypeToSMT(srctype), this.transformStdTypeToSMT(otype) };
+            
+        if(!isnot) {
+            return topt, fopt;
+        }
+        else {
+            return fopt, topt;
+        }
+    }
+
+    method transformITestTypeAsSafeConvertOptions(srctype: BSQAssembly::TypeSignature, itest: BSQAssembly::ITestType, onarg: SMTAssembly::SafeExpression): SMTAssembly::SafeExpression, SMTAssembly::SafeExpression {
+        if(!this.assembly.datatypes.has(srctype.tkeystr)) {
+            return this.transformITestTypeAsSafeConvertOptionsStd(srctype, itest.isnot, itest.ttype, onarg);
+        }
+        else {
+            let dtdecl = this.assembly.datatypes.get(srctype.tkeystr);
+            if(dtdecl.associatedMemberEntityDecls.size() != 2n || !this.assembly.isTypeConcrete(itest.ttype)) {
+                return this.transformITestTypeAsSafeConvertOptionsStd(srctype, itest.isnot, itest.ttype, onarg);
+            }
+            else {   
+                return this.transformITestTypeAsSafeConvertOptionsDatatype2Split(srctype, itest.isnot, itest.ttype, dtdecl.associatedMemberEntityDecls, onarg);
+            }
         }
     }
 
@@ -906,11 +934,28 @@ entity SMTTransformer {
         }
     }
 
+    method coerceDynamicRcvrExpAsNeeded(bexp: SMTAssembly::SafeExpression, btype: BSQAssembly::TypeSignature, rcvrtype: BSQAssembly::TypeSignature): SMTAssembly::SafeExpression {
+        let isbtypeConcrete = this.assembly.isNominalTypeConcrete(btype.tkeystr);
+        let isrcvrtypeConcrete = this.assembly.isNominalTypeConcrete(rcvrtype.tkeystr);
+        
+        if(isbtypeConcrete === isrcvrtypeConcrete) {
+            return bexp;
+        }
+        else {
+            if(isbtypeConcrete) {
+                return SMTAssembly::TermifyExpression{bexp, this.transformStdTypeToSMT(btype), this.transformStdTypeToSMT(rcvrtype)};
+            }
+            else {
+                return SMTAssembly::UntermifyExpression{bexp, this.transformStdTypeToSMT(btype), this.transformStdTypeToSMT(rcvrtype)};
+            }
+        }
+    }
+
     recursive method processPostfixInvokeStatic(op: BSQAssembly::PostfixInvokeStatic, ctx: SMTTransformerCtx, bexp: SMTExpTransformResult): SMTTransformerCtx, SMTExpTransformResult {
         let onarg, nctx, obinds = this.unpackSingleResultErrors(bexp, ctx);
         let scargs, scnctx, scobinds = this.processArgsInOrder[recursive](op.argsinfo.resolvedargs@some, nctx);
         
-        let aargs = scargs.pushFront(onarg);
+        let aargs = scargs.pushFront(this.coerceDynamicRcvrExpAsNeeded(onarg, op.baseType, op.resolvedType));
         var allobinds: Option<List<(|SMTAssembly::Expression, SMTAssembly::TypeKey, SMTAssembly::Identifier|)>>;
         if(obinds)@some {
             if(scobinds)@some {

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -376,8 +376,8 @@ entity ExplicitifyTransform {
     }
 
     recursive method processPostfixInvokeStatic(op: PostfixInvokeStatic, vmap: VarMapping): PostfixInvokeStatic {
-        let params = this.assembly.staticmethods.get(op.resolvedTrgt).params;
-        let nargs = this.processInvokeArgumentInfoStatic[recursive](op.sinfo, params, op.argsinfo, vmap);
+        let smdecl = this.assembly.staticmethods.get(op.resolvedTrgt);
+        let nargs = this.processInvokeArgumentInfoStatic[recursive](op.sinfo, smdecl.params, op.argsinfo, vmap);
 
         return op[argsinfo=nargs];
     }

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -85,12 +85,37 @@ entity ExplicitifyTransform {
         return this.processCoerceTypeAsNeeded(nexp, vtype);
     }
 
+    method processFieldDefaultValue(tsig: TypeSignature, name: Identifier): Expression {
+        var ff: MemberFieldDecl;
+        if(this.assembly.entities.has(tsig.tkeystr)) {
+            ff = this.assembly.entities.get(tsig.tkeystr).fields.find(pred(f) => f.name === name);
+        }
+        elif(this.assembly.concepts.has(tsig.tkeystr)) {
+            ff = this.assembly.concepts.get(tsig.tkeystr).fields.find(pred(f) => f.name === name);
+        }
+        elif(this.assembly.datamembers.has(tsig.tkeystr)) {
+            ff = this.assembly.datamembers.get(tsig.tkeystr).fields.find(pred(f) => f.name === name);
+        }
+        else {
+            ff = this.assembly.datatypes.get(tsig.tkeystr).fields.find(pred(f) => f.name === name);
+        }
+
+        let cv = this.assembly.tryResolveExpAsLiteralExpression(ff.defaultValue@some);
+        if(cv)@some {
+            return $cv;
+        }
+        else {
+            abort; %% Not implemented -- put in default value expression for the field
+        }
+    }
+
     recursive method processStdConstructorArgs(sinfo: SourceInfo, finfos: List<SaturatedFieldInfo>, ainfo: ConstructorArgumentInfo, vmap: VarMapping): ConstructorArgumentInfo {
         let resolvedargs = ainfo.shuffleinfo.mapIdx[recursive]<Expression>(fn(si, i) => {
             let fi = finfos.get(i);
 
             if($argidx = si.0)@none {
-                abort; %% Do static resolution or put in "default value expression" for the field
+                let resinfo = si.1@some;
+                return this.processFieldDefaultValue(resinfo.0, resinfo.1);
             }
             else {
                 let eexp = ainfo.srcargs.get($argidx).exp;

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -547,7 +547,7 @@ class BSQIREmitter {
         if(cdecl instanceof SomeTypeDecl) {
             const oftype = this.emitTypeSignature(exp.ctype.alltermargs[0]);
 
-            return `BSQAssembly::ConstructorPrimarySomeExpression{ ${cbase}, value=${vexp}, oftype=${oftype} }`;
+            return `BSQAssembly::ConstructorPrimarySpecialSomeExpression{ ${cbase}, value=${vexp}, ofttype=${oftype} }`;
         }
         else {
             assert(false, "Not implemented -- SpecialConstructableConstructor");

--- a/test/smtoutput/cons_exps/cons_cons.test.js
+++ b/test/smtoutput/cons_exps/cons_cons.test.js
@@ -2,13 +2,13 @@
 
 import { runishMainCodeUnsat } from "../../../bin/test/smtoutput/smtemit_nf.js";
 import { describe, it } from "node:test";
-/*
+
 describe ("SMT -- Constructable Constructor (Option)", () => {
     it("should smt exec option constructors", function () {
-        runishMainCodeUnsat("public function main(): Int { return Some<Int>{2i}.value; }", "2i");
+        runishMainCodeUnsat("public function main(): Int { return Some<Int>{2i}.value; }", "(assert (not (= 2 Main@main)))");
     });
 });
-*/
+
 /*
 describe ("Exec -- Constructable Constructor (Result)", () => {
     it("should exec result constructors", function () {

--- a/test/smtoutput/cons_exps/cons_entity.test.js
+++ b/test/smtoutput/cons_exps/cons_entity.test.js
@@ -33,5 +33,12 @@ describe ("SMT evaluate -- Entity w/ Invariant Constructor", () => {
     it("should smt exec find error", function () {
         runishMainCodeSat('entity Foo { field x: Int; field y: Int; invariant $x >= $y; } public function main(k: Int): Int { let f = Foo{k, 3i}; return f.x + f.y; }', "(declare-const a Int) (assert (not (is-@Result-err (Main@main a))))");
     });
+
+    it("should exec default", function () {
+        runishMainCodeUnsat('entity Foo { field f: Int = 0i; invariant $f != 3i; } public function main(): Int { return Foo{5i}.f; }', "(assert (not (= (@Result-ok 5) Main@main)))");
+        runishMainCodeUnsat('entity Foo { field f: Int = 0i; invariant $f != 3i; } public function main(): Int { return Foo{}.f; }', "(assert (not (= (@Result-ok 0) Main@main)))");
+
+        runishMainCodeUnsat('entity Foo { field f: Int = 0i; invariant $f != 3i; } public function main(): Int { return Foo{3i}.f; }', "(assert (not (is-@Result-err Main@main)))");
+    });
 });
 

--- a/test/smtoutput/cons_exps/cons_entity.test.js
+++ b/test/smtoutput/cons_exps/cons_entity.test.js
@@ -9,6 +9,17 @@ describe ("SMT evaluate -- Entity Constructor", () => {
         runishMainCodeUnsat('entity Foo { field f: Int; field g: Bool; } public function main(k: Int): Bool { return Foo{k, true}.g; }', "(assert (not (Main@main 3)))");
         runishMainCodeUnsat('entity Foo { field f: Int; field g: Bool; } public function main(k: Int): Int { return Foo{k, true}.f; }', "(assert (not (= (Main@main 3) 3)))");
     });
+
+    it("should smt exec nominal", function () {
+        runishMainCodeUnsat('entity Foo { field f: Int; } public function main(): Int { return Foo{f = 1i}.f; }', "(assert (not (= 1 Main@main)))");
+        runishMainCodeUnsat('entity Foo { field f: Int; field g: Bool; } public function main(): Bool { return Foo{1i, g = true}.g; }', "(assert (not Main@main))");
+        runishMainCodeUnsat('entity Foo { field f: Int; field g: Bool; } public function main(): Bool { return Foo{f=1i, g = true}.g; }', "(assert (not Main@main))");
+    });
+
+    it("should smt exec default", function () {
+        runishMainCodeUnsat('entity Foo { field f: Int = 0i; } public function main(): Int { return Foo{}.f; }', "(assert (not (= Main@main 0)))");
+        runishMainCodeUnsat('entity Foo { field f: Int = 0i; } public function main(): Int { return Foo{5i}.f; }', "(assert (not (= Main@main 5)))");
+    });
 });
 
 describe ("SMT evaluate -- Entity w/ Invariant Constructor", () => {

--- a/test/smtoutput/fcall_exps/ns_fcalls.test.js
+++ b/test/smtoutput/fcall_exps/ns_fcalls.test.js
@@ -15,6 +15,28 @@ describe ("SMT Exec -- NamespaceFunction", () => {
         runishMainCodeUnsat("function bar(x: Int): Int { return x + 1i; } public function main(): Int { let v: Option<Int> = none; return bar(v@some); }", "(assert (not (is-@Result-err Main@main)))");
     });
 
+    it("should smt exec simple named", function () {
+        runishMainCodeUnsat("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(x=1i, y=true); }", "(assert (not (= 1 Main@main)))");
+        runishMainCodeUnsat("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(y=true, x=1i); }", "(assert (not (= 1 Main@main)))");
+    });
+
+    it("should smt exec simple mixed", function () {
+        runishMainCodeUnsat("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(1i, y=true); }", "(assert (not (= 1 Main@main)))");
+        runishMainCodeUnsat("function foo(x: Int, y: Bool): Int { return x; } public function main(): Int { return foo(y=true, x=1i); }", "(assert (not (= 1 Main@main)))");
+    });
+
+    it("should smt exec simple default", function () {
+        runishMainCodeUnsat("function foo(x: Int, y: Int = 1i): Int { return x + y; } public function main(): Int { return foo(1i, 2i); }", "(assert (not (= 3 Main@main)))");
+        runishMainCodeUnsat("function foo(x: Int, y: Int = 1i): Int { return x + y; } public function main(): Int { return foo(1i); }", "(assert (not (= 2 Main@main)))");
+    });
+
+    /*
+    it("should smt exec dep default", function () {
+        runMainCode("function foo(x: Int, y: Int = $x): Int { return x + y; } public function main(): Int { return foo(1i, 2i); }", "3i");
+        runMainCode("function foo(x: Int, y: Int = $x): Int { return x + y; } public function main(): Int { return foo(1i); }", "2i");
+    });
+    */
+
     it("should smt exec templates", function () {
         runishMainCodeUnsat("function identity<T>(x: T): T { return x; } public function main(v: Bool): Int { return if(identity<Bool>(v)) then identity<Int>(0i) else 1i; }", "(assert (not (= 0 (Main@main true))))");
     });

--- a/test/smtoutput/mcall_exps/simple_resolved.test.js
+++ b/test/smtoutput/mcall_exps/simple_resolved.test.js
@@ -3,7 +3,7 @@
 import { runishMainCodeUnsat } from "../../../bin/test/smtoutput/smtemit_nf.js";
 import { describe, it } from "node:test";
 
-describe ("SMT Exec -- entity methods", () => {
+describe ("SMT -- entity methods", () => {
     it("should smt exec simple entity methods", function () {
         runishMainCodeUnsat('entity Foo { field f: Int; method foo(): Int { return this.f; }} public function main(): Int { return Foo{3i}.foo(); }', "(assert (not (= 3 Main@main)))"); 
         runishMainCodeUnsat('entity Foo { field f: Int; method foo(): Int { return this.f; }} public function main(): Int { let x = Foo{3i}; return x.foo(); }', "(assert (not (= 3 Main@main)))"); 
@@ -35,46 +35,45 @@ describe ("SMT Exec -- entity methods", () => {
     });
 });
 
-describe ("SMT Exec -- entity methods (Pre/Post)", () => {
+describe ("SMT -- entity methods (Pre/Post)", () => {
     it("should smt exec simple entity methods", function () {
         runishMainCodeUnsat('entity Foo { field f: Int; method foo(): Int requires this.f != 0i; { return this.f; }} public function main(a: Int): Int { return Foo{a}.foo(); }', "(assert (not (= (@Result-ok 3) (Main@main 3))))"); 
         runishMainCodeUnsat('entity Foo { field f: Int; method foo(): Int requires this.f != 0i; { return this.f; }} public function main(a: Int): Int { return Foo{a}.foo(); }', "(assert (not (is-@Result-err (Main@main 0))))"); 
     });
 });
 
-/*
-describe ("Exec -- eADT methods", () => {
-    it("should exec simple eADT methods", function () {
-        runMainCode('datatype Foo of Foo1 { field f: Int; method foo(): Int { return this.f; }} ; public function main(): Int { return Foo1{3i}.foo(); }', "3i"); 
-        runMainCode('datatype Foo of Foo1 { field f: Int; method foo(x: Int): Int { return this.f + x; }} ; public function main(): Int { return Foo1{3i}.foo(1i); }', "4i"); 
+describe ("SMT -- eADT methods", () => {
+    it("should smt exec simple eADT methods", function () {
+        runishMainCodeUnsat('datatype Foo of Foo1 { field f: Int; method foo(): Int { return this.f; }} ; public function main(): Int { return Foo1{3i}.foo(); }', "(assert (not (= 3 Main@main)))"); 
+        runishMainCodeUnsat('datatype Foo of Foo1 { field f: Int; method foo(x: Int): Int { return this.f + x; }} ; public function main(): Int { return Foo1{3i}.foo(1i); }', "(assert (not (= 4 Main@main)))");
     });
 
-    it("should exec simple eADT methods with template", function () {
-        runMainCode('datatype Foo of Foo1 { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} ; public function main(): Bool { let x = Foo1{3i}; return x.foo<Nat>(); }', "false"); 
-        runMainCode('datatype Foo of Foo1 { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} ; public function main(): Bool { let x = Foo1{3i}; return x.foo<Int>(); }', "true"); 
+    it("should smt exec simple eADT methods with template", function () {
+        runishMainCodeUnsat('datatype Foo of Foo1 { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} ; public function main(): Bool { let x = Foo1{3i}; return x.foo<Nat>(); }', "(assert Main@main)");
+        runishMainCodeUnsat('datatype Foo of Foo1 { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} ; public function main(): Bool { let x = Foo1{3i}; return x.foo<Int>(); }', "(assert (not Main@main))");
     });
 
-    it("should exec simple eADT methods with type template", function () {
-        runMainCode('datatype Foo<T> of Foo1 { field f: T; method foo(x: T): T { return if (true) then x else this.f; }} ; public function main(): Int { let x = Foo1<Int>{3i}; return x.foo(2i); }', "2i"); 
+    it("should smt exec simple eADT methods with type template", function () {
+        runishMainCodeUnsat('datatype Foo<T> of Foo1 { field f: T; method foo(x: T): T { return if (true) then x else this.f; }} ; public function main(): Int { let x = Foo1<Int>{3i}; return x.foo(2i); }', "(assert (not (= 2 Main@main)))");
     });
 
-    it("should exec simple ROOT eADT methods", function () {
-        runMainCode('datatype Foo of F1 { } | F2 { } & { method foo(): Int { return if(this)<F1> then 1i else 0i; } } public function main(): Int { return F1{}.foo(); }', "1i"); 
+    it("should smt exec simple ROOT eADT methods", function () {
+        runishMainCodeUnsat('datatype Foo of F1 { } | F2 { } & { method foo(): Int { return if(this)<F1> then 1i else 0i; } } public function main(): Int { return F1{}.foo(); }', "(assert (not (= 1 Main@main)))"); 
 
-        runMainCode('datatype Foo of F1 { f: Int } | F2 { g: Int } & { method foo(): Int { if(this)@<F1> { return $this.f; } else { return $this.g; } } } public function main(): Int { return F1{3i}.foo(); }', "3i"); 
+        runishMainCodeUnsat('datatype Foo of F1 { f: Int } | F2 { g: Int } & { method foo(): Int { if(this)@<F1> { return $this.f; } else { return $this.g; } } } public function main(): Int { return F1{3i}.foo(); }', "(assert (not (= 3 Main@main)))"); 
 
-        runMainCode('datatype Foo of F1 { f: Int } | F2 { g: Int } & { method foo(): Int { if(this)@<F1> { return $this.f; } else { return $this.g + 1i; } } } public function main(): Int { let x: Foo = F1{3i}; return x.foo(); }', "3i"); 
-        runMainCode('datatype Foo of F1 { f: Int } | F2 { g: Int } & { method foo(): Int { if(this)@<F1> { return $this.f; } else { return $this.g + 1i; } } } public function main(): Int { let x: Foo = F2{3i}; return x.foo(); }', "4i"); 
+        runishMainCodeUnsat('datatype Foo of F1 { f: Int } | F2 { g: Int } & { method foo(): Int { if(this)@<F1> { return $this.f; } else { return $this.g + 1i; } } } public function main(): Int { let x: Foo = F1{3i}; return x.foo(); }', "(assert (not (= 3 Main@main)))"); 
+        runishMainCodeUnsat('datatype Foo of F1 { f: Int } | F2 { g: Int } & { method foo(): Int { if(this)@<F1> { return $this.f; } else { return $this.g + 1i; } } } public function main(): Int { let x: Foo = F2{3i}; return x.foo(); }', "(assert (not (= 4 Main@main)))"); 
     });
 
-    it("should exec template ROOT eADT methods", function () {
-        runMainCode('datatype Foo<T> of F1 { } | F2 { } & { method foo(): Int { return if(this)<F1<T>> then 1i else 0i; } } public function main(): Int { return F1<Bool>{}.foo(); }', "1i"); 
+    it("should smt exec template ROOT eADT methods", function () {
+        runishMainCodeUnsat('datatype Foo<T> of F1 { } | F2 { } & { method foo(): Int { return if(this)<F1<T>> then 1i else 0i; } } public function main(): Int { return F1<Bool>{}.foo(); }', "(assert (not (= 1 Main@main)))"); 
 
-        runMainCode('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { return F1<Int>{3i}.foo(); }', "3i"); 
-        runMainCode('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { let x: Foo<Int> = F1<Int>{3i}; return x.foo(); }', "3i"); 
+        runishMainCodeUnsat('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { return F1<Int>{3i}.foo(); }', "(assert (not (= 3 Main@main)))"); 
+        runishMainCodeUnsat('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { let x: Foo<Int> = F1<Int>{3i}; return x.foo(); }', "(assert (not (= 3 Main@main)))"); 
     });
 });
-*/
+
 describe ("SMT -- type alias methods", () => {
     it("should smt exec simple type alias methods", function () {
         runishMainCodeUnsat('type Foo = Int & { method foo(): Int { return this.value; }} public function main(): Int { return 3i<Foo>.foo(); }', "(assert (not (= 3 Main@main)))"); 

--- a/test/smtoutput/mcall_exps/simple_resolved.test.js
+++ b/test/smtoutput/mcall_exps/simple_resolved.test.js
@@ -28,6 +28,13 @@ describe ("SMT Exec -- entity methods", () => {
         runishMainCodeUnsat('entity Foo { field x: Int; method m(y: Int): Int { return this.x + y; } } public function main(): Int { let foo: Option<Foo> = none; return foo@some.m(2i); }', "(assert (not (is-@Result-err Main@main)))");
         runishMainCodeUnsat('entity Foo { field x: Int; method m(y: Int): Int { return this.x + y; } } public function main(): Int { let foo: Option<Foo> = some(Foo{ 3i }); return foo@some.m(2i); }', "(assert (not (= (@Result-ok 5) Main@main)))");
     });
+
+    /*
+    it("should exec simple entity methods with both template and more", function () {
+        runMainCode('entity Foo<T> { field f: T; method foo<U>(u: U): U { return if (this.f)@<U> then $_ else u; }} public function main(): Nat { let x = Foo<Int>{3i}; return x.foo<Nat>(3n); }', "3n"); 
+        runMainCode('entity Foo<T> { field f: T; method foo<U>(t: T): T { return if (t)<U> then t else this.f; }} public function main(): Int { let x = Foo<Int>{3i}; return x.foo<Int>(3i); }', "3i"); 
+    });
+    */
 });
 
 describe ("SMT Exec -- entity methods (Pre/Post)", () => {

--- a/test/smtoutput/mcall_exps/simple_resolved.test.js
+++ b/test/smtoutput/mcall_exps/simple_resolved.test.js
@@ -29,12 +29,10 @@ describe ("SMT Exec -- entity methods", () => {
         runishMainCodeUnsat('entity Foo { field x: Int; method m(y: Int): Int { return this.x + y; } } public function main(): Int { let foo: Option<Foo> = some(Foo{ 3i }); return foo@some.m(2i); }', "(assert (not (= (@Result-ok 5) Main@main)))");
     });
 
-    /*
-    it("should exec simple entity methods with both template and more", function () {
-        runMainCode('entity Foo<T> { field f: T; method foo<U>(u: U): U { return if (this.f)@<U> then $_ else u; }} public function main(): Nat { let x = Foo<Int>{3i}; return x.foo<Nat>(3n); }', "3n"); 
-        runMainCode('entity Foo<T> { field f: T; method foo<U>(t: T): T { return if (t)<U> then t else this.f; }} public function main(): Int { let x = Foo<Int>{3i}; return x.foo<Int>(3i); }', "3i"); 
+    it("should smt exec simple entity methods with both template and more", function () {
+        runishMainCodeUnsat('entity Foo<T> { field f: T; method foo<U>(u: U): U { return if (this.f)@<U> then $_ else u; }} public function main(): Nat { let x = Foo<Int>{3i}; return x.foo<Nat>(3n); }', "(assert (not (= 3 Main@main)))"); 
+        runishMainCodeUnsat('entity Foo<T> { field f: T; method foo<U>(t: T): T { return if (t)<U> then t else this.f; }} public function main(): Int { let x = Foo<Int>{3i}; return x.foo<Int>(3i); }', "(assert (not (= 3 Main@main)))");
     });
-    */
 });
 
 describe ("SMT Exec -- entity methods (Pre/Post)", () => {


### PR DESCRIPTION
Notable:
1. Fix for invoke rcvr -- make sure when calling an method defined on GeneralType (e.g. concept) the rcvr argument is boxed.
2. Fix on binder ifs with datatype -- in special case where there are 2 possibilities then make sure the else case refines down as well as the if case -- e.g. `datatype Foo of F1 {} | F2 {}; ... let x: Foo = ...; if(x)@<F1> then /*$x is F1*/ else /*$x is F2*/; `