### PR TITLE
Cpp Emit Binding ITests Progress

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -326,6 +326,8 @@ PostfixAccessFromName {
 | PostfixBoolConstant {
     field value: Bool;
 }
+| PostfixAccessSomeValue {
+}
 ;
 
 entity PostfixOp provides Expression {

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -26,12 +26,12 @@ concept Statement {
 entity EmptyStatement provides Statement {
 }
 
-entity BinderInfo { %% TODO: Not implemented
+entity BinderInfo { 
     field srcname: VarIdentifier;
     field refineonfollow: Bool;
 }
 
-datatype ITest using { %% TODO: Not Implemented
+datatype ITest using { 
     field isnot: Bool;
 }
 of
@@ -78,7 +78,7 @@ RefArgumentValue { } %% TODO: Not implemented
 ;
 
 entity ArgumentList {
-    field args: List<ArgumentValue>; %% if none get default val in emitter
+    field args: List<ArgumentValue>; 
 }
 
 datatype IfStatement provides Statement using {
@@ -90,7 +90,7 @@ IfSimpleStatement { }
 | IfTestStatement {
     field itest: ITest;
 }
-| IfBinderStatement { %% TODO: Not implemented
+| IfBinderStatement { 
     field itest: ITest;
     field binder: BinderInfo;
 }

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -194,10 +194,10 @@ datatype IfExpression provides Expression using {
 }
 of
 IfSimpleExpression { }
-| IfTestExpression { %% TODO: Not implemented (need ITests for this to work)
+| IfTestExpression { 
     field itest: ITest;
 }
-| IfBinderExpression { %% TODO: Not implemented 
+| IfBinderExpression {
     field itest: ITest;
     field binder: BinderInfo;
 }

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -315,6 +315,9 @@ PostfixAccessFromName {
 | PostfixIsTest {
     field ttest: ITest;
 }
+| PostfixAsConvert {
+    field ttest: ITest;
+}
 | PostfixInvokeStatic { 
     field resolvedType: NominalTypeSignature;
     field resolvedTrgt: InvokeKey;

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -295,6 +295,10 @@ entity Assembly {
         return this.lookupNominalTypeDeclaration(tkey)?<AbstractEntityTypeDecl>;
     }
 
+    method isNominalTypeConcept(tkey: TypeKey): Bool {
+        return this.lookupNominalTypeDeclaration(tkey)?<AbstractConceptTypeDecl>;
+    }
+
     method isPrimtitiveType(tkey: TypeKey): Bool {
         return this.primitives.has(tkey);
     }

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -103,6 +103,10 @@ concept AbstractConceptTypeDecl provides AbstractNominalTypeDecl {
     field subtypes: List<TypeKey>;
 }
 
+entity ConceptTypeDecl provides AbstractConceptTypeDecl {
+    field fields: List<MemberFieldDecl>;
+}
+
 datatype PrimitiveConceptTypeDecl provides AbstractConceptTypeDecl 
 of
 OptionTypeDecl { 
@@ -230,6 +234,7 @@ entity Assembly {
     field datatypes: Map<TypeKey, DatatypeTypeDecl>;
 
     field pconcepts: Map<TypeKey, PrimitiveConceptTypeDecl>; %% Note: Currently only supports option
+    field concepts: Map<TypeKey, ConceptTypeDecl>; %% We dont emit these but need to look them up
 
     field allmethods: List<InvokeKey>;
     field typeinfos: Map<TypeKey, TypeInfo>;
@@ -257,6 +262,9 @@ entity Assembly {
         }
         elif(this.enums.has(tkey)) {
             return this.enums.get(tkey);
+        }
+        elif(this.concepts.has(tkey)) {
+            return this.concepts.get(tkey);
         }
         else {
             abort; %% Non suported typekey!
@@ -297,5 +305,26 @@ entity Assembly {
 
     method areTypesSame(t1: TypeSignature, t2: TypeSignature): Bool {
         return t1.tkeystr.value === t2.tkeystr.value;
+    }
+
+    method isSubtypeOf(t1: TypeSignature, t2: TypeSignature): Bool {
+        if(t1.tkeystr === t2.tkeystr) {
+            return true;
+        }
+        else {
+            if(t1?!<NominalTypeSignature> || t2?!<NominalTypeSignature>) {
+                return false;
+            }
+            else {
+                if(t1.tkeystr === 'None'<TypeKey>) {
+                    let tt2 = this.lookupNominalTypeDeclaration(t2.tkeystr);
+                    return tt2?<OptionTypeDecl>;
+                }
+                else {
+                    let tt1 = this.lookupNominalTypeDeclaration(t1.tkeystr);
+                    return tt1.saturatedProvides.someOf(pred(st) => st.tkeystr === t2.tkeystr);
+                }
+            }
+        }
     }
 }

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -166,9 +166,13 @@ public:
     DataEntry(uintptr_t* d) noexcept : data(*d) { }
 };
 
+//
+// This is redundant, we should juts use boxed<K> instead
+//
+
 // K is maximum possible size for datatype (deduced from member entities)
 template <size_t K> 
-class DataType { // May be able to make this more generic and use it to represent concepts too
+class DataType { 
 public:
     TypeInfoBase* typeinfo = nullptr;
     DataEntry<K> d;

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -248,7 +248,7 @@ public:
     }
 };
 
-typedef uint64_t None;
+typedef uintptr_t None;
 
 #define MAX_BSQ_INT ((int64_t(1) << 62) - 1)
 #define MIN_BSQ_INT (-(int64_t(1) << 62) + 1) 

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -115,52 +115,93 @@ public:
 };
 
 template <size_t K>
-class TupleEntry {
+class DataEntry {
 public:
     uintptr_t data[K] = {};
 
-    TupleEntry() noexcept = default;
-    TupleEntry(const TupleEntry& rhs) noexcept {
+    DataEntry() noexcept = default;
+    DataEntry(const DataEntry& rhs) noexcept {
         memcpy<K>(this->data, rhs->data);
     }
-    TupleEntry& operator=(const TupleEntry& rhs) noexcept {
+    DataEntry& operator=(const DataEntry& rhs) noexcept {
         memcpy<K>(this->data, rhs->data);
         
         return *this;
     }
 
-    TupleEntry(uintptr_t* d) {
+    DataEntry(uintptr_t* d) {
         memcpy<K>(this->data, d);
     }
 };
 
-// We may want to specialize K=2,3,4 as well
+// Maybe we combine K = 1 and K = 0 cases together
 template <>
-class TupleEntry<1> {
+class DataEntry<0> {
 public:
     uintptr_t data = 0;
 
-    TupleEntry() noexcept = default;
-    TupleEntry(const TupleEntry& rhs) noexcept : data(rhs.data) { }
-    TupleEntry& operator=(const TupleEntry& rhs) noexcept {        
-        data = rhs.data;
+    DataEntry() noexcept = default;
+    DataEntry(const DataEntry& rhs) noexcept : data(rhs.data) { }
+    DataEntry& operator=(const DataEntry& rhs) noexcept {        
+        this->data = rhs.data;
         return *this;
     }
 
-    TupleEntry(uintptr_t* d) noexcept : data(*d) { }
+    DataEntry(uintptr_t* d) noexcept : data(*d) { }
+};
+
+// We may want to specialize K=2,3,4 as well
+template <>
+class DataEntry<1> {
+public:
+    uintptr_t data = 0;
+
+    DataEntry() noexcept = default;
+    DataEntry(const DataEntry& rhs) noexcept : data(rhs.data) { }
+    DataEntry& operator=(const DataEntry& rhs) noexcept {        
+        this->data = rhs.data;
+        return *this;
+    }
+
+    DataEntry(uintptr_t* d) noexcept : data(*d) { }
+};
+
+// K is maximum possible size for datatype (deduced from member entities)
+template <size_t K> 
+class DataType { // May be able to make this more generic and use it to represent concepts too
+public:
+    TypeInfoBase* typeinfo = nullptr;
+    DataEntry<K> d;
+
+    DataType() noexcept = delete;
+    DataType(const DataType& rhs) noexcept : typeinfo(rhs.typeinfo), d(rhs.d) { }
+    DataType& operator=(const DataType& rhs) noexcept {
+        this->typeinfo = rhs.typeinfo;
+        this->d = rhs.d;
+
+        return *this;
+    }
+
+    DataType(TypeInfoBase* ti, uintptr_t* data): typeinfo(ti), d(data) {};
+
+    template<typename T>
+    constexpr T access() noexcept {
+        static_assert(sizeof(T) == sizeof(this->d));
+        return *reinterpret_cast<T*>(&this->d);
+    } 
 };
 
 template <size_t K0, size_t K1>
 class Tuple2 {
 public:
-    TupleEntry<K0> e0;
-    TupleEntry<K1> e1;
+    DataEntry<K0> e0;
+    DataEntry<K1> e1;
     
     Tuple2() noexcept = default;
     Tuple2(const Tuple2& rhs) noexcept : e0(rhs.e0), e1(rhs.e1) { }
     Tuple2& operator=(const Tuple2& rhs) noexcept {
-        e0 = rhs.e0;
-        e1 = rhs.e1;
+        this->e0 = rhs.e0;
+        this->e1 = rhs.e1;
 
         return *this;
     }
@@ -182,16 +223,16 @@ public:
 template <size_t K0, size_t K1, size_t K2>
 class Tuple3 {
 public:
-    TupleEntry<K0> e0;
-    TupleEntry<K1> e1;
-    TupleEntry<K2> e2;
+    DataEntry<K0> e0;
+    DataEntry<K1> e1;
+    DataEntry<K2> e2;
     
     Tuple3() noexcept = default;
     Tuple3(const Tuple3& rhs) noexcept : e0(rhs.e0), e1(rhs.e1), e2(rhs.e2) { }
     Tuple3& operator=(const Tuple3& rhs) noexcept {
-        e0 = rhs.e0;
-        e1 = rhs.e1;
-        e2 = rhs.e2;
+        this->e0 = rhs.e0;
+        this->e1 = rhs.e1;
+        this->e2 = rhs.e2;
 
         return *this;
     }
@@ -215,18 +256,18 @@ public:
 template <size_t K0, size_t K1, size_t K2, size_t K3>
 class Tuple4 {
 public:
-    TupleEntry<K0> e0;
-    TupleEntry<K1> e1;
-    TupleEntry<K2> e2;
-    TupleEntry<K3> e3;
+    DataEntry<K0> e0;
+    DataEntry<K1> e1;
+    DataEntry<K2> e2;
+    DataEntry<K3> e3;
     
     Tuple4() noexcept = default;
     Tuple4(const Tuple4& rhs) noexcept : e0(rhs.e0), e1(rhs.e1), e2(rhs.e2), e3(rhs.e3) { }
     Tuple4& operator=(const Tuple4& rhs) noexcept {
-        e0 = rhs.e0;
-        e1 = rhs.e1;
-        e2 = rhs.e2;
-        e3 = rhs.e3;
+        this->e0 = rhs.e0;
+        this->e1 = rhs.e1;
+        this->e2 = rhs.e2;
+        this->e3 = rhs.e3;
 
         return *this;
     }

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -115,91 +115,46 @@ public:
 };
 
 template <size_t K>
-class DataEntry {
+class TupleEntry {
 public:
     uintptr_t data[K] = {};
 
-    DataEntry() noexcept = default;
-    DataEntry(const DataEntry& rhs) noexcept {
+    TupleEntry() noexcept = default;
+    TupleEntry(const TupleEntry& rhs) noexcept {
         memcpy<K>(this->data, rhs->data);
     }
-    DataEntry& operator=(const DataEntry& rhs) noexcept {
+    TupleEntry& operator=(const TupleEntry& rhs) noexcept {
         memcpy<K>(this->data, rhs->data);
         
         return *this;
     }
 
-    DataEntry(uintptr_t* d) {
+    TupleEntry(uintptr_t* d) {
         memcpy<K>(this->data, d);
     }
 };
 
-// Maybe we combine K = 1 and K = 0 cases together
-template <>
-class DataEntry<0> {
-public:
-    uintptr_t data = 0;
-
-    DataEntry() noexcept = default;
-    DataEntry(const DataEntry& rhs) noexcept : data(rhs.data) { }
-    DataEntry& operator=(const DataEntry& rhs) noexcept {        
-        this->data = rhs.data;
-        return *this;
-    }
-
-    DataEntry(uintptr_t* d) noexcept : data(*d) { }
-};
-
 // We may want to specialize K=2,3,4 as well
 template <>
-class DataEntry<1> {
+class TupleEntry<1> {
 public:
     uintptr_t data = 0;
 
-    DataEntry() noexcept = default;
-    DataEntry(const DataEntry& rhs) noexcept : data(rhs.data) { }
-    DataEntry& operator=(const DataEntry& rhs) noexcept {        
+    TupleEntry() noexcept = default;
+    TupleEntry(const TupleEntry& rhs) noexcept : data(rhs.data) { }
+    TupleEntry& operator=(const TupleEntry& rhs) noexcept {        
         this->data = rhs.data;
         return *this;
     }
 
-    DataEntry(uintptr_t* d) noexcept : data(*d) { }
-};
-
-//
-// This is redundant, we should juts use boxed<K> instead
-//
-
-// K is maximum possible size for datatype (deduced from member entities)
-template <size_t K> 
-class DataType { 
-public:
-    TypeInfoBase* typeinfo = nullptr;
-    DataEntry<K> d;
-
-    DataType() noexcept = delete;
-    DataType(const DataType& rhs) noexcept : typeinfo(rhs.typeinfo), d(rhs.d) { }
-    DataType& operator=(const DataType& rhs) noexcept {
-        this->typeinfo = rhs.typeinfo;
-        this->d = rhs.d;
-
-        return *this;
-    }
-
-    DataType(TypeInfoBase* ti, uintptr_t* data): typeinfo(ti), d(data) {};
-
-    template<typename T>
-    constexpr T access() noexcept {
-        static_assert(sizeof(T) == sizeof(this->d));
-        return *reinterpret_cast<T*>(&this->d);
-    } 
+    TupleEntry(uintptr_t* d) noexcept : data(*d) { }
 };
 
 template <size_t K0, size_t K1>
 class Tuple2 {
 public:
-    DataEntry<K0> e0;
-    DataEntry<K1> e1;
+    TupleEntry<K0> e0;
+    TupleEntry<K1> e1;
     
     Tuple2() noexcept = default;
     Tuple2(const Tuple2& rhs) noexcept : e0(rhs.e0), e1(rhs.e1) { }
@@ -227,9 +182,9 @@ public:
 template <size_t K0, size_t K1, size_t K2>
 class Tuple3 {
 public:
-    DataEntry<K0> e0;
-    DataEntry<K1> e1;
-    DataEntry<K2> e2;
+    TupleEntry<K0> e0;
+    TupleEntry<K1> e1;
+    TupleEntry<K2> e2;
     
     Tuple3() noexcept = default;
     Tuple3(const Tuple3& rhs) noexcept : e0(rhs.e0), e1(rhs.e1), e2(rhs.e2) { }
@@ -260,10 +215,10 @@ public:
 template <size_t K0, size_t K1, size_t K2, size_t K3>
 class Tuple4 {
 public:
-    DataEntry<K0> e0;
-    DataEntry<K1> e1;
-    DataEntry<K2> e2;
-    DataEntry<K3> e3;
+    TupleEntry<K0> e0;
+    TupleEntry<K1> e1;
+    TupleEntry<K2> e2;
+    TupleEntry<K3> e3;
     
     Tuple4() noexcept = default;
     Tuple4(const Tuple4& rhs) noexcept : e0(rhs.e0), e1(rhs.e1), e2(rhs.e2), e3(rhs.e3) { }

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -718,8 +718,8 @@ constexpr __CoreCpp::BigNat operator "" _N(const char* v) { return __CoreCpp::Bi
 constexpr __CoreCpp::Float operator "" _f(long double v) { return __CoreCpp::Float(static_cast<double>(v)); }
 
 // For debugging
-std::ostream& operator<<(std::ostream &os, const __CoreCpp::Int& t) { return os << t.get(); }
-std::ostream& operator<<(std::ostream &os, const __CoreCpp::BigInt& t) { return os << __CoreCpp::t_to_string<__int128_t>(t.get()); }
-std::ostream& operator<<(std::ostream &os, const __CoreCpp::Nat& t) { return os << t.get(); }
-std::ostream& operator<<(std::ostream &os, const __CoreCpp::BigNat& t) { return os << __CoreCpp::t_to_string<__uint128_t>(t.get()); }
-std::ostream& operator<<(std::ostream &os, const __CoreCpp::Float& t) { return os << t.get(); }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::Int& t) { return os << t.get() << "_i"; }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::BigInt& t) { return os << __CoreCpp::t_to_string<__int128_t>(t.get()) << "_I"; }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::Nat& t) { return os << t.get() << "_n"; }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::BigNat& t) { return os << __CoreCpp::t_to_string<__uint128_t>(t.get()) << "_N"; }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::Float& t) { return os << t.get() << "_f"; }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -238,7 +238,8 @@ function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression
     %% Will need to do something similar for concepts
     if(ctx.asm.datatypes.has(etype.tkeystr)) {
         let emitetype = emitTypeKey(etype.tkeystr, false, ctx);
-        return String::concat(access, ".access<", emitetype, ">()");
+        return if(ctx.asm.areTypesSame(exp.etype, etype)) then access %% No need to call access for the same type
+            else String::concat(access, ".access<", emitetype, ">()");
     }
 
     return access;
@@ -505,12 +506,15 @@ function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSi
             else if(areTypesSame) then "true" else "false";
     }
     else {
-        if(ctx.asm.isSubtypeOf(it.ttype, baseType)) { %% This doesnt work
-            return "true";
+        %% T-type is concrete case
+        if(ctx.asm.isNominalTypeConcrete(it.ttype.tkeystr)) {
+            let ttype = emitTypeSignature(it.ttype, false, ctx);
+            return if(it.isnot) then String::concat(".typeinfo != &", ttype, "Type")
+                else String::concat(".typeinfo == &", ttype, "Type");
         }
-        else {
-            return "false";
-        }
+
+        %% Handle case where both are abstract (vtable lookup)
+        abort;
     }
 }
 
@@ -536,32 +540,31 @@ function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSign
     }
 }
 
-function emitITestAsConvertNone(isnot: Bool, baseType: CPPAssembly::TypeSignature, ctx: Context): (|String, CPPAssembly::TypeSignature|) {
+function emitITestAsConvertNone(isnot: Bool, baseType: CPPAssembly::TypeKey, ctx: Context): (|String, CPPAssembly::TypeKey|) {
     if(isnot) {
         return emitITestAsConvertSome(false, baseType, ctx);
     }
     else {
-        let tinfo = ctx.asm.typeinfos.get(baseType.tkeystr);
+        let tinfo = ctx.asm.typeinfos.get(baseType);
         let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
 
         %% No clue if this is the best way to fabricate our none type
-        return (|String::concat(accessor, "none()"), CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::None') }|);
+        return (|String::concat(accessor, "none()"), CPPAssembly::TypeKey::from('__CoreCpp::None') |);
     }
 }
 
-function emitITestAsConvertSome(isnot: Bool, baseType: CPPAssembly::TypeSignature, ctx: Context): (|String, CPPAssembly::TypeSignature|) {
-    let ant = ctx.asm.lookupNominalTypeDeclaration(baseType.tkeystr);
+function emitITestAsConvertSome(isnot: Bool, baseType: CPPAssembly::TypeKey, ctx: Context): (|String, CPPAssembly::TypeKey|) {
+    let ant = ctx.asm.lookupNominalTypeDeclaration(baseType);
     
     if(ant)@<CPPAssembly::OptionTypeDecl> {
         if(isnot) {
             return emitITestAsConvertNone(false, baseType, ctx);
         }
         else {
-            let tinfo = ctx.asm.typeinfos.get(baseType.tkeystr);
+            let tinfo = ctx.asm.typeinfos.get(baseType);
             let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
 
-            %% Lets also return the type we convert to
-            return (|String::concat(accessor, "some().value"), $ant.oftype|);
+            return (|String::concat(accessor, "some().value"), $ant.oftype.tkeystr|);
         }
     }
     else {
@@ -569,10 +572,22 @@ function emitITestAsConvertSome(isnot: Bool, baseType: CPPAssembly::TypeSignatur
     }
 }
 
+function emitITestAsConvertType(fromtype: CPPAssembly::TypeKey, totype: CPPAssembly::TypeKey, isnot: Bool, ctx: Context): (|String, CPPAssembly::TypeKey|) { 
+    if(ctx.asm.isNominalTypeConcept(fromtype)) {
+        let ttype = emitTypeKey(totype, false, ctx);
+        let tinfo = ctx.asm.typeinfos.get(fromtype);
+        let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
 
-function emitITestAsConvert(isnot: Bool, itc: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, ctx: Context): (|String, CPPAssembly::TypeSignature|) {
+        return (|String::concat(accessor, "access<", ttype,">()"), totype|);
+    }
+    else {
+        abort;
+    }
+}
+
+function emitITestAsConvert(isnot: Bool, itc: CPPAssembly::ITest, baseType: CPPAssembly::TypeKey, ctx: Context): (|String, CPPAssembly::TypeKey|) {
     match(itc)@ {
-        CPPAssembly::ITestType => { abort; }
+        CPPAssembly::ITestType => { return emitITestAsConvertType(baseType, $itc.ttype.tkeystr, isnot, ctx); }
         | CPPAssembly::ITestNone => { return emitITestAsConvertNone(isnot, baseType, ctx); }
         | CPPAssembly::ITestSome => { return emitITestAsConvertSome(isnot, baseType, ctx); }
         | CPPAssembly::ITestOk => { abort; }
@@ -589,7 +604,7 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
             CPPAssembly::PostfixAccessFromName => { return String::concat(acc, emitPostfixAccessFromName($op, ctx)); }
             | CPPAssembly::PostfixAccessFromIndex => { return emitPostfixAccessFromIndex($op, acc, ctx); }
             | CPPAssembly::PostfixIsTest => { return String::concat(acc, emitITestAsTest($op.ttest, $op.baseType, ctx)); }
-            | CPPAssembly::PostfixAsConvert => { return String::concat(acc, emitITestAsConvert($op.ttest.isnot, $op.ttest, $op.baseType, ctx).0); }
+            | CPPAssembly::PostfixAsConvert => { return String::concat(acc, emitITestAsConvert($op.ttest.isnot, $op.ttest, $op.baseType.tkeystr, ctx).0); }
             | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, pop.rootExp, ctx); } %% This will not chain method calls :(
             | CPPAssembly::PostfixBoolConstant => { return if($op.value === true) then "true" else "false"; }
             | CPPAssembly::PostfixAccessSomeValue => { return emitPostfixAccessSomeValue($op, acc, pop.rootExp.etype, ctx); }
@@ -663,15 +678,13 @@ function emitConstructorExpression(exp: CPPAssembly::ConstructorExpression, ctx:
 }
 
 function emitIfTestExpression(exp: CPPAssembly::IfTestExpression, i: String, t: String, e: String, ctx: Context): String {
-    let itest = emitITestAsTest(exp.itest, exp.texp.etype, ctx);
+    let itest = String::concat(i, emitITestAsTest(exp.itest, exp.texp.etype, ctx)); %% Likely doesnt work if the itest is just bool
 
     return String::concat(itest, " ? ", t, " : ", e);
 }
 
 function emitIfBinderExpression(exp: CPPAssembly::IfBinderExpression, i: String, t: String, e: String, ctx: Context): String {
-    let itest = emitITestAsTest(exp.itest, exp.texp.etype, ctx);
-
-    return String::concat(itest, " ? ", t, " : ", e);
+    abort; %% TODO: Not Implemented
 }
 
 function emitIfExpression(exp: CPPAssembly::IfExpression, ctx: Context): String {
@@ -836,10 +849,10 @@ function emitIfBinderStatement(stmt: CPPAssembly::IfBinderStatement, ctx: Contex
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
 
     let bname = emitVarIdentifier(stmt.binder.srcname);
-    let convert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, stmt.cond.etype, ctx);
+    let convert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, stmt.cond.etype.tkeystr, ctx);
     let reasign = String::concat(bname, " = ", expr, convert.0);
 
-    let tbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeSignature(convert.1, false, ctx), " ", reasign, ";%n;");
+    let tbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeKey(convert.1, false, ctx), " ", reasign, ";%n;");
 
     let ifstmt = String::concat(indent, "if( ", itest, " ) {%n;");
     return String::concat(ifstmt, tbassign, trueBlock, indent, "}%n;");
@@ -885,13 +898,42 @@ function emitIfElseBinderStatement(stmt: CPPAssembly::IfElseBinderStatement, ctx
     let itest = String::concat(expr, emitITestAsTest(stmt.itest, stmt.cond.etype, ctx));
 
     let bname = emitVarIdentifier(stmt.binder.srcname); 
-    let tconvert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, stmt.cond.etype, ctx); 
+    let tconvert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, stmt.cond.etype.tkeystr, ctx); 
     let treasign = String::concat(bname, " = ", expr, tconvert.0);
-    let tbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeSignature(tconvert.1, false, ctx), " ", treasign, ";%n;");
+    let tbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeKey(tconvert.1, false, ctx), " ", treasign, ";%n;");
 
-    let fconvert = emitITestAsConvert(!stmt.itest.isnot, stmt.itest, stmt.cond.etype, ctx); 
-    let freasign = String::concat(bname, " = ", expr, fconvert.0);
-    let fbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeSignature(fconvert.1, false, ctx), " ", freasign, ";%n;");
+    %% Need to handle case where we are a datatype with only two member entities. Type should be infered to be the other entity in else case
+
+    var n: Nat;
+    let concretetype = ctx.asm.lookupNominalTypeDeclaration(stmt.cond.etype.tkeystr);
+    if(concretetype)@<CPPAssembly::DatatypeTypeDecl> {
+        n = $concretetype.associatedMemberEntityDecls.size();
+    }
+    else {
+        n = 0n;
+    }
+
+    %%
+    %% I believe this breaks none and some converts...
+    %%
+
+    var fbassign: String;
+    if(n == 2n) { %% If only two member entities implicitly convert to entity we are not
+        let othermember = concretetype@<CPPAssembly::DatatypeTypeDecl>
+            .associatedMemberEntityDecls.find(pred(ets) => !ctx.asm.areTypesSame(ets, stmt.itest@<CPPAssembly::ITestType>.ttype)).tkeystr;
+        
+        %%
+        %% We will need some way to pass in the from type here, which is othermember in thiscase (perhaps option in constructor?)
+        %%
+
+        let fconvert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, stmt.cond.etype.tkeystr, ctx); 
+        let freasign = String::concat(bname, " = ", expr, fconvert.0);
+        fbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeKey(fconvert.1, false, ctx), " ", freasign, ";%n;");
+    }
+    else {
+        let freasign = String::concat(bname, " = ", emitSpecialThis());
+        fbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeKey(stmt.cond.etype.tkeystr, false, ctx), " ", freasign, ";%n;");
+    }
 
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
     let falseBlock = emitBlockStatement(stmt.falseBlock, ctx, indent);
@@ -1127,9 +1169,9 @@ function emitDatatypeTypeDecl(dt: CPPAssembly::DatatypeTypeDecl, ctx: Context, i
 
     let template = String::concat(full_indent, "template<typename T>%n;");
 
-    let cons = if(datasize === "0") then String::concat(full_indent, name, "(__CoreCpp::TypeInfoBase* ti) noexcept : Boxed(ti) {};%n;")
-        else if(datasize === "1") then String::concat(template, full_indent, name, "(__CoreCpp::TypeInfoBase* ti, T d) noexcept : Boxed(ti, reinterpret_cast<uintptr_t*>(&d)) {};%n;")
-        else String::concat(template, full_indent, name, "(__CoreCpp::TypeInfoBase* ti, T d) noexcept : Boxed(ti, reinterpret_cast<uintptr_t(*)[", datasize, "]>(&d)) {};%n;");
+    let cons = if(datasize === "0") then String::concat(full_indent, name, "(__CoreCpp::TypeInfoBase* ti) noexcept : Boxed(ti) {};%n;%n;")
+        else if(datasize === "1") then String::concat(template, full_indent, name, "(__CoreCpp::TypeInfoBase* ti, T d) noexcept : Boxed(ti, reinterpret_cast<uintptr_t*>(&d)) {};%n;%n;")
+        else String::concat(template, full_indent, name, "(__CoreCpp::TypeInfoBase* ti, T d) noexcept : Boxed(ti, reinterpret_cast<uintptr_t(*)[", datasize, "]>(&d)) {};%n;%n;");
     let allcons = String::concat(def, assign, copy, cons);
 
     let access = if(datasize === "0") then String::concat(template, full_indent, "constexpr T access() noexcept { return T{}; }%n;")

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -587,7 +587,7 @@ function emitITestAsConvertType(isnot: Bool, fromtype: CPPAssembly::TypeKey, tot
             abort; %% TODO: Concept support
         }
         else {
-            ttype = String::concat(emitTypeKey(totype, false, ctx), "ᙚBase"); 
+            ttype = String::concat(emitTypeKey(totype, false, ctx), "ᕮBase"); 
 
         }
     }
@@ -1077,8 +1077,8 @@ function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::Typ
     let specialName = emitSpecialTemplate(String::fromCString(name));
     
     let pre = if(rtype === "bool") 
-        then String::concat(rtype, " ", specialName)
-        else String::concat("const ", rtype, " ", specialName);
+        then String::concat(indent, rtype, " ", specialName)
+        else String::concat(indent, "const ", rtype, " ", specialName);
 
     var params_impl: String;
     if(params === "") {
@@ -1094,7 +1094,7 @@ function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::Typ
 
 function emitMethods(ant: CPPAssembly::AbstractNominalTypeDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
     let staticmethods = ant.staticmethods
-        .reduce<String>(indent, fn(acc, ik) => {
+        .reduce<String>("", fn(acc, ik) => {
             return String::concat(acc, emitMethodDecl(ctx.asm.staticmethods.get(ik), declaredIn, ctx, indent));
     });
 
@@ -1174,7 +1174,7 @@ function emitDatatypeTypeDecl(dt: CPPAssembly::DatatypeTypeDecl, ctx: Context, i
     let name = emitTypeKey(dt.tkey, false, nctx);
 
     %% Emit all fields as a base type to allow for safe access
-    let entries = dt.saturatedBFieldInfo.reduce<String>(String::concat(indent, "struct ", name, "ᙚBase { %n;"), 
+    let entries = dt.saturatedBFieldInfo.reduce<String>(String::concat(indent, "struct ", name, "ᕮBase { %n;"), 
         fn(acc, entry) => {
             return String::concat(acc, emitSaturatedFieldInfo(entry, nctx, full_indent));
     });
@@ -1183,7 +1183,7 @@ function emitDatatypeTypeDecl(dt: CPPAssembly::DatatypeTypeDecl, ctx: Context, i
     let base = String::concat(indent, "class ", name, " : public __CoreCpp::Boxed<", datasize, "> {%n;");
     let def = String::concat(indent, "public:%n;", full_indent, name, "() noexcept = default;%n;");
     let assign = String::concat(full_indent, name, "(const ", name, "& rhs) noexcept = default;%n;");
-    let copy = String::concat(full_indent, name, "& operator=(const ", name, "& rhs) noexcept = default;%n;");
+    let copy = String::concat(full_indent, name, "& operator=(const ", name, "& rhs) noexcept = default;%n;%n;");
 
     let template = String::concat(full_indent, "template<typename T>%n;");
 
@@ -1241,7 +1241,9 @@ function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CP
             return String::concat(base, emitSpecialThis(), ", ", params, ") noexcept;%n;");           
         }
     }
-    abort; %% TODO: Support other method types!
+    else {
+        abort; %% TODO: Support other method types!
+    }
 }
 
 function emitFunctionForwardDeclaration(decl: CPPAssembly::AbstractInvokeDecl, ctx: Context, ident: String): String {
@@ -1408,12 +1410,7 @@ recursive function emitFuncForwardDeclarations(nsdecl: CPPAssembly::NamespaceDec
         return String::concat(acc, emitFunctionForwardDeclaration(ctx.asm.typefuncs.get(ikey)@<CPPAssembly::AbstractInvokeDecl>, ctx, indent));
     });
 
-    %% Eventually will need to modify this to allow other method types
-    let method_fwddecls = nsdecl.staticmethods.reduce<String>(typefunc_fwddecls, fn(acc, mtkey) => {
-        return String::concat(acc, emitMethodForwardDeclaration(ctx.asm.staticmethods.get(mtkey.0), mtkey.1, ctx, indent));
-    });
-
-    return String::concat(method_fwddecls, indent);
+    return String::concat(typefunc_fwddecls, indent);
 }
 
 recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: String): String {
@@ -1448,20 +1445,25 @@ function emitNamespaceDeclFwdDecls(nsdecl: CPPAssembly::NamespaceDecl, ctx: Cont
     let full_indent = String::concat("    ", indent);
     let ns = String::concat(indent, "namespace ", String::fromCString(nsdecl.nsname), " {%n;");
 
-    let subns = nsdecl.subns
+    let subns_fwddecls = nsdecl.subns
         .reduce<String>(ns, fn(acc, name, decl) => {
             return String::concat(acc, emitNamespaceDeclFwdDecls[recursive](decl, ctx, full_indent));
     });
 
-    let fwddecls = nsdecl.alltypes
+    let ant_fwddecls = nsdecl.alltypes
         .filter(pred(tk) => ctx.asm.typeinfos.get(tk).tag !== CPPAssembly::Tag#Value)
-        .reduce<String>(subns, fn(acc, tk) => {
+        .reduce<String>("", fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let fwddecl = emitAbstractNominalForwardDeclaration(ant, ctx, full_indent); 
             return String::concat(acc, fwddecl);
     });
 
-    return String::concat(fwddecls, "}%n;");
+    let method_fwddecls = nsdecl.staticmethods
+        .reduce<String>("", fn(acc, mtkey) => {
+            return String::concat(acc, emitMethodForwardDeclaration(ctx.asm.staticmethods.get(mtkey.0), mtkey.1, ctx, full_indent));
+    });
+
+    return String::concat(subns_fwddecls, ant_fwddecls, method_fwddecls, "}%n;");
 }
 
 %%
@@ -1514,7 +1516,7 @@ function emitAssembly(asm: CPPAssembly::Assembly): String {
 
     %% Non-value type forward decls
     let fwddecls = asm.nsdecls
-        .reduce<String>(String::concat(primitive_typeinfos, "//%n;// Ref and Tagged Type Forward Declarations%n;//%n;"),
+        .reduce<String>(String::concat(primitive_typeinfos, "//%n;// Ref, Tagged Type, and Method Forward Declarations%n;//%n;"),
         fn(acc, nsname, nsdecl) => {
             return String::concat(acc, emitNamespaceDeclFwdDecls(nsdecl, ctx, ""));
     });

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -187,7 +187,12 @@ function emitVarIdentifier(vi: CPPAssembly::VarIdentifier): String {
     if(vival === "this") {
         return emitSpecialThis();
     }
-    return emitSpecialTemplate(vival);
+    elif (vival === "$this") {
+        return String::concat("$", emitSpecialThis());
+    }
+    else {
+        return emitSpecialTemplate(vival);
+    }
 }
 
 function emitInvokeKey(ik: CPPAssembly::InvokeKey, ctx: Context): String {
@@ -445,7 +450,7 @@ function emitPostfixAccessFromName(op: CPPAssembly::PostfixAccessFromName, ctx: 
     switch(op_tinfo.tag) {
         CPPAssembly::Tag#Value => { return String::concat(".", ident); }
         | CPPAssembly::Tag#Ref => { return String::concat("->", ident); }
-        | CPPAssembly::Tag#Tagged => { abort; } %% TODO: Need to handle virtual lookups (and add our little vtable to backend that emits)
+        | CPPAssembly::Tag#Tagged => { return String::concat(".", ident); } 
     }
 }
 
@@ -540,31 +545,30 @@ function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSign
     }
 }
 
-function emitITestAsConvertNone(isnot: Bool, baseType: CPPAssembly::TypeKey, ctx: Context): (|String, CPPAssembly::TypeKey|) {
+function emitITestAsConvertNone(isnot: Bool, fromtype: CPPAssembly::TypeKey, ctx: Context): (|String, String|) {
     if(isnot) {
-        return emitITestAsConvertSome(false, baseType, ctx);
+        return emitITestAsConvertSome(false, fromtype, ctx);
     }
     else {
-        let tinfo = ctx.asm.typeinfos.get(baseType);
+        let tinfo = ctx.asm.typeinfos.get(fromtype);
         let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
 
-        %% No clue if this is the best way to fabricate our none type
-        return (|String::concat(accessor, "none()"), CPPAssembly::TypeKey::from('__CoreCpp::None') |);
+        return (|String::concat(accessor, "none()"), "__CoreCpp::None" |);
     }
 }
 
-function emitITestAsConvertSome(isnot: Bool, baseType: CPPAssembly::TypeKey, ctx: Context): (|String, CPPAssembly::TypeKey|) {
-    let ant = ctx.asm.lookupNominalTypeDeclaration(baseType);
+function emitITestAsConvertSome(isnot: Bool, fromtype: CPPAssembly::TypeKey, ctx: Context): (|String, String|) {
+    let ant = ctx.asm.lookupNominalTypeDeclaration(fromtype);
     
     if(ant)@<CPPAssembly::OptionTypeDecl> {
         if(isnot) {
-            return emitITestAsConvertNone(false, baseType, ctx);
+            return emitITestAsConvertNone(false, fromtype, ctx);
         }
         else {
-            let tinfo = ctx.asm.typeinfos.get(baseType);
+            let tinfo = ctx.asm.typeinfos.get(fromtype);
             let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
 
-            return (|String::concat(accessor, "some().value"), $ant.oftype.tkeystr|);
+            return (|String::concat(accessor, "some().value"), emitTypeKey($ant.oftype.tkeystr, false, ctx)|);
         }
     }
     else {
@@ -572,24 +576,39 @@ function emitITestAsConvertSome(isnot: Bool, baseType: CPPAssembly::TypeKey, ctx
     }
 }
 
-function emitITestAsConvertType(fromtype: CPPAssembly::TypeKey, totype: CPPAssembly::TypeKey, isnot: Bool, ctx: Context): (|String, CPPAssembly::TypeKey|) { 
-    if(ctx.asm.isNominalTypeConcept(fromtype)) {
-        let ttype = emitTypeKey(totype, false, ctx);
-        let tinfo = ctx.asm.typeinfos.get(fromtype);
-        let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
+function emitITestAsConvertType(isnot: Bool, fromtype: CPPAssembly::TypeKey, totype: CPPAssembly::TypeKey, ctx: Context): (|String, String|) { 
+    let tinfo = ctx.asm.typeinfos.get(fromtype);
+    let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
+    var ttype: String;
 
-        return (|String::concat(accessor, "access<", ttype,">()"), totype|);
+    if(fromtype.value === totype.value) {
+        let e = ctx.asm.lookupNominalTypeDeclaration(totype);
+        if(e)@!<CPPAssembly::DatatypeTypeDecl> {
+            abort; %% TODO: Concept support
+        }
+        else {
+            ttype = String::concat(emitTypeKey(totype, false, ctx), "ᙚBase"); 
+
+        }
+    }
+    elif(ctx.asm.isNominalTypeConcept(fromtype)) {
+        ttype = emitTypeKey(totype, false, ctx);
     }
     else {
         abort;
     }
+
+    return (|String::concat(accessor, "access<", ttype,">()"), ttype|);
 }
 
-function emitITestAsConvert(isnot: Bool, itc: CPPAssembly::ITest, baseType: CPPAssembly::TypeKey, ctx: Context): (|String, CPPAssembly::TypeKey|) {
+function emitITestAsConvert(isnot: Bool, itc: CPPAssembly::ITest, fromtype: CPPAssembly::TypeKey, totype: Option<CPPAssembly::TypeKey>, ctx: Context): (|String, String|) { %% Convert, Emitted type
     match(itc)@ {
-        CPPAssembly::ITestType => { return emitITestAsConvertType(baseType, $itc.ttype.tkeystr, isnot, ctx); }
-        | CPPAssembly::ITestNone => { return emitITestAsConvertNone(isnot, baseType, ctx); }
-        | CPPAssembly::ITestSome => { return emitITestAsConvertSome(isnot, baseType, ctx); }
+        CPPAssembly::ITestType => { 
+            let ntotype = if(totype)none then $itc.ttype.tkeystr else totype@some; %% For postfix itest convert case
+            return emitITestAsConvertType(isnot, fromtype, ntotype, ctx); 
+        }
+        | CPPAssembly::ITestNone => { return emitITestAsConvertNone(isnot, fromtype, ctx); }
+        | CPPAssembly::ITestSome => { return emitITestAsConvertSome(isnot, fromtype, ctx); }
         | CPPAssembly::ITestOk => { abort; }
         | CPPAssembly::ITestFail => { abort; }
     }
@@ -604,7 +623,7 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
             CPPAssembly::PostfixAccessFromName => { return String::concat(acc, emitPostfixAccessFromName($op, ctx)); }
             | CPPAssembly::PostfixAccessFromIndex => { return emitPostfixAccessFromIndex($op, acc, ctx); }
             | CPPAssembly::PostfixIsTest => { return String::concat(acc, emitITestAsTest($op.ttest, $op.baseType, ctx)); }
-            | CPPAssembly::PostfixAsConvert => { return String::concat(acc, emitITestAsConvert($op.ttest.isnot, $op.ttest, $op.baseType.tkeystr, ctx).0); }
+            | CPPAssembly::PostfixAsConvert => { return String::concat(acc, emitITestAsConvert($op.ttest.isnot, $op.ttest, $op.baseType.tkeystr, none, ctx).0); }
             | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, pop.rootExp, ctx); } %% This will not chain method calls :(
             | CPPAssembly::PostfixBoolConstant => { return if($op.value === true) then "true" else "false"; }
             | CPPAssembly::PostfixAccessSomeValue => { return emitPostfixAccessSomeValue($op, acc, pop.rootExp.etype, ctx); }
@@ -849,10 +868,10 @@ function emitIfBinderStatement(stmt: CPPAssembly::IfBinderStatement, ctx: Contex
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
 
     let bname = emitVarIdentifier(stmt.binder.srcname);
-    let convert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, stmt.cond.etype.tkeystr, ctx);
+    let convert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, stmt.cond.etype.tkeystr, none, ctx);
     let reasign = String::concat(bname, " = ", expr, convert.0);
 
-    let tbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeKey(convert.1, false, ctx), " ", reasign, ";%n;");
+    let tbassign = String::concat(full_indent, "[[maybe_unused]] ", convert.1, " ", reasign, ";%n;");
 
     let ifstmt = String::concat(indent, "if( ", itest, " ) {%n;");
     return String::concat(ifstmt, tbassign, trueBlock, indent, "}%n;");
@@ -895,17 +914,16 @@ function emitIfElseBinderStatement(stmt: CPPAssembly::IfElseBinderStatement, ctx
     let full_indent = String::concat("    ", indent);
     
     let expr = emitExpression(stmt.cond, ctx);
-    let itest = String::concat(expr, emitITestAsTest(stmt.itest, stmt.cond.etype, ctx));
+    let etype = stmt.cond.etype;
+    let itest = String::concat(expr, emitITestAsTest(stmt.itest, etype, ctx));
 
     let bname = emitVarIdentifier(stmt.binder.srcname); 
-    let tconvert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, stmt.cond.etype.tkeystr, ctx); 
+    let tconvert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, stmt.cond.etype.tkeystr, none, ctx); 
     let treasign = String::concat(bname, " = ", expr, tconvert.0);
-    let tbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeKey(tconvert.1, false, ctx), " ", treasign, ";%n;");
-
-    %% Need to handle case where we are a datatype with only two member entities. Type should be infered to be the other entity in else case
+    let tbassign = String::concat(full_indent, "[[maybe_unused]] ", tconvert.1, " ", treasign, ";%n;");
 
     var n: Nat;
-    let concretetype = ctx.asm.lookupNominalTypeDeclaration(stmt.cond.etype.tkeystr);
+    let concretetype = ctx.asm.lookupNominalTypeDeclaration(etype.tkeystr);
     if(concretetype)@<CPPAssembly::DatatypeTypeDecl> {
         n = $concretetype.associatedMemberEntityDecls.size();
     }
@@ -913,26 +931,19 @@ function emitIfElseBinderStatement(stmt: CPPAssembly::IfElseBinderStatement, ctx
         n = 0n;
     }
 
-    %%
-    %% I believe this breaks none and some converts...
-    %%
-
     var fbassign: String;
     if(n == 2n) { %% If only two member entities implicitly convert to entity we are not
         let othermember = concretetype@<CPPAssembly::DatatypeTypeDecl>
             .associatedMemberEntityDecls.find(pred(ets) => !ctx.asm.areTypesSame(ets, stmt.itest@<CPPAssembly::ITestType>.ttype)).tkeystr;
-        
-        %%
-        %% We will need some way to pass in the from type here, which is othermember in thiscase (perhaps option in constructor?)
-        %%
 
-        let fconvert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, stmt.cond.etype.tkeystr, ctx); 
+        let fconvert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, etype.tkeystr, some(othermember), ctx); 
         let freasign = String::concat(bname, " = ", expr, fconvert.0);
-        fbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeKey(fconvert.1, false, ctx), " ", freasign, ";%n;");
+        fbassign = String::concat(full_indent, "[[maybe_unused]] ", fconvert.1, " ", freasign, ";%n;");
     }
     else {
-        let freasign = String::concat(bname, " = ", emitSpecialThis());
-        fbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeKey(stmt.cond.etype.tkeystr, false, ctx), " ", freasign, ";%n;");
+        let fconvert = emitITestAsConvert(!stmt.itest.isnot, stmt.itest, etype.tkeystr, some(etype.tkeystr), ctx); 
+        let freasign = String::concat(bname, " = ", expr, fconvert.0);
+        fbassign = String::concat(full_indent, "[[maybe_unused]] ", fconvert.1, " ", freasign, ";%n;");
     }
 
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
@@ -1162,6 +1173,13 @@ function emitDatatypeTypeDecl(dt: CPPAssembly::DatatypeTypeDecl, ctx: Context, i
 
     let name = emitTypeKey(dt.tkey, false, nctx);
 
+    %% Emit all fields as a base type to allow for safe access
+    let entries = dt.saturatedBFieldInfo.reduce<String>(String::concat(indent, "struct ", name, "ᙚBase { %n;"), 
+        fn(acc, entry) => {
+            return String::concat(acc, emitSaturatedFieldInfo(entry, nctx, full_indent));
+    });
+    let basetype = String::concat(entries, indent, "};%n;");
+
     let base = String::concat(indent, "class ", name, " : public __CoreCpp::Boxed<", datasize, "> {%n;");
     let def = String::concat(indent, "public:%n;", full_indent, name, "() noexcept = default;%n;");
     let assign = String::concat(full_indent, name, "(const ", name, "& rhs) noexcept = default;%n;");
@@ -1170,14 +1188,14 @@ function emitDatatypeTypeDecl(dt: CPPAssembly::DatatypeTypeDecl, ctx: Context, i
     let template = String::concat(full_indent, "template<typename T>%n;");
 
     let cons = if(datasize === "0") then String::concat(full_indent, name, "(__CoreCpp::TypeInfoBase* ti) noexcept : Boxed(ti) {};%n;%n;")
-        else if(datasize === "1") then String::concat(template, full_indent, name, "(__CoreCpp::TypeInfoBase* ti, T d) noexcept : Boxed(ti, reinterpret_cast<uintptr_t*>(&d)) {};%n;%n;")
-        else String::concat(template, full_indent, name, "(__CoreCpp::TypeInfoBase* ti, T d) noexcept : Boxed(ti, reinterpret_cast<uintptr_t(*)[", datasize, "]>(&d)) {};%n;%n;");
+        else if(datasize === "1") then String::concat(template, full_indent, name, "(__CoreCpp::TypeInfoBase* ti, T d) noexcept : Boxed(ti, *reinterpret_cast<uintptr_t*>(&d)) {};%n;%n;")
+        else String::concat(template, full_indent, name, "(__CoreCpp::TypeInfoBase* ti, T d) noexcept : Boxed(ti, *reinterpret_cast<uintptr_t(*)[", datasize, "]>(&d)) {};%n;%n;");
     let allcons = String::concat(def, assign, copy, cons);
 
     let access = if(datasize === "0") then String::concat(template, full_indent, "constexpr T access() noexcept { return T{}; }%n;")
         else String::concat(template, full_indent, "constexpr T access() noexcept { return *reinterpret_cast<T*>(&this->data); }%n;");
 
-    return String::concat(base, allcons, access, indent, "};%n;");
+    return String::concat(basetype, base, allcons, access, indent, "};%n;");
 }
 
 function emitEnumTypeDecl(etd: CPPAssembly::EnumTypeDecl, ctx: Context, indent: String): String {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -506,12 +506,15 @@ function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSign
     }
 }
 
-function emitITestAsConvert(itc: CPPAssembly::PostfixAsConvert, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
-    if(ctx.asm.lookupNominalTypeDeclaration(baseType.tkeystr)?<CPPAssembly::OptionTypeDecl>) {
+function emitITestAsConvert(itc: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, ctx: Context): (|String, CPPAssembly::TypeSignature|) {
+    let ant = ctx.asm.lookupNominalTypeDeclaration(baseType.tkeystr);
+    
+    if(ant)@<CPPAssembly::OptionTypeDecl> {
         let tinfo = ctx.asm.typeinfos.get(baseType.tkeystr);
         let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
 
-        return String::concat(accessor, "some().value");
+        %% Lets also return the type we convert to
+        return (|String::concat(accessor, "some().value"), $ant.oftype|);
     }
     else {
         abort; %% Only options are supported for now
@@ -527,7 +530,7 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
             CPPAssembly::PostfixAccessFromName => { return String::concat(acc, emitPostfixAccessFromName($op, ctx)); }
             | CPPAssembly::PostfixAccessFromIndex => { return emitPostfixAccessFromIndex($op, acc, ctx); }
             | CPPAssembly::PostfixIsTest => { return String::concat(acc, emitITestAsTest($op.ttest, $op.baseType, ctx)); }
-            | CPPAssembly::PostfixAsConvert => { return String::concat(acc, emitITestAsConvert($op, $op.baseType, ctx)); }
+            | CPPAssembly::PostfixAsConvert => { return String::concat(acc, emitITestAsConvert($op.ttest, $op.baseType, ctx).0); }
             | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, rootExp, ctx); } %% This will not chain method calls :(
             | CPPAssembly::PostfixBoolConstant => { return if($op.value === true) then "true" else "false"; }
         }
@@ -747,8 +750,21 @@ function emitIfTestStatement(stmt: CPPAssembly::IfTestStatement, ctx: Context, i
     return String::concat(ifstmt, trueBlock, indent, "}");
 }
 
-function emitIfBinderStatement(stmt: CPPAssembly::IfStatement, ctx: Context, indent: String): String {
-    abort; %% TODO: Not Implemented!    
+function emitIfBinderStatement(stmt: CPPAssembly::IfBinderStatement, ctx: Context, indent: String): String {
+    let full_indent = String::concat("    ", indent);
+    
+    let expr = emitExpression(stmt.cond, ctx);
+    let itest = String::concat(expr, emitITestAsTest(stmt.itest, stmt.cond.etype, ctx));
+    let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
+
+    let bname = emitVarIdentifier(stmt.binder.srcname);
+    let convert = emitITestAsConvert(stmt.itest, stmt.cond.etype, ctx);
+    let reasign = String::concat(bname, " = ", expr, convert.0);
+
+    let tbassign = String::concat(full_indent, emitTypeSignature(convert.1, false, ctx), " ", reasign, ";%n;");
+
+    let ifstmt = String::concat(indent, "if( ", itest, " ) {%n;");
+    return String::concat(ifstmt, tbassign, trueBlock, indent, "}%n;");
 }
 
 function emitIfStatement(stmt: CPPAssembly::IfStatement, ctx: Context, indent: String): String {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -481,7 +481,9 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, rootexp: 
         let rootexptype = emitTypeSignature(rootexp.etype, false, ctx);
         let rootdef = ctx.asm.lookupNominalTypeDeclaration(op.resolvedType.tkeystr);
         let coerceroottype = emitTypeKey(rootdef.tkey, false, ctx);
-        thisarg = String::concat(coerceroottype, "{ &", rootexptype, "Type, ", exp, "}"); 
+    
+        thisarg = if(rootdef.saturatedBFieldInfo.size() === 0n) then String::concat(coerceroottype, "{ &", rootexptype, "Type }")
+            else String::concat(coerceroottype, "{ &", rootexptype, "Type, ", exp, " }"); 
     }
     else {
         thisarg = exp;
@@ -643,12 +645,15 @@ function emitConstructorStdExpression(exp: CPPAssembly::ConstructorStdExpression
     if(tinfo.tag === CPPAssembly::Tag#Ref) {
         return String::concat("new ", cons); %% We use new solely to keep the code compiling before GC integration
     }
-    elif(ctx.asm.datatypes.has(exp.ctype.tkeystr)) { %% This feels odd, should inspect this
-        let dm = ctx.asm.datamembers.get(exp.ctype.tkeystr);
-        let pts = emitTypeSignature(dm.parentTypeDecl@<CPPAssembly::TypeSignature>, false, ctx);
-        let dmts = emitTypeKey(dm.tkey, false, ctx);
+    elif(ctx.asm.datatypes.has(exp.ctype.tkeystr)) { 
+        %* TODO: This is wrong...
+        let pts = emitTypeSignature(exp.ctype, false, ctx);
+        let dmts = emitTypeKey(exp.ctype.tkey, false, ctx);
 
-        return String::concat(pts, "{ &", dmts, "Type, ", cons, " }");
+        return if(dm.saturatedBFieldInfo.size() === 0n) then String::concat(pts, "{ &", dmts, "Type }")
+            else String::concat(pts, "{ &", dmts, "Type, ", cons, " }");
+        *%
+        abort;
     }
     elif(ctx.asm.concepts.has(exp.ctype.tkeystr)) {
         abort; %% TODO: Concept constructors!
@@ -1135,19 +1140,22 @@ function emitDatatypeTypeDecl(dt: CPPAssembly::DatatypeTypeDecl, ctx: Context, i
 
     let name = emitTypeKey(dt.tkey, false, nctx);
 
-    %%
-    %% Lets make this derive from Boxed<K> instead (with some slight modifications)
-    %%
-
-    let base = String::concat(indent, "class ", name, " : public __CoreCpp::DataType<", datasize, "> {%n;");
+    let base = String::concat(indent, "class ", name, " : public __CoreCpp::Boxed<", datasize, "> {%n;");
     let def = String::concat(indent, "public:%n;", full_indent, name, "() noexcept = default;%n;");
     let assign = String::concat(full_indent, name, "(const ", name, "& rhs) noexcept = default;%n;");
     let copy = String::concat(full_indent, name, "& operator=(const ", name, "& rhs) noexcept = default;%n;");
 
-    let cons = String::concat(full_indent, "template<typename T>%n;", full_indent, name, "(__CoreCpp::TypeInfoBase* ti, T d) noexcept : DataType(ti, reinterpret_cast<uintptr_t*>(&d)) {};%n;");
+    let template = String::concat(full_indent, "template<typename T>%n;");
+
+    let cons = if(datasize === "0") then String::concat(full_indent, name, "(__CoreCpp::TypeInfoBase* ti) noexcept : Boxed(ti) {};%n;")
+        else if(datasize === "1") then String::concat(template, full_indent, name, "(__CoreCpp::TypeInfoBase* ti, T d) noexcept : Boxed(ti, reinterpret_cast<uintptr_t*>(&d)) {};%n;")
+        else String::concat(template, full_indent, name, "(__CoreCpp::TypeInfoBase* ti, T d) noexcept : Boxed(ti, reinterpret_cast<uintptr_t(*)[", datasize, "]>(&d)) {};%n;");
     let allcons = String::concat(def, assign, copy, cons);
 
-    return String::concat(base, allcons, indent, "};%n;");
+    let access = if(datasize === "0") then String::concat(template, full_indent, "constexpr T access() noexcept { return T{}; }%n;")
+        else String::concat(template, full_indent, "constexpr T access() noexcept { return *reinterpret_cast<T*>(&this->data); }%n;");
+
+    return String::concat(base, allcons, access, indent, "};%n;");
 }
 
 function emitEnumTypeDecl(etd: CPPAssembly::EnumTypeDecl, ctx: Context, indent: String): String {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -147,32 +147,35 @@ function emitTypeSignature(ts: CPPAssembly::TypeSignature, isParamField: Bool, c
     }
 }
 
-function emitTypeKey(tk: CPPAssembly::TypeKey, isParamField: Bool, ctx: Context): String {
+function emitTypeKeyBase(tk: CPPAssembly::TypeKey, isParamField: Bool, ctx: Context): String {
     let emit = emitResolvedNamespace(ctx.fullns_list, emitResolvedTemplates(some(tk), none, ctx)); 
-    let asnominal = ctx.asm.lookupNominalTypeDeclaration(tk);
-
-    %% explicitly emit core prefix where necessary
-    var resolveddef: String;
-    if(ctx.fullns_list.get(0n) === 'Core') {
-        resolveddef = emit;
-    }
-    elif(asnominal?<CPPAssembly::OptionTypeDecl> || asnominal?<CPPAssembly::SomeTypeDecl>) {
-        resolveddef = String::concat("Core::", emit);
-    }
-    else {
-        resolveddef = emit;
-    }
 
     if(isParamField) {
         let tinfo = ctx.asm.typeinfos.tryGet(tk)@some;
 
         switch(tinfo.tag) {
-            CPPAssembly::Tag#Value => { return resolveddef; }
-            | CPPAssembly::Tag#Ref => { return String::concat(resolveddef, "*"); }
-            | CPPAssembly::Tag#Tagged => { abort; } %% Not fully confident on how to handle this quite yet
+            CPPAssembly::Tag#Value => { return emit; }
+            | CPPAssembly::Tag#Ref => { return String::concat(emit, "*"); }
+            | CPPAssembly::Tag#Tagged => { return emit; }
         }
     }
-    return resolveddef;
+    return emit;
+}
+
+function emitTypeKey(tk: CPPAssembly::TypeKey, isParamField: Bool, ctx: Context): String {
+    let asnominal = ctx.asm.lookupNominalTypeDeclaration(tk);
+    let emit = emitTypeKeyBase(tk, isParamField, ctx);
+
+    %% explicitly emit core prefix where necessary
+    if(ctx.fullns_list.get(0n) === 'Core') {
+        return emit;
+    }
+    elif(asnominal?<CPPAssembly::OptionTypeDecl> || asnominal?<CPPAssembly::SomeTypeDecl>) {
+        return String::concat("Core::", emit);
+    }
+    else {
+        return emit;
+    }
 }
 
 function emitIdentifier(i: CPPAssembly::Identifier): String {
@@ -228,8 +231,17 @@ function emitLiteralNoneExpression(exp: CPPAssembly::LiteralNoneExpression, ctx:
     return "INTPTR_MAX";
 }
 
-function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression): String {
-    return emitVarIdentifier(exp.vname);
+function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression, ctx: Context): String {
+    let access = emitVarIdentifier(exp.vname);
+    let etype = exp.layouttype;
+
+    %% Will need to do something similar for concepts
+    if(ctx.asm.datatypes.has(etype.tkeystr)) {
+        let emitetype = emitTypeKey(etype.tkeystr, false, ctx);
+        return String::concat(access, ".access<", emitetype, ">()");
+    }
+
+    return access;
 }
 
 function emitReturnSingleStatement(ret: CPPAssembly::ReturnSingleStatement, ctx: Context, indent: String): String {
@@ -455,20 +467,33 @@ function emitPostfixAccessFromIndex(op: CPPAssembly::PostfixAccessFromIndex, acc
     return String::concat(acc, ".access<", accessed, ", ", idx, ">()");
 }
 
-function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: String, ctx: Context): String {
+function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, rootexp: CPPAssembly::Expression, ctx: Context): String {
     %% We don't want to do any resolution of these keys yet
     let ik = String::fromCString(op.resolvedTrgt.value);
     let tk = String::fromCString(op.resolvedType.tkeystr.value);
 
     let args = emitArgumentList(op.args, ctx);
-    
+    let exp = emitExpression(rootexp, ctx);
+
+    %% Case where rootexps type provides some concept, and the method we call is declared in the concept not rootexp
+    var thisarg: String;
+    if(!ctx.asm.areTypesSame(rootexp.etype, op.resolvedType)) {
+        let rootexptype = emitTypeSignature(rootexp.etype, false, ctx);
+        let rootdef = ctx.asm.lookupNominalTypeDeclaration(op.resolvedType.tkeystr);
+        let coerceroottype = emitTypeKey(rootdef.tkey, false, ctx);
+        thisarg = String::concat(coerceroottype, "{ &", rootexptype, "Type, ", exp, "}"); 
+    }
+    else {
+        thisarg = exp;
+    }
+
     %% Remove abstract nominal we were in
     var resolvedInvoke = emitSpecialTemplate(ik.removePrefixString(tk).removePrefixString("::"));
     if(args === "") {
-        return String::concat(resolvedInvoke, "(", expr, ")");
+        return String::concat(resolvedInvoke, "(", thisarg, ")");
     }
     else {
-         return String::concat(resolvedInvoke, "(", expr, ", ", args, ")");       
+         return String::concat(resolvedInvoke, "(", thisarg, ", ", args, ")");       
     }
 }
 
@@ -575,7 +600,7 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
             | CPPAssembly::PostfixAccessFromIndex => { return emitPostfixAccessFromIndex($op, acc, ctx); }
             | CPPAssembly::PostfixIsTest => { return String::concat(acc, emitITestAsTest($op.ttest, $op.baseType, ctx)); }
             | CPPAssembly::PostfixAsConvert => { return String::concat(acc, emitITestAsConvert($op.ttest.isnot, $op.ttest, $op.baseType, ctx).0); }
-            | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, rootExp, ctx); } %% This will not chain method calls :(
+            | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, pop.rootExp, ctx); } %% This will not chain method calls :(
             | CPPAssembly::PostfixBoolConstant => { return if($op.value === true) then "true" else "false"; }
             | CPPAssembly::PostfixAccessSomeValue => { return emitPostfixAccessSomeValue($op, acc, pop.rootExp.etype, ctx); }
         }
@@ -612,10 +637,25 @@ function emitConstructorPrimarySpecialConstructableExpression(exp: CPPAssembly::
 function emitConstructorStdExpression(exp: CPPAssembly::ConstructorStdExpression, ctx: Context): String {
     let emitargs = emitArgumentList(exp.args, ctx); 
     let name = emitTypeSignature(exp.ctype, false, ctx);
-    if(ctx.asm.typeinfos.get(exp.ctype.tkeystr).tag === CPPAssembly::Tag#Ref) {
-        return String::concat("new ", name, "{ ", emitargs, " }"); %% We use new solely to keep the code compiling before GC integration
+    let tinfo = ctx.asm.typeinfos.get(exp.ctype.tkeystr);
+
+    let cons = String::concat(name, "{ ", emitargs, " }");
+    if(tinfo.tag === CPPAssembly::Tag#Ref) {
+        return String::concat("new ", cons); %% We use new solely to keep the code compiling before GC integration
     }
-    return String::concat(name, "{ ", emitargs, " }"); 
+    elif(ctx.asm.datatypes.has(exp.ctype.tkeystr)) { %% This feels odd, should inspect this
+        let dm = ctx.asm.datamembers.get(exp.ctype.tkeystr);
+        let pts = emitTypeSignature(dm.parentTypeDecl@<CPPAssembly::TypeSignature>, false, ctx);
+        let dmts = emitTypeKey(dm.tkey, false, ctx);
+
+        return String::concat(pts, "{ &", dmts, "Type, ", cons, " }");
+    }
+    elif(ctx.asm.concepts.has(exp.ctype.tkeystr)) {
+        abort; %% TODO: Concept constructors!
+    }
+    else {
+        return cons;
+    } 
 }
 
 function emitConstructorEListExpression(exp: CPPAssembly::ConstructorEListExpression, ctx: Context): String {
@@ -642,14 +682,22 @@ function emitConstructorExpression(exp: CPPAssembly::ConstructorExpression, ctx:
     }
 }
 
+function emitIfTestExpression(exp: CPPAssembly::IfTestExpression, i: String, t: String, e: String, ctx: Context): String {
+    let itest = emitITestAsTest(exp.itest, exp.texp.etype, ctx);
+
+    return String::concat(itest, " ? ", t, " : ", e);
+}
+
+
 function emitIfExpression(exp: CPPAssembly::IfExpression, ctx: Context): String {
     let texp = emitExpression(exp.texp, ctx);
     let thenexp = emitExpression(exp.thenexp, ctx);
     let elseexp = emitExpression(exp.elseexp, ctx);
 
-    match(exp) {
+    match(exp)@ {
         CPPAssembly::IfSimpleExpression => { return String::concat(texp, " ? ", thenexp, " : ", elseexp); }
-        | _ => { abort; } %% TODO: Not Implemented
+        | CPPAssembly::IfTestExpression => { return emitIfTestExpression($exp, texp, thenexp, elseexp, ctx); }
+        | CPPAssembly::IfBinderExpression => { abort; }
     }
 }
 
@@ -730,7 +778,7 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): String {
         %%| CPPAssembly::AccessNamespaceConstantExpression => { abort; }
         %%| CPPAssembly::AccessStaticFieldExpression => { abort; } 
         | CPPAssembly::AccessEnumExpression => { return emitAccessEnumExpression($e, ctx); }
-        | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e); }
+        | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e, ctx); }
         %%| CPPAssembly::AccessCapturedVariableExpression => { abort; }
         | CPPAssembly::ConstructorExpression => { return emitConstructorExpression($e, ctx); }
         | CPPAssembly::ConstructorPrimaryExpression => { return emitConstructorPrimaryExpression($e, ctx); }
@@ -1049,7 +1097,6 @@ function emitEntityTypeDecl(e: CPPAssembly::EntityTypeDecl, declaredIn: CPPAssem
     let e_enum = generateEntriesEnum(e@<CPPAssembly::AbstractNominalTypeDecl>, e.fields, ctx, indent);
     let e_vtable = generateVTable(e@<CPPAssembly::AbstractNominalTypeDecl>, e.fields, ctx, indent);
     let e_tinfo = emitTypeInfo(ctx.asm.typeinfos.get(e.tkey), some(e), ctx, indent);
-    let e_methods = emitMethods(e@<CPPAssembly::AbstractNominalTypeDecl>, declaredIn, ctx, indent);    
 
     let base = String::concat(e_enum, e_vtable, e_tinfo);
 
@@ -1058,7 +1105,7 @@ function emitEntityTypeDecl(e: CPPAssembly::EntityTypeDecl, declaredIn: CPPAssem
             return String::concat(acc, emitSaturatedFieldInfo(entry, nctx, String::concat("    ", indent)));
     });
 
-    return String::concat(entries, indent, "};%n;", e_methods);
+    return String::concat(entries, indent, "};%n;");
 }
 
 function emitDatatypeMemberEntityDecl(dm: CPPAssembly::DatatypeMemberEntityTypeDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
@@ -1068,7 +1115,6 @@ function emitDatatypeMemberEntityDecl(dm: CPPAssembly::DatatypeMemberEntityTypeD
     let dm_enum = generateEntriesEnum(dm@<CPPAssembly::AbstractNominalTypeDecl>, dm.fields, ctx, indent);
     let dm_vtable = generateVTable(dm@<CPPAssembly::AbstractNominalTypeDecl>, dm.fields, ctx, indent);
     let dm_tinfo = emitTypeInfo(ctx.asm.typeinfos.get(dm.tkey), some(dm), ctx, indent);
-    let dm_methods = emitMethods(dm@<CPPAssembly::AbstractNominalTypeDecl>, declaredIn, ctx, indent);
 
     let base = String::concat(dm_enum, dm_vtable, dm_tinfo);
 
@@ -1077,16 +1123,21 @@ function emitDatatypeMemberEntityDecl(dm: CPPAssembly::DatatypeMemberEntityTypeD
             return String::concat(acc, emitSaturatedFieldInfo(entry, nctx, String::concat("    ", indent)));
     });
 
-    return String::concat(fields, indent, "};%n;", dm_methods);
+    return String::concat(fields, indent, "};%n;");
 }
 
-function emitDatatypeTypeDecl(dm: CPPAssembly::DatatypeTypeDecl, ctx: Context, indent: String): String {
+function emitDatatypeTypeDecl(dt: CPPAssembly::DatatypeTypeDecl, ctx: Context, indent: String): String {
+    let nctx = ctx.updateCurrentNamespace(dt.declaredInNS, dt.fullns);
     let full_indent = String::concat("    ", indent);
 
-    let tinfo = ctx.asm.typeinfos.get(dm.tkey);
+    let tinfo = ctx.asm.typeinfos.get(dt.tkey);
     let datasize = String::fromCString((tinfo.slotsize - 1n).toCString()); %% Ignore typeinfo pointer
 
-    let name = String::fromCString(dm.name);
+    let name = emitTypeKey(dt.tkey, false, nctx);
+
+    %%
+    %% Lets make this derive from Boxed<K> instead (with some slight modifications)
+    %%
 
     let base = String::concat(indent, "class ", name, " : public __CoreCpp::DataType<", datasize, "> {%n;");
     let def = String::concat(indent, "public:%n;", full_indent, name, "() noexcept = default;%n;");
@@ -1395,7 +1446,15 @@ function emitNamespaceDeclTypes(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context
             return String::concat(acc, def);
     });
 
-    return String::concat(other, indent, "}%n;");
+    %% Emit methods after all type defintions to prevent types not being fully defined but used
+    let methods = nsdecl.alltypes
+        .reduce<String>(String::concat(other, "//%n;// All Methods%n;//%n;"), fn(acc, tk) => {
+            let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
+            let func = emitMethods(ant, tk, ctx, full_indent);
+            return String::concat(acc, func);
+    });
+
+    return String::concat(methods, indent, "}%n;");
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): String {    

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -225,7 +225,7 @@ function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression):
 }
 
 function emitLiteralNoneExpression(exp: CPPAssembly::LiteralNoneExpression, ctx: Context): String {
-    return "UINT64_MAX";
+    return "INTPTR_MAX";
 }
 
 function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression): String {
@@ -472,6 +472,16 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: Str
     }
 }
 
+%% I think we need to do the none convert somehow here
+%% If somehow somethign that is not a some gets passed in here we will see some weird output...
+function emitPostfixAccessSomeValue(isnot: Bool, op: CPPAssembly::PostfixAccessSomeValue, acc: String, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
+    %% We should make this a method, we use it in itest convert
+    let tinfo = ctx.asm.typeinfos.get(baseType.tkeystr);
+    let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
+
+    return String::concat(acc, accessor, "some().value"); 
+}
+
 function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
     %% For now we only support ITests where both types are concrete
     if(ctx.asm.isNominalTypeConcrete(it.ttype.tkeystr) && ctx.asm.isNominalTypeConcrete(baseType.tkeystr)) {
@@ -506,18 +516,47 @@ function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSign
     }
 }
 
-function emitITestAsConvert(itc: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, ctx: Context): (|String, CPPAssembly::TypeSignature|) {
-    let ant = ctx.asm.lookupNominalTypeDeclaration(baseType.tkeystr);
-    
-    if(ant)@<CPPAssembly::OptionTypeDecl> {
+function emitITestAsConvertNone(isnot: Bool, baseType: CPPAssembly::TypeSignature, ctx: Context): (|String, CPPAssembly::TypeSignature|) {
+    if(isnot) {
+        return emitITestAsConvertSome(false, baseType, ctx);
+    }
+    else {
         let tinfo = ctx.asm.typeinfos.get(baseType.tkeystr);
         let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
 
-        %% Lets also return the type we convert to
-        return (|String::concat(accessor, "some().value"), $ant.oftype|);
+        %% No clue if this is the best way to fabricate our none type
+        return (|String::concat(accessor, "none()"), CPPAssembly::NominalTypeSignature{ CPPAssembly::TypeKey::from('__CoreCpp::None') }|);
+    }
+}
+
+function emitITestAsConvertSome(isnot: Bool, baseType: CPPAssembly::TypeSignature, ctx: Context): (|String, CPPAssembly::TypeSignature|) {
+    let ant = ctx.asm.lookupNominalTypeDeclaration(baseType.tkeystr);
+    
+    if(ant)@<CPPAssembly::OptionTypeDecl> {
+        if(isnot) {
+            return emitITestAsConvertNone(true, baseType, ctx);
+        }
+        else {
+            let tinfo = ctx.asm.typeinfos.get(baseType.tkeystr);
+            let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
+
+            %% Lets also return the type we convert to
+            return (|String::concat(accessor, "some().value"), $ant.oftype|);
+        }
     }
     else {
         abort; %% Only options are supported for now
+    }
+}
+
+
+function emitITestAsConvert(isnot: Bool, itc: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, ctx: Context): (|String, CPPAssembly::TypeSignature|) {
+    match(itc)@ {
+        CPPAssembly::ITestType => { abort; }
+        | CPPAssembly::ITestNone => { return emitITestAsConvertNone(isnot, baseType, ctx); }
+        | CPPAssembly::ITestSome => { return emitITestAsConvertSome(isnot, baseType, ctx); }
+        | CPPAssembly::ITestOk => { abort; }
+        | CPPAssembly::ITestFail => { abort; }
     }
 }
 
@@ -530,9 +569,10 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
             CPPAssembly::PostfixAccessFromName => { return String::concat(acc, emitPostfixAccessFromName($op, ctx)); }
             | CPPAssembly::PostfixAccessFromIndex => { return emitPostfixAccessFromIndex($op, acc, ctx); }
             | CPPAssembly::PostfixIsTest => { return String::concat(acc, emitITestAsTest($op.ttest, $op.baseType, ctx)); }
-            | CPPAssembly::PostfixAsConvert => { return String::concat(acc, emitITestAsConvert($op.ttest, $op.baseType, ctx).0); }
+            | CPPAssembly::PostfixAsConvert => { return String::concat(acc, emitITestAsConvert($op.ttest.isnot, $op.ttest, $op.baseType, ctx).0); }
             | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, rootExp, ctx); } %% This will not chain method calls :(
             | CPPAssembly::PostfixBoolConstant => { return if($op.value === true) then "true" else "false"; }
+            | CPPAssembly::PostfixAccessSomeValue => { return emitPostfixAccessSomeValue($op, acc, pop.rootExp.etype, ctx); }
         }
     });
 }
@@ -758,10 +798,10 @@ function emitIfBinderStatement(stmt: CPPAssembly::IfBinderStatement, ctx: Contex
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
 
     let bname = emitVarIdentifier(stmt.binder.srcname);
-    let convert = emitITestAsConvert(stmt.itest, stmt.cond.etype, ctx);
+    let convert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, stmt.cond.etype, ctx);
     let reasign = String::concat(bname, " = ", expr, convert.0);
 
-    let tbassign = String::concat(full_indent, emitTypeSignature(convert.1, false, ctx), " ", reasign, ";%n;");
+    let tbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeSignature(convert.1, false, ctx), " ", reasign, ";%n;");
 
     let ifstmt = String::concat(indent, "if( ", itest, " ) {%n;");
     return String::concat(ifstmt, tbassign, trueBlock, indent, "}%n;");
@@ -777,6 +817,7 @@ function emitIfStatement(stmt: CPPAssembly::IfStatement, ctx: Context, indent: S
     }
 }
 
+%% May want to remove some o the repetitive code in the 3 flavours of ifelse
 function emitIfElseSimpleStatement(stmt: CPPAssembly::IfElseSimpleStatement, ctx: Context, indent: String): String {
     let expr = emitExpression(stmt.cond, ctx);
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
@@ -798,8 +839,28 @@ function emitIfElseTestStatement(stmt: CPPAssembly::IfElseTestStatement, ctx: Co
     return String::concat(ifstmt, trueBlock, indent, "}%n;", elseBlockText);
 }
 
-function emitIfElseBinderStatement(stmt: CPPAssembly::IfElseBinderStatement, ctx: Context, ident: String): String {
-    abort; %% TODO: Not Implemented!
+%% Looks like we will need also to handle else bind case
+function emitIfElseBinderStatement(stmt: CPPAssembly::IfElseBinderStatement, ctx: Context, indent: String): String {
+    let full_indent = String::concat("    ", indent);
+    
+    let expr = emitExpression(stmt.cond, ctx);
+    let itest = String::concat(expr, emitITestAsTest(stmt.itest, stmt.cond.etype, ctx));
+
+    let bname = emitVarIdentifier(stmt.binder.srcname); 
+    let tconvert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, stmt.cond.etype, ctx); 
+    let treasign = String::concat(bname, " = ", expr, tconvert.0);
+    let tbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeSignature(tconvert.1, false, ctx), " ", treasign, ";%n;");
+
+    let fconvert = emitITestAsConvert(!stmt.itest.isnot, stmt.itest, stmt.cond.etype, ctx); 
+    let freasign = String::concat(bname, " = ", expr, fconvert.0);
+    let fbassign = String::concat(full_indent, "[[maybe_unused]] ", emitTypeSignature(fconvert.1, false, ctx), " ", freasign, ";%n;");
+
+    let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
+    let falseBlock = emitBlockStatement(stmt.falseBlock, ctx, indent);
+    let elseBlockText = String::concat(indent, "else {%n;", fbassign, falseBlock, indent, "}%n;");
+    
+    let ifstmt = String::concat(indent, "if( ", itest, " ) {%n;"); 
+    return String::concat(ifstmt, tbassign, trueBlock, indent, "}%n;", elseBlockText);
 }
 
 function emitIfElseStatement(stmt: CPPAssembly::IfElseStatement, ctx: Context, indent: String): String {
@@ -1199,9 +1260,10 @@ function emitPrimtiveConceptTypeDecl(pc: CPPAssembly::PrimitiveConceptTypeDecl, 
     let nonecons = String::concat(indenttkey, "(__CoreCpp::TypeInfoBase* ti) noexcept : Boxed(ti) {};%n;%n;");
 
     let someaccessor = String::concat(full_indent, sometkey, " some() noexcept { return *reinterpret_cast<", sometkey,"*>(&this->data); }%n;");
+    let noneaccessor = String::concat(full_indent, "__CoreCpp::None none() noexcept { return INTPTR_MAX; }%n;");
 
     let cons = String::concat(defaultc, assign, copy, somecons, nonecons);
-    return String::concat(visibility, cons, someaccessor, indent, "};%n;");
+    return String::concat(visibility, cons, someaccessor, noneaccessor, indent, "};%n;");
 }
 
 recursive function emitFuncForwardDeclarations(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: String): String {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -463,7 +463,23 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, rootexp: 
     let tk = String::fromCString(op.resolvedType.tkeystr.value);
 
     let args = emitArguments(op.args, ctx);
-    
+    let exp = emitExpression(rootexp, ctx);
+
+    %% The "this" arguemnt does not exist in explicitify so we handle the coersion here (we manually added it for cpp emission)
+    var thisarg: String;
+    if(!ctx.asm.areTypesSame(rootexp.etype, op.resolvedType)) {
+        let rootexptype = emitTypeSignature(rootexp.etype, false, ctx);
+        let roottinfo = ctx.asm.typeinfos.get(rootexp.etype.tkeystr);
+        let targettype = emitTypeKey(op.resolvedType.tkeystr, false, ctx);
+
+        let slotsize = if(roottinfo.tag === CPPAssembly::Tag#Tagged) then roottinfo.slotsize - 1n else roottinfo.slotsize;
+        thisarg = if(slotsize == 0n) then String::concat(targettype, "{ &", rootexptype, "Type }")
+            else String::concat(targettype, "{ &", rootexptype, "Type, ", exp, " }"); 
+    }
+    else {
+        thisarg = exp;
+    } 
+
     %% Remove abstract nominal we were in
     var resolvedInvoke = emitSpecialTemplate(ik.removePrefixString(tk).removePrefixString("::"));
     if(args === "") {
@@ -474,10 +490,7 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, rootexp: 
     }
 }
 
-%% I think we need to do the none convert somehow here
-%% If somehow somethign that is not a some gets passed in here we will see some weird output...
 function emitPostfixAccessSomeValue(op: CPPAssembly::PostfixAccessSomeValue, acc: String, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
-    %% We should make this a method, we use it in itest convert
     let tinfo = ctx.asm.typeinfos.get(baseType.tkeystr);
     let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
 
@@ -586,7 +599,7 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
 
 function emitConstructorPrimarySpecialSomeExpression(cpsse: CPPAssembly::ConstructorPrimarySpecialSomeExpression, ctx: Context): String {
     let value = emitExpression(cpsse.value, ctx);
-    let sometype = String::concat("Core::", emitTypeSignature(cpsse.ctype, false, ctx));
+    let sometype = emitTypeSignature(cpsse.ctype, false, ctx);
 
     return String::concat(sometype, "{ ", value, "}");
 }
@@ -619,19 +632,6 @@ function emitConstructorStdExpression(exp: CPPAssembly::ConstructorStdExpression
     let cons = String::concat(name, "{ ", emitargs, " }");
     if(tinfo.tag === CPPAssembly::Tag#Ref) {
         return String::concat("new ", cons); %% We use new solely to keep the code compiling before GC integration
-    }
-    elif(ctx.asm.datatypes.has(exp.ctype.tkeystr)) { 
-        %* TODO: This is wrong...
-        let pts = emitTypeSignature(exp.ctype, false, ctx);
-        let dmts = emitTypeKey(exp.ctype.tkey, false, ctx);
-
-        return if(dm.saturatedBFieldInfo.size() === 0n) then String::concat(pts, "{ &", dmts, "Type }")
-            else String::concat(pts, "{ &", dmts, "Type, ", cons, " }");
-        *%
-        abort;
-    }
-    elif(ctx.asm.concepts.has(exp.ctype.tkeystr)) {
-        abort; %% TODO: Concept constructors!
     }
     else {
         return cons;
@@ -668,6 +668,11 @@ function emitIfTestExpression(exp: CPPAssembly::IfTestExpression, i: String, t: 
     return String::concat(itest, " ? ", t, " : ", e);
 }
 
+function emitIfBinderExpression(exp: CPPAssembly::IfBinderExpression, i: String, t: String, e: String, ctx: Context): String {
+    let itest = emitITestAsTest(exp.itest, exp.texp.etype, ctx);
+
+    return String::concat(itest, " ? ", t, " : ", e);
+}
 
 function emitIfExpression(exp: CPPAssembly::IfExpression, ctx: Context): String {
     let texp = emitExpression(exp.texp, ctx);
@@ -677,7 +682,7 @@ function emitIfExpression(exp: CPPAssembly::IfExpression, ctx: Context): String 
     match(exp)@ {
         CPPAssembly::IfSimpleExpression => { return String::concat(texp, " ? ", thenexp, " : ", elseexp); }
         | CPPAssembly::IfTestExpression => { return emitIfTestExpression($exp, texp, thenexp, elseexp, ctx); }
-        | CPPAssembly::IfBinderExpression => { abort; }
+        | CPPAssembly::IfBinderExpression => { return emitIfBinderExpression($exp, texp, thenexp, elseexp, ctx); }
     }
 }
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -244,13 +244,10 @@ function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression
     let access = emitVarIdentifier(exp.vname);
     let etype = exp.layouttype;
 
-    if(ctx.asm.datatypes.has(etype.tkeystr)) {
+    if(etype?!<CPPAssembly::EListTypeSignature> && ctx.asm.isNominalTypeConcept(etype.tkeystr)) {
         let emitetype = emitTypeKey(etype.tkeystr, false, ctx);
         return if(ctx.asm.areTypesSame(etype, exp.etype)) then access 
             else String::concat(access, ".access<", emitetype, ">()");
-    }
-    elif(ctx.asm.concepts.has(etype.tkeystr)) {
-        abort; %% TODO: Do something similar to datatypes for concepts
     }
     else {
         return access;
@@ -594,26 +591,10 @@ function emitITestAsConvertSome(isnot: Bool, fromtype: CPPAssembly::TypeKey, ctx
 function emitITestAsConvertType(isnot: Bool, fromtype: CPPAssembly::TypeKey, totype: CPPAssembly::TypeKey, ctx: Context): (|String, String|) { 
     let tinfo = ctx.asm.typeinfos.get(fromtype);
     let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
-    var ttype: String;
+    let ttype = emitTypeKey(totype, false, ctx);
 
-    if(fromtype.value === totype.value) {
-        let e = ctx.asm.lookupNominalTypeDeclaration(totype);
-        if(e)@!<CPPAssembly::DatatypeTypeDecl> {
-            abort; %% TODO: Concept support
-        }
-        else {
-            ttype = emitTypeKey(totype, false, ctx); 
-
-        }
-    }
-    elif(ctx.asm.isNominalTypeConcept(fromtype)) {
-        ttype = emitTypeKey(totype, false, ctx);
-    }
-    else {
-        abort;
-    }
-
-    return (|String::concat(accessor, "access<", ttype,">()"), ttype|);
+    return if(fromtype.value === totype.value) then (|"", ttype|) 
+        else (|String::concat(accessor, "access<", ttype,">()"), ttype|);
 }
 
 function emitITestAsConvert(isnot: Bool, itc: CPPAssembly::ITest, fromtype: CPPAssembly::TypeKey, totype: Option<CPPAssembly::TypeKey>, ctx: Context): (|String, String|) { %% Convert, Emitted type
@@ -718,7 +699,7 @@ function emitIfTestExpression(exp: CPPAssembly::IfTestExpression, i: String, t: 
 }
 
 function emitIfBinderExpression(exp: CPPAssembly::IfBinderExpression, i: String, t: String, e: String, ctx: Context): String {
-    abort; %% TODO: Not Implemented
+    abort; %% TODO: Not Implemented (need to put bindings in a lambda in emission)
 }
 
 function emitIfExpression(exp: CPPAssembly::IfExpression, ctx: Context): String {
@@ -924,7 +905,6 @@ function emitIfElseTestStatement(stmt: CPPAssembly::IfElseTestStatement, ctx: Co
     return String::concat(ifstmt, trueBlock, indent, "}%n;", elseBlockText);
 }
 
-%% Looks like we will need also to handle else bind case
 function emitIfElseBinderStatement(stmt: CPPAssembly::IfElseBinderStatement, ctx: Context, indent: String): String {
     let full_indent = String::concat("    ", indent);
     
@@ -947,7 +927,7 @@ function emitIfElseBinderStatement(stmt: CPPAssembly::IfElseBinderStatement, ctx
     }
 
     var fbassign: String;
-    if(n == 2n) { %% If only two member entities implicitly convert to entity we are not
+    if(n == 2n) { %% If only two member entities implicitly convert to entity that we are not
         let othermember = concretetype@<CPPAssembly::DatatypeTypeDecl>
             .associatedMemberEntityDecls.find(pred(ets) => !ctx.asm.areTypesSame(ets, stmt.itest@<CPPAssembly::ITestType>.ttype)).tkeystr;
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1080,6 +1080,25 @@ function emitDatatypeMemberEntityDecl(dm: CPPAssembly::DatatypeMemberEntityTypeD
     return String::concat(fields, indent, "};%n;", dm_methods);
 }
 
+function emitDatatypeTypeDecl(dm: CPPAssembly::DatatypeTypeDecl, ctx: Context, indent: String): String {
+    let full_indent = String::concat("    ", indent);
+
+    let tinfo = ctx.asm.typeinfos.get(dm.tkey);
+    let datasize = String::fromCString((tinfo.slotsize - 1n).toCString()); %% Ignore typeinfo pointer
+
+    let name = String::fromCString(dm.name);
+
+    let base = String::concat(indent, "class ", name, " : public __CoreCpp::DataType<", datasize, "> {%n;");
+    let def = String::concat(indent, "public:%n;", full_indent, name, "() noexcept = default;%n;");
+    let assign = String::concat(full_indent, name, "(const ", name, "& rhs) noexcept = default;%n;");
+    let copy = String::concat(full_indent, name, "& operator=(const ", name, "& rhs) noexcept = default;%n;");
+
+    let cons = String::concat(full_indent, "template<typename T>%n;", full_indent, name, "(__CoreCpp::TypeInfoBase* ti, T d) noexcept : DataType(ti, reinterpret_cast<uintptr_t*>(&d)) {};%n;");
+    let allcons = String::concat(def, assign, copy, cons);
+
+    return String::concat(base, allcons, indent, "};%n;");
+}
+
 function emitEnumTypeDecl(etd: CPPAssembly::EnumTypeDecl, ctx: Context, indent: String): String {
     let full_indent = String::concat("    ", indent);
 
@@ -1096,7 +1115,9 @@ function emitAbstractNominalForwardDeclaration(e: CPPAssembly::AbstractNominalTy
     let nctx = ctx.updateCurrentNamespace(e.declaredInNS, e.fullns);
     let tkey = emitTypeKey(e.tkey, false, nctx);
 
-    return String::concat(indent, "struct ", tkey, ";%n;");
+    let dtype = if(e?<CPPAssembly::DatatypeTypeDecl> || e?<CPPAssembly::ConceptTypeDecl>) then "class " else "struct ";
+
+    return String::concat(indent, dtype, tkey, ";%n;");
 }
 
 function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
@@ -1209,7 +1230,7 @@ function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, 
         | CPPAssembly::DatatypeMemberEntityTypeDecl => { return emitDatatypeMemberEntityDecl($ant, declaredIn, ctx, indent); }
         | CPPAssembly::PrimitiveConceptTypeDecl => { return emitPrimtiveConceptTypeDecl($ant, ctx, indent); }
         | CPPAssembly::ConstructableTypeDecl => { return emitConstructableTypeDecl($ant, ctx, indent); }
-        | CPPAssembly::DatatypeTypeDecl => { return ""; } %% Dont emit anything for datatype - the members contain what we care about
+        | CPPAssembly::DatatypeTypeDecl => { return emitDatatypeTypeDecl($ant, ctx, indent); } 
         | CPPAssembly::EnumTypeDecl => { return emitEnumTypeDecl($ant, ctx, indent); }
         | _ => { abort; }
     }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -149,17 +149,30 @@ function emitTypeSignature(ts: CPPAssembly::TypeSignature, isParamField: Bool, c
 
 function emitTypeKey(tk: CPPAssembly::TypeKey, isParamField: Bool, ctx: Context): String {
     let emit = emitResolvedNamespace(ctx.fullns_list, emitResolvedTemplates(some(tk), none, ctx)); 
+    let asnominal = ctx.asm.lookupNominalTypeDeclaration(tk);
+
+    %% explicitly emit core prefix where necessary
+    var resolveddef: String;
+    if(ctx.fullns_list.get(0n) === 'Core') {
+        resolveddef = emit;
+    }
+    elif(asnominal?<CPPAssembly::OptionTypeDecl> || asnominal?<CPPAssembly::SomeTypeDecl>) {
+        resolveddef = String::concat("Core::", emit);
+    }
+    else {
+        resolveddef = emit;
+    }
 
     if(isParamField) {
         let tinfo = ctx.asm.typeinfos.tryGet(tk)@some;
 
         switch(tinfo.tag) {
-            CPPAssembly::Tag#Value => { return emit; }
-            | CPPAssembly::Tag#Ref => { return String::concat(emit, "*"); }
+            CPPAssembly::Tag#Value => { return resolveddef; }
+            | CPPAssembly::Tag#Ref => { return String::concat(resolveddef, "*"); }
             | CPPAssembly::Tag#Tagged => { abort; } %% Not fully confident on how to handle this quite yet
         }
     }
-    return emit;
+    return resolveddef;
 }
 
 function emitIdentifier(i: CPPAssembly::Identifier): String {
@@ -486,9 +499,22 @@ function emitITestNone(it: CPPAssembly::ITestNone, baseType: CPPAssembly::TypeSi
 function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
     match(it)@ {
         CPPAssembly::ITestType => { return emitITestType($it, baseType, ctx); }
-        | CPPAssembly::ITestSome => { return emitITestSome($it, baseType, ctx); }
         | CPPAssembly::ITestNone => { return emitITestNone($it, baseType, ctx); }
-        | _ => { abort; } %% TODO: Not Implemented!
+        | CPPAssembly::ITestSome => { return emitITestSome($it, baseType, ctx); }
+        | CPPAssembly::ITestOk => { abort; }
+        | CPPAssembly::ITestFail => { abort; }
+    }
+}
+
+function emitITestAsConvert(itc: CPPAssembly::PostfixAsConvert, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
+    if(ctx.asm.lookupNominalTypeDeclaration(baseType.tkeystr)?<CPPAssembly::OptionTypeDecl>) {
+        let tinfo = ctx.asm.typeinfos.get(baseType.tkeystr);
+        let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
+
+        return String::concat(accessor, "some().value");
+    }
+    else {
+        abort; %% Only options are supported for now
     }
 }
 
@@ -501,6 +527,7 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
             CPPAssembly::PostfixAccessFromName => { return String::concat(acc, emitPostfixAccessFromName($op, ctx)); }
             | CPPAssembly::PostfixAccessFromIndex => { return emitPostfixAccessFromIndex($op, acc, ctx); }
             | CPPAssembly::PostfixIsTest => { return String::concat(acc, emitITestAsTest($op.ttest, $op.baseType, ctx)); }
+            | CPPAssembly::PostfixAsConvert => { return String::concat(acc, emitITestAsConvert($op, $op.baseType, ctx)); }
             | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, rootExp, ctx); } %% This will not chain method calls :(
             | CPPAssembly::PostfixBoolConstant => { return if($op.value === true) then "true" else "false"; }
         }
@@ -509,7 +536,7 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
 
 function emitConstructorPrimarySpecialSomeExpression(cpsse: CPPAssembly::ConstructorPrimarySpecialSomeExpression, ctx: Context): String {
     let args = cpsse.args.args.map<String>(fn(arg) => emitExpression(arg.exp, ctx) );
-    let sometype = String::concat("Core::", emitTypeSignature(cpsse.ctype, false, ctx));
+    let sometype = emitTypeSignature(cpsse.ctype, false, ctx);
 
     return String::concat(sometype, "{ ", String::joinAll(", ", args), "}");
 }
@@ -585,7 +612,7 @@ function emitWidenedTypeExpression(exp: CPPAssembly::CoerceWidenTypeExpression, 
     let emitexp = emitExpression(exp.exp, ctx);
 
     let fromtkey_size = String::fromCString(ctx.asm.typeinfos.tryGet(fromtkey)@some.slotsize.toCString()); %% This is T
-    let name = String::concat("Core::", emitTypeSignature(tottsig, false, ctx));
+    let name = emitTypeSignature(tottsig, false, ctx);
 
     let ttype = String::concat(emitTypeSignature(exp.srctype, false, ctx), "Type");
 
@@ -593,7 +620,7 @@ function emitWidenedTypeExpression(exp: CPPAssembly::CoerceWidenTypeExpression, 
         return String::concat(name, "{ &", removeCppPrefix(ttype) ," }");
     }
 
-    return String::concat(name, "{ &Core::", ttype, ", ", emitexp, " }");
+    return String::concat(name, "{ &", ttype, ", ", emitexp, " }");
 }
 
 %% We will need this to help us take "this.f?<Int>" to "false"
@@ -692,10 +719,9 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): String {
 function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitializationStatement, ctx: Context, indent: String): String {
     let name = emitIdentifier(stmt.name);
     let stype = emitTypeSignature(stmt.vtype, false, ctx);
-    let resolved_stype = if(stype.startsWithString("Option") || stype.startsWithString("Some")) then String::concat("Core::", stype) else stype;
     let exp = emitExpression(stmt.exp, ctx);
 
-    let full_indent: String = String::concat(indent, "    ", resolved_stype);
+    let full_indent: String = String::concat(indent, "    ", stype);
     return String::concat(full_indent, " ", name, " = ", exp, ";");
 }
 
@@ -1108,11 +1134,13 @@ function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, 
 }
 
 function emitSomeTypeDecl(std: CPPAssembly::SomeTypeDecl, ctx: Context, indent: String): String {
+    let nctx = ctx.updateCurrentNamespace(std.declaredInNS, std.fullns);
+    
     let full_indent = String::concat("    ", indent);
-    let sometype = emitTypeKey(std.tkey, false, ctx);
-    let ttype = emitTypeSignature(std.oftype, true, ctx);
+    let sometype = emitTypeKey(std.tkey, false, nctx);
+    let ttype = emitTypeSignature(std.oftype, true, nctx);
 
-    let std_tinfo = emitTypeInfo(ctx.asm.typeinfos.get(std.tkey), some(std), ctx, indent);
+    let std_tinfo = emitTypeInfo(nctx.asm.typeinfos.get(std.tkey), some(std), nctx, indent);
 
     let value = String::concat(sometype, " {%n;", full_indent, ttype, " value;%n;", indent);
     return String::concat(std_tinfo, indent, "struct ", value, "};%n;");
@@ -1131,12 +1159,14 @@ function emitConstructableTypeDecl(ctd: CPPAssembly::ConstructableTypeDecl, ctx:
 
 %% Note: Only supports options currently
 function emitPrimtiveConceptTypeDecl(pc: CPPAssembly::PrimitiveConceptTypeDecl, ctx: Context, indent: String): String {
+    let nctx = ctx.updateCurrentNamespace(pc.declaredInNS, pc.fullns);
+    
     let full_indent = String::concat("    ", indent);
-    let tkey = emitTypeKey(pc.tkey, false, ctx);
-    let k = String::fromCString((ctx.asm.typeinfos.get(pc.tkey).slotsize - 1n).toCString()); %% Slot size includes "2" ptr to typeinfo, so we ignore
-    let sometkey = emitTypeSignature(pc@<CPPAssembly::OptionTypeDecl>.someType, false, ctx);
+    let tkey = emitTypeKey(pc.tkey, false, nctx);
+    let k = String::fromCString((nctx.asm.typeinfos.get(pc.tkey).slotsize - 1n).toCString()); %% Slot size includes "2" ptr to typeinfo, so we ignore
+    let sometkey = emitTypeSignature(pc@<CPPAssembly::OptionTypeDecl>.someType, false, nctx);
 
-    let pc_tinfo = emitTypeInfo(ctx.asm.typeinfos.get(pc.tkey), some(pc), ctx, indent);
+    let pc_tinfo = emitTypeInfo(nctx.asm.typeinfos.get(pc.tkey), some(pc), nctx, indent);
 
     let def = String::concat(indent, "class ", tkey, " : public __CoreCpp::Boxed<", k, ">{%n;");
     let visibility = String::concat(pc_tinfo, def, indent, "public:%n;");

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -87,6 +87,10 @@ function removeCppPrefix(s: String): String {
     return if(s.startsWithString("__CoreCpp::")) then s.removePrefixString("__CoreCpp::") else s;
 }
 
+function getAbstractConceptBase(s: String): String {
+    return String::concat(s, "ᕮBase");
+}
+
 function convertCStringList(l: List<CString>): List<String> {
     return l.map<String>(fn(e) => String::fromCString(e));
 }
@@ -240,14 +244,17 @@ function emitAccessVariableExpression(exp: CPPAssembly::AccessVariableExpression
     let access = emitVarIdentifier(exp.vname);
     let etype = exp.layouttype;
 
-    %% Will need to do something similar for concepts
     if(ctx.asm.datatypes.has(etype.tkeystr)) {
         let emitetype = emitTypeKey(etype.tkeystr, false, ctx);
-        return if(ctx.asm.areTypesSame(exp.etype, etype)) then access %% No need to call access for the same type
+        return if(ctx.asm.areTypesSame(etype, exp.etype)) then access 
             else String::concat(access, ".access<", emitetype, ">()");
     }
-
-    return access;
+    elif(ctx.asm.concepts.has(etype.tkeystr)) {
+        abort; %% TODO: Do something similar to datatypes for concepts
+    }
+    else {
+        return access;
+    }
 }
 
 function emitReturnSingleStatement(ret: CPPAssembly::ReturnSingleStatement, ctx: Context, indent: String): String {
@@ -444,13 +451,21 @@ function emitCallTypeFunctionExpression(e: CPPAssembly::CallTypeFunctionExpressi
 }
 
 function emitPostfixAccessFromName(op: CPPAssembly::PostfixAccessFromName, ctx: Context): String {
-    let ident = emitIdentifier(op.name);
+    var pre: String;
+    if(ctx.asm.isNominalTypeConcept(op.baseType.tkeystr)) {
+        let name = emitTypeSignature(op.baseType, false, ctx);
+        pre = String::concat(".access<", getAbstractConceptBase(name), ">()");
+    }
+    else {
+        pre = "";
+    }
 
+    let ident = emitIdentifier(op.name);
     let op_tinfo = ctx.asm.typeinfos.get(op.declaredInType.tkeystr);
     switch(op_tinfo.tag) {
-        CPPAssembly::Tag#Value => { return String::concat(".", ident); }
-        | CPPAssembly::Tag#Ref => { return String::concat("->", ident); }
-        | CPPAssembly::Tag#Tagged => { return String::concat(".", ident); } 
+        CPPAssembly::Tag#Value => { return String::concat(pre, ".", ident); }
+        | CPPAssembly::Tag#Ref => { return String::concat(pre, "->", ident); }
+        | CPPAssembly::Tag#Tagged => { return String::concat(pre, ".", ident); } 
     }
 }
 
@@ -517,9 +532,9 @@ function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSi
             return if(it.isnot) then String::concat(".typeinfo != &", ttype, "Type")
                 else String::concat(".typeinfo == &", ttype, "Type");
         }
-
-        %% Handle case where both are abstract (vtable lookup)
-        abort;
+        else {
+            abort; %% Handle case where both are abstract (vtable lookup likely)
+        }
     }
 }
 
@@ -587,7 +602,7 @@ function emitITestAsConvertType(isnot: Bool, fromtype: CPPAssembly::TypeKey, tot
             abort; %% TODO: Concept support
         }
         else {
-            ttype = String::concat(emitTypeKey(totype, false, ctx), "ᕮBase"); 
+            ttype = emitTypeKey(totype, false, ctx); 
 
         }
     }
@@ -1173,7 +1188,7 @@ function emitDatatypeTypeDecl(dt: CPPAssembly::DatatypeTypeDecl, ctx: Context, i
 
     let name = emitTypeKey(dt.tkey, false, nctx);
 
-    %% Emit all fields as a base type to allow for safe access
+    %% If we need to access a field of a datatype without knowing what type defined it use this struct 
     let entries = dt.saturatedBFieldInfo.reduce<String>(String::concat(indent, "struct ", name, "ᕮBase { %n;"), 
         fn(acc, entry) => {
             return String::concat(acc, emitSaturatedFieldInfo(entry, nctx, full_indent));
@@ -1458,12 +1473,7 @@ function emitNamespaceDeclFwdDecls(nsdecl: CPPAssembly::NamespaceDecl, ctx: Cont
             return String::concat(acc, fwddecl);
     });
 
-    let method_fwddecls = nsdecl.staticmethods
-        .reduce<String>("", fn(acc, mtkey) => {
-            return String::concat(acc, emitMethodForwardDeclaration(ctx.asm.staticmethods.get(mtkey.0), mtkey.1, ctx, full_indent));
-    });
-
-    return String::concat(subns_fwddecls, ant_fwddecls, method_fwddecls, "}%n;");
+    return String::concat(subns_fwddecls, ant_fwddecls, "}%n;");
 }
 
 %%
@@ -1496,9 +1506,15 @@ function emitNamespaceDeclTypes(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context
             return String::concat(acc, def);
     });
 
+    %% Only support static methods for now
+    let method_fwddecls = nsdecl.staticmethods
+        .reduce<String>(String::concat(other, "//%n;// All Methods%n;//%n;"), fn(acc, mtkey) => {
+            return String::concat(acc, emitMethodForwardDeclaration(ctx.asm.staticmethods.get(mtkey.0), mtkey.1, ctx, full_indent));
+    });
+
     %% Emit methods after all type defintions to prevent types not being fully defined but used
     let methods = nsdecl.alltypes
-        .reduce<String>(String::concat(other, "//%n;// All Methods%n;//%n;"), fn(acc, tk) => {
+        .reduce<String>(method_fwddecls, fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let func = emitMethods(ant, tk, ctx, full_indent);
             return String::concat(acc, func);
@@ -1516,7 +1532,7 @@ function emitAssembly(asm: CPPAssembly::Assembly): String {
 
     %% Non-value type forward decls
     let fwddecls = asm.nsdecls
-        .reduce<String>(String::concat(primitive_typeinfos, "//%n;// Ref, Tagged Type, and Method Forward Declarations%n;//%n;"),
+        .reduce<String>(String::concat(primitive_typeinfos, "//%n;// Ref and Tagged Type Forward Declarations%n;//%n;"),
         fn(acc, nsname, nsdecl) => {
             return String::concat(acc, emitNamespaceDeclFwdDecls(nsdecl, ctx, ""));
     });

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -474,7 +474,7 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, expr: Str
 
 %% I think we need to do the none convert somehow here
 %% If somehow somethign that is not a some gets passed in here we will see some weird output...
-function emitPostfixAccessSomeValue(isnot: Bool, op: CPPAssembly::PostfixAccessSomeValue, acc: String, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
+function emitPostfixAccessSomeValue(op: CPPAssembly::PostfixAccessSomeValue, acc: String, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
     %% We should make this a method, we use it in itest convert
     let tinfo = ctx.asm.typeinfos.get(baseType.tkeystr);
     let accessor = if(tinfo.tag === CPPAssembly::Tag#Ref) then "->" else ".";
@@ -490,7 +490,12 @@ function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSi
             else if(areTypesSame) then "true" else "false";
     }
     else {
-        abort; %% TODO: ITests on concepts not yet supported!
+        if(ctx.asm.isSubtypeOf(it.ttype, baseType)) { %% This doesnt work
+            return "true";
+        }
+        else {
+            return "false";
+        }
     }
 }
 
@@ -534,7 +539,7 @@ function emitITestAsConvertSome(isnot: Bool, baseType: CPPAssembly::TypeSignatur
     
     if(ant)@<CPPAssembly::OptionTypeDecl> {
         if(isnot) {
-            return emitITestAsConvertNone(true, baseType, ctx);
+            return emitITestAsConvertNone(false, baseType, ctx);
         }
         else {
             let tinfo = ctx.asm.typeinfos.get(baseType.tkeystr);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -323,9 +323,10 @@ entity CPPTransformer {
         let isnot = itest.isnot;
         match(itest)@ {
             BSQAssembly::ITestType => { return this.transformITestType($itest, isnot); }
-            | BSQAssembly::ITestSome => { return this.transformITestSome(isnot); }
             | BSQAssembly::ITestNone => { return this.transformITestNone(isnot); }
-            | _ => { abort; } 
+            | BSQAssembly::ITestSome => { return this.transformITestSome(isnot); }
+            | BSQAssembly::ITestOk => { abort; }
+            | BSQAssembly::ITestFail => { abort; }
         }
     }
 
@@ -342,9 +343,9 @@ entity CPPTransformer {
             | BSQAssembly::PostfixProjectFromNames => { abort; }
             | BSQAssembly::PostfixAccessFromIndex => { return CPPAssembly::PostfixAccessFromIndex{ baseType, $op.idxk }; }
             | BSQAssembly::PostfixIsTest => { return CPPAssembly::PostfixIsTest{ baseType, this.transformITestAsTest($op.ttest) }; }
-            | BSQAssembly::PostfixAsConvert => { abort; }
+            | BSQAssembly::PostfixAsConvert => { return CPPAssembly::PostfixAsConvert{ baseType, this.transformITestAsTest($op.ttest) }; }
             | BSQAssembly::PostfixAssignFields => { abort; }
-            | BSQAssembly::PostfixInvokeStatic => {
+            | BSQAssembly::PostfixInvokeStatic => { %% Maybe move to its own method
                 let resolvedType = CPPTransformNameManager::convertNominalTypeSignature($op.resolvedType);
                 let resolvedTrgt = CPPTransformNameManager::convertInvokeKey($op.resolvedTrgt);
                 let args = this.transformArgumentList($op.argsinfo.args);
@@ -793,7 +794,9 @@ entity CPPTransformer {
     }
 
     %%
-    %% TODO: Need to explicitly handle the tuple case
+    %% When we generate the typeinfo for some<tuple> we will need to explicitly handle how we determine the field size.
+    %% this likely means we need to modify this method to support access of `entries` list or this typesig, walk the fields
+    %% recursively determining their slotsize and typesize to construct our new type. Think of it as a union.
     %%
     recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat, bsqasm: BSQAssembly::Assembly): CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> { 
         let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -446,7 +446,7 @@ entity CPPTransformer {
 
         match(exp)@ {
             BSQAssembly::IfSimpleExpression => { return CPPAssembly::IfSimpleExpression{ etype, texp, thenexp, elseexp }; }
-            | _ => { abort; } %% TODO: Not Implemented 
+            | BSQAssembly::IfTestExpression => { return CPPAssembly::IfTestExpression{ etype, texp, thenexp, elseexp, this.transformITestAsTest($exp.itest) }; } %% TODO: Not Implemented 
         }
     }
 
@@ -1252,10 +1252,7 @@ entity CPPTransformer {
                 return (| acc.0 + 1n, gen_tinfo.1 |);
         });
 
-        %% This may not be right, but for now we dont emit any type info for concepts or datatypes. The types
-        %% who provide them contain all the necessary fields, so this should be unnecessary. 
         let generated_typeinfos_abstract = bsqasm.allabstracttypes
-            .filter(pred(tkey) => !bsqasm.concepts.has(tkey) && !bsqasm.datatypes.has(tkey))
             .reduce<(| Nat, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> |)>(
                 generated_typeinfos_concrete, fn(acc, tkey) => {
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -429,7 +429,8 @@ entity CPPTransformer {
 
         match(exp)@ {
             BSQAssembly::IfSimpleExpression => { return CPPAssembly::IfSimpleExpression{ etype, texp, thenexp, elseexp }; }
-            | BSQAssembly::IfTestExpression => { return CPPAssembly::IfTestExpression{ etype, texp, thenexp, elseexp, this.transformITestAsTest($exp.itest) }; } %% TODO: Not Implemented 
+            | BSQAssembly::IfTestExpression => { return CPPAssembly::IfTestExpression{ etype, texp, thenexp, elseexp, this.transformITestAsTest($exp.itest) }; }
+            | BSQAssembly::IfBinderExpression => { return CPPAssembly::IfBinderExpression{ etype, texp, thenexp, elseexp, this.transformITestAsTest($exp.itest), this.transformBinderInfo($exp.binder) };}
         }
     }
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -113,8 +113,8 @@ namespace CPPTransformNameManager {
         }
     }
 
-    function shouldBeRef(fields: List<BSQAssembly::MemberFieldDecl>, asm: BSQAssembly::Assembly): Bool {
-        let fieldsPrimitive = fields.reduce<Bool>(true, fn(acc, f) => acc && asm.isPrimtitiveType(f.declaredType.tkeystr));
+    function shouldBeRef(fields: List<BSQAssembly::SaturatedFieldInfo>, asm: BSQAssembly::Assembly): Bool {
+        let fieldsPrimitive = fields.reduce<Bool>(true, fn(acc, f) => acc && asm.isPrimtitiveType(f.ftype.tkeystr));
         if(fields.size() > 4n || !fieldsPrimitive) {
             return true;
         }
@@ -849,15 +849,16 @@ entity CPPTransformer {
             var tkey: CPPAssembly::TypeKey;
             if(bsqasm.entities.has(typekey)) {
                 let e = bsqasm.entities.get(typekey);
-                let isRef = CPPTransformNameManager::shouldBeRef(e.fields, bsqasm);
-                fields_tinfo = e.saturatedBFieldInfo.map<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(
-                    fn(f_tkey) => this.generateTypeInfo[recursive](f_tkey.ftype.tkeystr, tinfos, cur_tid, bsqasm) );
+                let isRef = CPPTransformNameManager::shouldBeRef(e.saturatedBFieldInfo, bsqasm);
+                fields_tinfo = e.saturatedBFieldInfo
+                    .map<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(
+                        fn(f_tkey) => this.generateTypeInfo[recursive](f_tkey.ftype.tkeystr, tinfos, cur_tid, bsqasm) );
                 tag = if(isRef) then CPPAssembly::Tag#Ref else CPPAssembly::Tag#Value;
                 tkey = CPPTransformNameManager::convertTypeKey(e.tkey);
             }
             elif(bsqasm.datamembers.has(typekey)) {
                 let dm = bsqasm.datamembers.get(typekey);
-                let isRef = CPPTransformNameManager::shouldBeRef(dm.fields, bsqasm);
+                let isRef = CPPTransformNameManager::shouldBeRef(dm.saturatedBFieldInfo, bsqasm);
                 fields_tinfo = dm.saturatedBFieldInfo.map<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(
                     fn(f_tkey) => this.generateTypeInfo[recursive](f_tkey.ftype.tkeystr, tinfos, cur_tid, bsqasm) );
                 tag = if(isRef) then CPPAssembly::Tag#Ref else CPPAssembly::Tag#Value;
@@ -884,7 +885,7 @@ entity CPPTransformer {
 
             matchedType = this.generateNominalConcreteTypeInfo(fields_tinfo, next_tid, tkey, tag, bsqasm);
         }
-        elif(bsqasm.isNominalTypeConcept(typekey)) {
+        elif(bsqasm.isNominalTypeConcept(typekey)) { %% I believe we dont need to emit typeinfo for concepts or datatypes whatsoever...
             var maxFieldCount: Nat;
             if(bsqasm.concepts.has(typekey)) {
                 maxFieldCount = this.findMaxFieldCount(bsqasm.concepts.get(typekey)@<BSQAssembly::AbstractConceptTypeDecl>, bsqasm);
@@ -894,7 +895,7 @@ entity CPPTransformer {
             }
             elif(bsqasm.pconcepts.has(typekey)) {
                 let pc = bsqasm.pconcepts.get(typekey);
-                if(pc)@<BSQAssembly::OptionTypeDecl> { %% I "think" sometype would be best here
+                if(pc)@<BSQAssembly::OptionTypeDecl> {
                     let pcinfo = this.generateTypeInfo[recursive]($pc.someType.tkeystr, tinfos, cur_tid, bsqasm).0;
                     let named_pcinfo = CPPAssembly::TypeInfo{ next_tid, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, CString::concat('2', pcinfo.ptrmask), cpptkey, CPPAssembly::Tag#Tagged };
 
@@ -966,6 +967,13 @@ entity CPPTransformer {
             fn(e) => CPPTransformNameManager::convertNominalTypeSignature(e));
 
         return CPPAssembly::DatatypeTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9, base.10, fields, associatedMemberEntityDecls }; 
+    }
+
+    method transformConceptTypeDeclToCpp(ctd: BSQAssembly::ConceptTypeDecl): CPPAssembly::ConceptTypeDecl {
+        let base = this.transformAbstractConceptTypeDeclBase(ctd@<BSQAssembly::AbstractConceptTypeDecl>);
+        let fields = this.transformMemberFieldDecl(ctd.saturatedBFieldInfo, ctd, ctd.fields);
+
+        return CPPAssembly::ConceptTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9, base.10, fields }; 
     }
 
     method transformSomeTypeDecl(std: BSQAssembly::SomeTypeDecl): CPPAssembly::SomeTypeDecl {
@@ -1228,6 +1236,12 @@ entity CPPTransformer {
                 return acc.insert(CPPTransformNameManager::convertInvokeKey(ikey), transformer.transformOverrideMethodDecl(decl));
         });
 
+        let transformer_concepts = bsqasm.concepts.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::ConceptTypeDecl>>(
+            Map<CPPAssembly::TypeKey, CPPAssembly::ConceptTypeDecl>{}, fn(acc, tk, ctd) => {
+                let cppctd = transformer.transformConceptTypeDeclToCpp(ctd);
+                return acc.insert(cppctd.tkey, cppctd);
+        });
+
         let transformer_allmethods = bsqasm.allmethods.map<CPPAssembly::InvokeKey>(fn(ikey) => {
             return CPPTransformNameManager::convertInvokeKey(ikey);
         });
@@ -1236,13 +1250,18 @@ entity CPPTransformer {
             (| 0n, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>{} |), fn(acc, tkey) => {
                 let gen_tinfo = transformer.generateTypeInfo(tkey, acc.1, acc.0, bsqasm);
                 return (| acc.0 + 1n, gen_tinfo.1 |);
-            });
-        
-        let generated_typeinfos_abstract = bsqasm.allabstracttypes.reduce<(| Nat, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> |)>(
-            generated_typeinfos_concrete, fn(acc, tkey) => {
-                let gen_tinfo = transformer.generateTypeInfo(tkey, acc.1, acc.0, bsqasm);
-                return (| acc.0 + 1n, gen_tinfo.1 |);
-            });
+        });
+
+        %% This may not be right, but for now we dont emit any type info for concepts or datatypes. The types
+        %% who provide them contain all the necessary fields, so this should be unnecessary. 
+        let generated_typeinfos_abstract = bsqasm.allabstracttypes
+            .filter(pred(tkey) => !bsqasm.concepts.has(tkey) && !bsqasm.datatypes.has(tkey))
+            .reduce<(| Nat, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> |)>(
+                generated_typeinfos_concrete, fn(acc, tkey) => {
+
+                    let gen_tinfo = transformer.generateTypeInfo(tkey, acc.1, acc.0, bsqasm);
+                    return (| acc.0 + 1n, gen_tinfo.1 |);
+        });
 
         return CPPAssembly::Assembly {
             nsdecls = transformer_nsdecls_enums,
@@ -1260,6 +1279,7 @@ entity CPPTransformer {
             datamembers = transformer_datamembers,
             datatypes = transformer_datatypes,
             pconcepts = transformer_pconcepts,
+            concepts = transformer_concepts,
             allmethods = transformer_allmethods, %% Might need to do someting like the funcs, being able to get the ns is nice
             typeinfos = generated_typeinfos_abstract.1
         };

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -358,7 +358,7 @@ entity CPPTransformer {
             | BSQAssembly::PostfixNop => { abort; }
             | BSQAssembly::PostfixAbort => { abort; }
             | BSQAssembly::PostfixWidenConvert => { abort; }
-            | BSQAssembly::PostfixAccessSomeValue => { abort; }
+            | BSQAssembly::PostfixAccessSomeValue => { return CPPAssembly::PostfixAccessSomeValue{ baseType }; }
             | BSQAssembly::PostfixLiteralNoneValue => { abort; }
         }
     }
@@ -609,6 +609,13 @@ entity CPPTransformer {
         }
     }
 
+    method transformIfElseBinderStatement(stmt: BSQAssembly::IfElseBinderStatement, cond: CPPAssembly::Expression, tb: CPPAssembly::BlockStatement, fb: CPPAssembly::BlockStatement): CPPAssembly::IfElseBinderStatement {
+        let itest = this.transformITestAsTest(stmt.itest);
+        let binder = this.transformBinderInfo(stmt.binder);       
+    
+        return CPPAssembly::IfElseBinderStatement{ cond, tb, fb, itest, binder };
+    }
+
     recursive method transformIfElseStatement(stmt: BSQAssembly::IfElseStatement): CPPAssembly::IfElseStatement {
         let cond = this.transformExpressionToCpp[recursive](stmt.texp);
         let trueBlock = this.transformBlockStatement(stmt.trueBlock);
@@ -617,7 +624,7 @@ entity CPPTransformer {
         match(stmt)@ {
             BSQAssembly::IfElseSimpleStatement => { return CPPAssembly::IfElseSimpleStatement{ cond, trueBlock, falseBlock }; }
             | BSQAssembly::IfElseTestStatement => { return CPPAssembly::IfElseTestStatement{ cond, trueBlock, falseBlock, this.transformITestAsTest($stmt.itest) }; }
-            | BSQAssembly::IfElseBinderStatement => { abort; } %% TODO: Not Implemented
+            | BSQAssembly::IfElseBinderStatement => { return this.transformIfElseBinderStatement($stmt, cond, trueBlock, falseBlock); } %% TODO: Not Implemented
         }
     }
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -799,9 +799,9 @@ entity CPPTransformer {
     }
 
     %%
-    %% When we generate the typeinfo for some<tuple> we will need to explicitly handle how we determine the field size.
+    %% When we generate the typeinfo for tuple as a field or some(tuple) we will need to explicitly handle how we determine the field size.
     %% this likely means we need to modify this method to support access of `entries` list or this typesig, walk the fields
-    %% recursively determining their slotsize and typesize to construct our new type. Think of it as a union.
+    %% recursively determining their slotsize and typesize to construct our new type. 
     %%
     recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat, bsqasm: BSQAssembly::Assembly): CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> { 
         let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -869,7 +869,7 @@ entity CPPTransformer {
 
             matchedType = this.generateNominalConcreteTypeInfo(fields_tinfo, next_tid, tkey, tag, bsqasm);
         }
-        elif(bsqasm.isNominalTypeConcept(typekey)) { %% I believe we dont need to emit typeinfo for concepts or datatypes whatsoever...
+        elif(bsqasm.isNominalTypeConcept(typekey)) {
             var maxFieldCount: Nat;
             if(bsqasm.concepts.has(typekey)) {
                 maxFieldCount = this.findMaxFieldCount(bsqasm.concepts.get(typekey)@<BSQAssembly::AbstractConceptTypeDecl>, bsqasm);
@@ -1093,8 +1093,14 @@ entity CPPTransformer {
                     fn(decl) => {
                         let new_datamembers = decl.datamembers.pushBack(cpptk);
                         let new_alltypes = decl.alltypes.pushBack(cpptk);
+                        
+                        let new_staticmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>::concat(decl.staticmethods, cppstaticmethods);
+                        let new_virtmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>::concat(decl.virtmethods, cppvirtmethods);
+                        let new_absmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>::concat(decl.absmethods, cppabsmethods);
+                        let new_overmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>::concat(decl.overmethods, cppovermethods);
+
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, decl.typefuncs, decl.constructables, decl.entities,
-                            new_datamembers, decl.datatypes, decl.pconcepts, cppstaticmethods, cppvirtmethods, cppabsmethods, cppovermethods,
+                            new_datamembers, decl.datatypes, decl.pconcepts, new_staticmethods, new_virtmethods, new_absmethods, new_overmethods,
                             decl.enums, new_alltypes };
                     });                     
             });
@@ -1116,8 +1122,14 @@ entity CPPTransformer {
                     fn(decl) => {
                         let new_datatypes = decl.datatypes.pushBack(cpptk);
                         let new_alltypes = decl.alltypes.pushBack(cpptk);
+                        
+                        let new_staticmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>::concat(decl.staticmethods, cppstaticmethods);
+                        let new_virtmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>::concat(decl.virtmethods, cppvirtmethods);
+                        let new_absmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>::concat(decl.absmethods, cppabsmethods);
+                        let new_overmethods = List<(|CPPAssembly::InvokeKey, CPPAssembly::TypeKey|)>::concat(decl.overmethods, cppovermethods);
+                        
                         return CPPAssembly::NamespaceDecl{ decl.nsname, decl.subns, decl.nsfuncs, decl.typefuncs, decl.constructables, decl.entities,
-                            decl.datamembers, new_datatypes, decl.pconcepts, cppstaticmethods, cppvirtmethods, cppabsmethods, cppovermethods,
+                            decl.datamembers, new_datatypes, decl.pconcepts, new_staticmethods, new_virtmethods, new_absmethods, new_overmethods,
                             decl.enums, new_alltypes };
                     });                     
             });

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -584,6 +584,20 @@ entity CPPTransformer {
         return CPPAssembly::BlockStatement{ stmts, block.isScoping };
     }
 
+    method transformBinderInfo(binder: BSQAssembly::BinderInfo): CPPAssembly::BinderInfo {
+        let srcname = CPPTransformNameManager::convertVarIdentifier(binder.srcname);
+        let refineonfollow = binder.refineonfollow;
+
+        return CPPAssembly::BinderInfo{ srcname, refineonfollow };
+    }
+
+    method transformIfBinderStatement(stmt: BSQAssembly::IfBinderStatement, cond: CPPAssembly::Expression, tb: CPPAssembly::BlockStatement): CPPAssembly::IfBinderStatement {
+        let itest = this.transformITestAsTest(stmt.itest);
+        let binder = this.transformBinderInfo(stmt.binder);
+
+        return CPPAssembly::IfBinderStatement{ cond, tb, itest, binder };
+    }
+
     recursive method transformIfStatement(stmt: BSQAssembly::IfStatement): CPPAssembly::IfStatement {
         let cond = this.transformExpressionToCpp[recursive](stmt.texp);
         let trueBlock = this.transformBlockStatement(stmt.trueBlock);
@@ -591,7 +605,7 @@ entity CPPTransformer {
         match(stmt)@ {
             BSQAssembly::IfSimpleStatement => { return CPPAssembly::IfSimpleStatement{ cond, trueBlock }; }
             | BSQAssembly::IfTestStatement => { return CPPAssembly::IfTestStatement{ cond, trueBlock, this.transformITestAsTest($stmt.itest) }; }
-            | BSQAssembly::IfBinderStatement => { abort; } %% TODO: Not Implemented
+            | BSQAssembly::IfBinderStatement => { return this.transformIfBinderStatement($stmt, cond, trueBlock); }
         }
     }
 

--- a/test/cppoutput/asserts/assert.test.js
+++ b/test/cppoutput/asserts/assert.test.js
@@ -13,7 +13,7 @@ describe ("Exec -- simple abort", () => {
 });
 */
 
-describe ("Cpp Emit Evaluate -- simple assert", () => {
+describe ("CPP Emit Evaluate -- simple assert", () => {
     it("should exec simple assert", function () {
         runMainCode("public function main(): Int { assert true; return 1i; }", "1_i");
         // runMainCode("public function main(): Int { assert debug false; return 1i; }", "1i");

--- a/test/cppoutput/elist/elist_const_access.test.js
+++ b/test/cppoutput/elist/elist_const_access.test.js
@@ -11,7 +11,7 @@ describe ("Exec -- elist decl and access", () => {
         runMainCode('public function main(): Bool { let x = (|2i, true|); return x.1; }', "true"); 
     });
 
-/*
+/* TODO: This is a funny special case for Option<elist> and Some<elist> as we dont emit tinfo for elists themselves
     it("should exec option elist", function () {
         runMainCode('public function main(): Int { let x: Option<(|Int, Bool|)> = some((|2i, true|)); return x@some.0; }', "2i"); 
     });

--- a/test/cppoutput/if_stmts/simple_if.test.js
+++ b/test/cppoutput/if_stmts/simple_if.test.js
@@ -13,4 +13,14 @@ describe ("CPP Emit Evaluate -- If Statement", () => {
         runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)some { return 3i; } return 1i; }", "3_i");
         runMainCode("public function main(): Int { let x: Option<Int> = none; if(x)some { return 3i; } return 1i; }", "1_i");
     });
+
+    it("should exec binder itest ifs", function () {
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@some { return $x; } return 1i; }", "3_i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if($y = x)@some { return $y; } return 1i; }", "3_i");
+    });
+
+    it("should exec binder & reflow itest ifs", function () {
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@@!some { return 0i; } return x; }", "3_i");
+        runMainCode("public function main(): Int { let x: Option<Int> = none; if(x)@@!some { return 0i; } return x; }", "0_i");
+    });
 });

--- a/test/cppoutput/if_stmts/simple_ifelse.test.js
+++ b/test/cppoutput/if_stmts/simple_ifelse.test.js
@@ -15,14 +15,14 @@ describe ("CPP Emit Evaluate -- Simple if-elif-else statements", () => {
         runMainCode("public function main(): Int { let x: Option<Int> = none; if(x)some { return 3i; } else { return 1i; } }", "1_i");
     });
     it("should exec binder itest ifs", function () {
-        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@some { return $x; } else { return 1i; } }", "3i");
-        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if($y = x)@some { return $y; } else { return 1i; } }", "3i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@some { return $x; } else { return 1i; } }", "3_i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if($y = x)@some { return $y; } else { return 1i; } }", "3_i");
 
-        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@none { return 1i; } else { return $x; } }", "3i");
-        runMainCode("public function main(): Int { let x: Option<Int> = none; if(x)@none { return 1i; } else { return $x; } }", "1i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@none { return 1i; } else { return $x; } }", "3_i");
+        runMainCode("public function main(): Int { let x: Option<Int> = none; if(x)@none { return 1i; } else { return $x; } }", "1_i");
     });
 
     it("should exec binder & reflow itest ifs", function () {
-        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@@!some { return 0i; } else { ; } return x; }", "3i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@@!some { return 0i; } else { ; } return x; }", "3_i");
     });
 });

--- a/test/cppoutput/if_stmts/simple_ifelse.test.js
+++ b/test/cppoutput/if_stmts/simple_ifelse.test.js
@@ -14,4 +14,15 @@ describe ("CPP Emit Evaluate -- Simple if-elif-else statements", () => {
         runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)some { return 3i; } else { return 1i; } }", "3_i");
         runMainCode("public function main(): Int { let x: Option<Int> = none; if(x)some { return 3i; } else { return 1i; } }", "1_i");
     });
+    it("should exec binder itest ifs", function () {
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@some { return $x; } else { return 1i; } }", "3i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if($y = x)@some { return $y; } else { return 1i; } }", "3i");
+
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@none { return 1i; } else { return $x; } }", "3i");
+        runMainCode("public function main(): Int { let x: Option<Int> = none; if(x)@none { return 1i; } else { return $x; } }", "1i");
+    });
+
+    it("should exec binder & reflow itest ifs", function () {
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); if(x)@@!some { return 0i; } else { ; } return x; }", "3i");
+    });
 });

--- a/test/cppoutput/mcall_exps/simple_resolved.test.js
+++ b/test/cppoutput/mcall_exps/simple_resolved.test.js
@@ -46,12 +46,10 @@ describe ("CPP Emit Evaluate -- eADT methods", () => {
         runMainCode('datatype Foo<T> of Foo1 { field f: T; method foo(x: T): T { return if (true) then x else this.f; }} ; public function main(): Int { let x = Foo1<Int>{3i}; return x.foo(2i); }', "2_i"); 
     });
    
-/*  Needs ITestType in constsimplify 
     it("should exec simple eADT methods with template", function () {
         runMainCode('datatype Foo of Foo1 { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} ; public function main(): Bool { let x = Foo1{3i}; return x.foo<Nat>(); }', "false"); 
         runMainCode('datatype Foo of Foo1 { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} ; public function main(): Bool { let x = Foo1{3i}; return x.foo<Int>(); }', "true"); 
     });
-*/  
 
 /*
     it("should exec simple ROOT eADT methods", function () {

--- a/test/cppoutput/mcall_exps/simple_resolved.test.js
+++ b/test/cppoutput/mcall_exps/simple_resolved.test.js
@@ -50,18 +50,18 @@ describe ("CPP Emit Evaluate -- eADT methods", () => {
     });
 
     it("should exec simple ROOT eADT methods", function () {
-        runMainCode('datatype Foo of F1 { } | F2 { } & { method foo(): Int { return if(this)<F1> then 1i else 0i; } } public function main(): Int { return F1{}.foo(); }', "1i"); 
+        runMainCode('datatype Foo of F1 { } | F2 { } & { method foo(): Int { return if(this)<F1> then 1i else 0i; } } public function main(): Int { return F1{}.foo(); }', "1_i"); 
 
-        runMainCode('datatype Foo of F1 { f: Int } | F2 { g: Int } & { method foo(): Int { if(this)@<F1> { return $this.f; } else { return $this.g; } } } public function main(): Int { return F1{3i}.foo(); }', "3i"); 
+        runMainCode('datatype Foo of F1 { f: Int } | F2 { g: Int } & { method foo(): Int { if(this)@<F1> { return $this.f; } else { return $this.g; } } } public function main(): Int { return F1{3i}.foo(); }', "3_i"); 
 
-        runMainCode('datatype Foo of F1 { f: Int } | F2 { g: Int } & { method foo(): Int { if(this)@<F1> { return $this.f; } else { return $this.g + 1i; } } } public function main(): Int { let x: Foo = F1{3i}; return x.foo(); }', "3i"); 
-        runMainCode('datatype Foo of F1 { f: Int } | F2 { g: Int } & { method foo(): Int { if(this)@<F1> { return $this.f; } else { return $this.g + 1i; } } } public function main(): Int { let x: Foo = F2{3i}; return x.foo(); }', "4i"); 
+        runMainCode('datatype Foo of F1 { f: Int } | F2 { g: Int } & { method foo(): Int { if(this)@<F1> { return $this.f; } else { return $this.g + 1i; } } } public function main(): Int { let x: Foo = F1{3i}; return x.foo(); }', "3_i"); 
+        runMainCode('datatype Foo of F1 { f: Int } | F2 { g: Int } & { method foo(): Int { if(this)@<F1> { return $this.f; } else { return $this.g + 1i; } } } public function main(): Int { let x: Foo = F2{3i}; return x.foo(); }', "4_i"); 
     });
 
     it("should exec template ROOT eADT methods", function () {
-        runMainCode('datatype Foo<T> of F1 { } | F2 { } & { method foo(): Int { return if(this)<F1<T>> then 1i else 0i; } } public function main(): Int { return F1<Bool>{}.foo(); }', "1i"); 
+        runMainCode('datatype Foo<T> of F1 { } | F2 { } & { method foo(): Int { return if(this)<F1<T>> then 1i else 0i; } } public function main(): Int { return F1<Bool>{}.foo(); }', "1_i"); 
 
-        runMainCode('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { return F1<Int>{3i}.foo(); }', "3i"); 
-        runMainCode('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { let x: Foo<Int> = F1<Int>{3i}; return x.foo(); }', "3i"); 
+        runMainCode('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { return F1<Int>{3i}.foo(); }', "3_i"); 
+        runMainCode('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { let x: Foo<Int> = F1<Int>{3i}; return x.foo(); }', "3_i"); 
     });
 });

--- a/test/cppoutput/mcall_exps/simple_resolved.test.js
+++ b/test/cppoutput/mcall_exps/simple_resolved.test.js
@@ -60,6 +60,7 @@ describe ("CPP Emit Evaluate -- eADT methods", () => {
 
     it("should exec template ROOT eADT methods", function () {
         runMainCode('datatype Foo<T> of F1 { } | F2 { } & { method foo(): Int { return if(this)<F1<T>> then 1i else 0i; } } public function main(): Int { return F1<Bool>{}.foo(); }', "1_i"); 
+        runMainCode('datatype Foo<T> of F1 { } | F2 { } & { method foo(): Int { return if(this)<F1<T>> then 1i else 0i; } } public function main(): Int { return F2<Bool>{}.foo(); }', "0_i");
 
         runMainCode('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { return F1<Int>{3i}.foo(); }', "3_i"); 
         runMainCode('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { let x: Foo<Int> = F1<Int>{3i}; return x.foo(); }', "3_i"); 

--- a/test/cppoutput/mcall_exps/simple_resolved.test.js
+++ b/test/cppoutput/mcall_exps/simple_resolved.test.js
@@ -28,12 +28,10 @@ describe ("CPP Emit Evaluate -- entity methods", () => {
         runMainCode('entity Foo<T> { field f: T; method foo(x: T): T { return if (true) then x else this.f; }} public function main(): Int { let x = Foo<Int>{3i}; return x.foo(2i); }', "2_i"); 
     });
 
-/*   Needs ITestType in constsimplify
     it("should exec simple entity methods with both template", function () {
         runMainCode('entity Foo<T> { field f: T; method foo<U>(): Bool { return this.f?<U>; }} public function main(): Bool { let x = Foo<Int>{3i}; return x.foo<Nat>(); }', "false"); 
         runMainCode('entity Foo<T> { field f: T; method foo<U>(): Bool { return this.f?<U>; }} public function main(): Bool { let x = Foo<Int>{3i}; return x.foo<Int>(); }', "true"); 
     });
-*/
 });
 
 describe ("CPP Emit Evaluate -- eADT methods", () => {
@@ -51,7 +49,6 @@ describe ("CPP Emit Evaluate -- eADT methods", () => {
         runMainCode('datatype Foo of Foo1 { field f: Int; method foo<T>(): Bool { return this.f?<T>; }} ; public function main(): Bool { let x = Foo1{3i}; return x.foo<Int>(); }', "true"); 
     });
 
-/*
     it("should exec simple ROOT eADT methods", function () {
         runMainCode('datatype Foo of F1 { } | F2 { } & { method foo(): Int { return if(this)<F1> then 1i else 0i; } } public function main(): Int { return F1{}.foo(); }', "1i"); 
 
@@ -67,5 +64,4 @@ describe ("CPP Emit Evaluate -- eADT methods", () => {
         runMainCode('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { return F1<Int>{3i}.foo(); }', "3i"); 
         runMainCode('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { let x: Foo<Int> = F1<Int>{3i}; return x.foo(); }', "3i"); 
     });
-    */
 });

--- a/test/cppoutput/mcall_exps/simple_resolved.test.js
+++ b/test/cppoutput/mcall_exps/simple_resolved.test.js
@@ -64,5 +64,6 @@ describe ("CPP Emit Evaluate -- eADT methods", () => {
 
         runMainCode('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { return F1<Int>{3i}.foo(); }', "3_i"); 
         runMainCode('datatype Foo<T> of F1 { f: T } | F2 { g: T } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.g; } } } public function main(): Int { let x: Foo<Int> = F1<Int>{3i}; return x.foo(); }', "3_i"); 
+        runMainCode('datatype Foo<T> using { field x: T; } of F1 { f: T } | F2 { g: T } | F3 { } & { method foo(): T { if(this)@<F1<T>> { return $this.f; } else { return $this.x; } } } public function main(): Int { let x: Foo<Int> = F1<Int>{2i, 3i}; return x.foo(); }', "3_i" );
     });
 });

--- a/test/cppoutput/special_cons_exps/optional_const.test.js
+++ b/test/cppoutput/special_cons_exps/optional_const.test.js
@@ -5,7 +5,7 @@ import { describe, it } from "node:test";
 
 describe ("CPP Emit Evaluate -- Special Constructor infer in if-else and assign positions", () => {
     it("should exec some/none with if-else", function () {
-        // runMainCode("public function main(): Int { let x: Option<Int> = if(true) then some(3i) else none; return x@some; }", "3_i");
+        runMainCode("public function main(): Int { let x: Option<Int> = if(true) then some(3i) else none; return x@some; }", "3_i");
         runMainCode("public function main(): Bool { let x: Option<Int> = if(false) then some(3i) else none; return x?!some; }", "true");
     });
 
@@ -20,7 +20,7 @@ describe ("CPP Emit Evaluate -- Special Constructor infer in if-else and assign 
 describe ("Exec -- Special Constructor Optional", () => {
     it("should exec none with simple infer", function () {
         runMainCode("public function main(): Int { let x: Some<Int> = some(3i); return x.value; }", "3_i");
-        // runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return x@some; }", "3i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return x@some; }", "3_i");
     });
 });
 

--- a/test/cppoutput/type_exps/oo_isas.test.js
+++ b/test/cppoutput/type_exps/oo_isas.test.js
@@ -4,6 +4,12 @@ import { runMainCode } from "../../../bin/test/runtime/runtime_nf.js";
 import { describe, it } from "node:test";
 
 describe ("Exec -- entity is/as", () => {
+
+    //
+    // TODO: Concepts are lacking the necessary backend for emission so we ignore
+    //
+
+/*
     it("should exec simple entity is", function () {
         runMainCode('concept Foo { field f: Int; } concept Baz {} entity Bar provides Foo, Baz { } public function main(): Bool { let bb: Foo = Bar{3i}; return bb?<Bar>; }', "true");
         runMainCode('concept Foo { field f: Int; } concept Baz {} entity Bar provides Foo, Baz { } public function main(): Bool { let bb: Foo = Bar{3i}; return bb?<Baz>; }', "true"); 
@@ -16,7 +22,7 @@ describe ("Exec -- entity is/as", () => {
 
         runMainCode('concept Foo { field f: Int; } concept Baz {} entity Bar provides Foo, Baz { } public function main(): Int { return Bar{3i}@<Foo>.f; }', "3i"); 
     });
-
+*/
 /*
     it("should fail exec simple entity as", function () {
         runMainCodeError('concept Foo { field f: Int; } concept Baz { field g: Int; } entity Bar provides Foo { } entity Goo provides Foo, Baz { } public function main(): Int { let bb: Foo = Bar{3i}; return bb@<Baz>.g; }', "Error -- expected subtytype of Main::Baz @ test.bsq:3"); 

--- a/test/cppoutput/type_exps/oo_isas.test.js
+++ b/test/cppoutput/type_exps/oo_isas.test.js
@@ -1,0 +1,25 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/runtime/runtime_nf.js";
+import { describe, it } from "node:test";
+
+describe ("Exec -- entity is/as", () => {
+    it("should exec simple entity is", function () {
+        runMainCode('concept Foo { field f: Int; } concept Baz {} entity Bar provides Foo, Baz { } public function main(): Bool { let bb: Foo = Bar{3i}; return bb?<Bar>; }', "true");
+        runMainCode('concept Foo { field f: Int; } concept Baz {} entity Bar provides Foo, Baz { } public function main(): Bool { let bb: Foo = Bar{3i}; return bb?<Baz>; }', "true"); 
+        runMainCode('concept Foo { field f: Int; } concept Baz {} entity Bar provides Foo { } public function main(): Bool { let bb: Foo = Bar{3i}; return bb?<Baz>; }', "false"); 
+    });
+
+    it("should exec simple entity as", function () {
+        runMainCode('concept Foo { field f: Int; } concept Baz {} entity Bar provides Foo, Baz { } public function main(): Int { return Bar{3i}@<Bar>.f; }', "3i");
+        runMainCode('concept Foo { field f: Int; } concept Baz {} entity Bar provides Foo, Baz { } public function main(): Int { let bb: Foo = Bar{3i}; return bb@<Bar>.f; }', "3i");
+
+        runMainCode('concept Foo { field f: Int; } concept Baz {} entity Bar provides Foo, Baz { } public function main(): Int { return Bar{3i}@<Foo>.f; }', "3i"); 
+    });
+
+/*
+    it("should fail exec simple entity as", function () {
+        runMainCodeError('concept Foo { field f: Int; } concept Baz { field g: Int; } entity Bar provides Foo { } entity Goo provides Foo, Baz { } public function main(): Int { let bb: Foo = Bar{3i}; return bb@<Baz>.g; }', "Error -- expected subtytype of Main::Baz @ test.bsq:3"); 
+    });
+*/
+});


### PR DESCRIPTION
Added support for emission in cpp of 
 - `IfBinderStatement`
 - `IfElseBinderStatement`
 - `IfTestExpression`
 - `ITestType` (with support for convert)

We are still lacking `IfBinderExpression`s and `MatchStatement`s, but this should be a nice foundation (I will take care of these in my next PR). I also explicitly emit datatypes now that extend our backend `Boxed<K>` class to help with `ITestType`. 

With these changes, some bosque code like so
```
datatype Foo<T> using { 
    field x: T; 
} 
of 
F1 { f: T } 
| F2 { g: T } 
| F3 { h: T } & { 
    method foo(): T { 
        let val = this.x;
        if(this)@<F1<T>> { 
            return $this.f; 
        } else { 
            return $this.x; 
        } 
    }
} 

public function main(): Int { 
    let x: Foo<Int> = F3<Int>{5i, 3i}; 
    return x.foo(); 
} 
```

Will emit in cpp
```
// Primitive TypeInfos would be here
//
// Ref and Tagged Type Forward Declarations
//
namespace Main {
    class FooᐸIntᐳ;
}
namespace Main {
//
// Value Type Definitions
//
    enum F1ᐸIntᐳ_entries {
        F1ᐸIntᐳ_x,
        F1ᐸIntᐳ_f
    };
    const __CoreCpp::FieldOffsetInfo F1ᐸIntᐳ_vtable[] = {
        { 3, F1ᐸIntᐳ_entries::F1ᐸIntᐳ_x, 0 },
        { 3, F1ᐸIntᐳ_entries::F1ᐸIntᐳ_f, 8 }
    };
    __CoreCpp::TypeInfoBase F1ᐸIntᐳType = {
        .type_id = 4,
        .type_size = 16, 
        .slot_size = 2,
        .ptr_mask = "00",
        .typekey = "Main::F1<Int>",
        .vtable = F1ᐸIntᐳ_vtable
    };
    struct F1ᐸIntᐳ{ 
        __CoreCpp::Int x;
        __CoreCpp::Int f;
    };
    enum F2ᐸIntᐳ_entries {
        F2ᐸIntᐳ_x,
        F2ᐸIntᐳ_g
    };
    const __CoreCpp::FieldOffsetInfo F2ᐸIntᐳ_vtable[] = {
        { 3, F2ᐸIntᐳ_entries::F2ᐸIntᐳ_x, 0 },
        { 3, F2ᐸIntᐳ_entries::F2ᐸIntᐳ_g, 8 }
    };
    __CoreCpp::TypeInfoBase F2ᐸIntᐳType = {
        .type_id = 5,
        .type_size = 16, 
        .slot_size = 2,
        .ptr_mask = "00",
        .typekey = "Main::F2<Int>",
        .vtable = F2ᐸIntᐳ_vtable
    };
    struct F2ᐸIntᐳ{ 
        __CoreCpp::Int x;
        __CoreCpp::Int g;
    };
    enum F3ᐸIntᐳ_entries {
        F3ᐸIntᐳ_x,
        F3ᐸIntᐳ_h
    };
    const __CoreCpp::FieldOffsetInfo F3ᐸIntᐳ_vtable[] = {
        { 3, F3ᐸIntᐳ_entries::F3ᐸIntᐳ_x, 0 },
        { 3, F3ᐸIntᐳ_entries::F3ᐸIntᐳ_h, 8 }
    };
    __CoreCpp::TypeInfoBase F3ᐸIntᐳType = {
        .type_id = 6,
        .type_size = 16, 
        .slot_size = 2,
        .ptr_mask = "00",
        .typekey = "Main::F3<Int>",
        .vtable = F3ᐸIntᐳ_vtable
    };
    struct F3ᐸIntᐳ{ 
        __CoreCpp::Int x;
        __CoreCpp::Int h;
    };
//
// Ref and Tagged Type Definitions
//
    struct FooᐸIntᐳᕮBase { 
        __CoreCpp::Int x;
    };
    class FooᐸIntᐳ : public __CoreCpp::Boxed<2> {
    public:
        FooᐸIntᐳ() noexcept = default;
        FooᐸIntᐳ(const FooᐸIntᐳ& rhs) noexcept = default;
        FooᐸIntᐳ& operator=(const FooᐸIntᐳ& rhs) noexcept = default;

        template<typename T>
        FooᐸIntᐳ(__CoreCpp::TypeInfoBase* ti, T d) noexcept : Boxed(ti, *reinterpret_cast<uintptr_t(*)[2]>(&d)) {};

        template<typename T>
        constexpr T access() noexcept { return *reinterpret_cast<T*>(&this->data); }
    };
//
// All Methods
//
    const __CoreCpp::Int foo([[maybe_unused]] FooᐸIntᐳ 𝐭𝐡𝐢𝐬) noexcept;
    const __CoreCpp::Int foo([[maybe_unused]] FooᐸIntᐳ 𝐭𝐡𝐢𝐬) noexcept {
        __CoreCpp::Int val = 𝐭𝐡𝐢𝐬.access<FooᐸIntᐳᕮBase>().x;
        if( 𝐭𝐡𝐢𝐬.typeinfo == &F1ᐸIntᐳType ) {
            [[maybe_unused]] F1ᐸIntᐳ $𝐭𝐡𝐢𝐬 = 𝐭𝐡𝐢𝐬.access<F1ᐸIntᐳ>();
            return $𝐭𝐡𝐢𝐬.f;
        }
        else {
            [[maybe_unused]] FooᐸIntᐳ $𝐭𝐡𝐢𝐬 = 𝐭𝐡𝐢𝐬;
            return $𝐭𝐡𝐢𝐬.access<FooᐸIntᐳᕮBase>().x;
        }
    }
}
//
// Emitted Functions
//
namespace Main {
    __CoreCpp::Int main() noexcept;
    __CoreCpp::Int main() noexcept  {
        FooᐸIntᐳ x = FooᐸIntᐳ{ &F3ᐸIntᐳType, F3ᐸIntᐳ{ 5_i, 3_i } };
        return foo(x);
    }
}
```