### PR TITLE
Cpp Emit Match Statement, Switch Statement, and If Binder Expression

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -107,6 +107,13 @@ entity IfElifElseStatement provides Statement {
     invariant !$condflow.empty();
 }
 
+entity MatchStatement provides Statement {
+    field sval: Expression;
+    field bindInfo: Option<BinderInfo>;
+    field matchflow: List<(|TypeSignature, BlockStatement|)>;
+    field mustExhaustive: Bool;
+}
+
 entity VariableInitializationStatement provides Statement {
     field name: Identifier; 
     field vtype: TypeSignature;

--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -114,6 +114,14 @@ entity MatchStatement provides Statement {
     field mustExhaustive: Bool;
 }
 
+entity SwitchStatement provides Statement {
+    field sval: Expression;
+    field switchflow: List<(|Option<Expression>, BlockStatement|)>;
+
+    field mustExhaustive: Bool;
+    field optypes: List<TypeSignature>;
+}
+
 entity VariableInitializationStatement provides Statement {
     field name: Identifier; 
     field vtype: TypeSignature;

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -6,7 +6,8 @@
 #include <csetjmp>
 #include <variant> // TODO: Need to remove dependency!
 
-#define 𝐚𝐬𝐬𝐞𝐫𝐭(E) if(!(E)) { std::longjmp(__CoreCpp::info.error_handler, true); }
+#define 𝐚𝐛𝐨𝐫𝐭 (std::longjmp(__CoreCpp::info.error_handler, true))
+#define 𝐚𝐬𝐬𝐞𝐫𝐭(E) if(!(E)) { 𝐚𝐛𝐨𝐫𝐭; }
 
 namespace __CoreCpp {
 
@@ -158,6 +159,11 @@ public:
     Boxed& operator=(const Boxed& rhs) noexcept = default;        
 
     Boxed(TypeInfoBase* ti) noexcept: typeinfo(ti) {};
+
+    template<typename T>
+    constexpr T access() noexcept { 
+        return T{};
+    }
 };
 
 template <size_t K>

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1077,7 +1077,30 @@ function emitMatchStatement(stmt: CPPAssembly::MatchStatement, ctx: Context, ind
     });
 
     let matches = String::joinAll("", matchflow);
-    let failure = String::concat(full_indent, "else {%n;", fullfull_indent, "𝐚𝐛𝐨𝐫𝐭;%n;", full_indent, "%n;}%n;");
+    let failure = String::concat(full_indent, "else {%n;", fullfull_indent, "𝐚𝐛𝐨𝐫𝐭;%n;", full_indent, "}%n;");
+    return String::concat(matches, failure);
+}
+
+function emitSwitchStatement(stmt: CPPAssembly::SwitchStatement, ctx: Context, indent: String): String {
+    let full_indent = String::concat("    ", indent); 
+    let fullfull_indent = String::concat("    ", full_indent);
+
+    let sval = emitExpression(stmt.sval, ctx);
+
+    let switchflow = stmt.switchflow.mapIdx<String>(fn(sf, ii) => {
+        let block = String::concat(emitBlockStatement(sf.1, ctx, full_indent), full_indent, "}%n;");
+        let exp = if(sf.0)none then "true" else String::concat(sval, " == ", emitExpression(sf.0@some, ctx)); 
+
+        if(ii == 0n) {
+            return String::concat(full_indent, "if( ", exp, " ) {%n;", block);
+        }
+        else {
+            return String::concat(full_indent, "else if( ", exp, " ) {%n;", block);
+        }
+    });
+
+    let matches = String::joinAll("", switchflow);
+    let failure = String::concat(full_indent, "else {%n;", fullfull_indent, "𝐚𝐛𝐨𝐫𝐭;%n;", full_indent, "}%n;");
     return String::concat(matches, failure);
 }
 
@@ -1099,7 +1122,7 @@ function emitStatement(stmt: CPPAssembly::Statement, ctx: Context, indent: Strin
         | CPPAssembly::IfStatement => { return emitIfStatement($stmt, ctx, indent); }
         | CPPAssembly::IfElseStatement => { return emitIfElseStatement($stmt, ctx, indent); }
         | CPPAssembly::IfElifElseStatement => { return emitIfElifElseStatement($stmt, ctx, indent); }
-        %%| CPPAssembly::SwitchStatement => { abort; }
+        | CPPAssembly::SwitchStatement => { return emitSwitchStatement($stmt, ctx, indent); }
         | CPPAssembly::MatchStatement => { return emitMatchStatement($stmt, ctx, indent); }
         %%| CPPAssembly::AbortStatement => { abort; }
         | CPPAssembly::AssertStatement => { return emitAssertStatement($stmt, ctx, indent); }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -676,8 +676,21 @@ function emitConstructorStdExpression(exp: CPPAssembly::ConstructorStdExpression
     let emitargs = emitArguments(exp.args, ctx); 
     let name = emitTypeSignature(exp.ctype, false, ctx);
     let tinfo = ctx.asm.typeinfos.get(exp.ctype.tkeystr);
+    let ant = ctx.asm.lookupNominalTypeDeclaration(exp.ctype.tkeystr);
 
-    let cons = String::concat(name, "{ ", emitargs, " }");
+    var cons: String;
+    if(ant)@<CPPAssembly::DatatypeMemberEntityTypeDecl> { 
+        if($ant.saturatedBFieldInfo.size() == 0n) { %% Boxed<0> case
+            cons = "";   
+        }
+        else {
+            cons = String::concat(name, "{ ", emitargs, " }");
+        }
+    }
+    else {
+        cons = String::concat(name, "{ ", emitargs, " }");
+    }
+
     if(tinfo.tag === CPPAssembly::Tag#Ref) {
         return String::concat("new ", cons); %% We use new solely to keep the code compiling before GC integration
     }
@@ -747,7 +760,8 @@ function emitWidenedTypeExpression(exp: CPPAssembly::CoerceWidenTypeExpression, 
         return String::concat(name, "{ &", removeCppPrefix(ttype) ," }");
     }
 
-    return String::concat(name, "{ &", ttype, ", ", emitexp, " }");
+    return if(emitexp === "") then String::concat(name, "{ &", ttype, " }")
+        else String::concat(name, "{ &", ttype, ", ", emitexp, " }");
 }
 
 %% We will need this to help us take "this.f?<Int>" to "false"
@@ -1003,6 +1017,47 @@ function emitAssertStatement(stmt: CPPAssembly::AssertStatement, ctx: Context, i
     return String::concat(full_indent, "𝐚𝐬𝐬𝐞𝐫𝐭(", cond, ");");
 } 
 
+function tryGenerateBindType(bind: Option<CPPAssembly::BinderInfo>, expr: String, fromtype: CPPAssembly::TypeKey, totype: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
+    let full_indent = String::concat("    ", indent);
+    if(bind)@none {
+        return "";
+    }
+    else {
+        let bname = emitVarIdentifier($bind.srcname);
+        let convert = emitITestAsConvertType(true, fromtype, totype, ctx); 
+        let bindtype = String::concat("[[maybe_unused]] ", convert.1, " ");
+        let reassign = String::concat(bindtype, bname, " = ", expr, convert.0, ";%n;");
+
+        return String::concat(full_indent, reassign);
+    }
+}
+
+function emitMatchStatement(stmt: CPPAssembly::MatchStatement, ctx: Context, indent: String): String {
+    let full_indent = String::concat("    ", indent); 
+    let fullfull_indent = String::concat("    ", full_indent);
+
+    let expr = emitExpression(stmt.sval, ctx);
+    let sval = String::concat(expr, ".typeinfo == &");
+    var bind: String;
+
+    let matchflow = stmt.matchflow.mapIdx<String>(fn(mf, ii) => {
+        let bind = tryGenerateBindType(stmt.bindInfo, expr, stmt.sval.etype.tkeystr, mf.0.tkeystr, ctx, full_indent);
+        let block = String::concat(bind, emitBlockStatement(mf.1, ctx, full_indent), full_indent, "}%n;");
+        let ts = removeCppPrefix(emitTypeSignature(mf.0, false, ctx));
+
+        if(ii == 0n) {
+            return String::concat(full_indent, "if(", sval, ts, "Type) {%n;", block);
+        }
+        else {
+            return String::concat(full_indent, "else if(", sval, ts, "Type) {%n;", block);
+        }
+    });
+
+    let matches = String::joinAll("", matchflow);
+    let failure = String::concat(full_indent, "else {%n;", fullfull_indent, "𝐚𝐛𝐨𝐫𝐭;%n;", full_indent, "%n;}%n;");
+    return String::concat(matches, failure);
+}
+
 function emitStatement(stmt: CPPAssembly::Statement, ctx: Context, indent: String): String {
     match(stmt)@ {
         CPPAssembly::EmptyStatement => { return ""; }
@@ -1022,7 +1077,7 @@ function emitStatement(stmt: CPPAssembly::Statement, ctx: Context, indent: Strin
         | CPPAssembly::IfElseStatement => { return emitIfElseStatement($stmt, ctx, indent); }
         | CPPAssembly::IfElifElseStatement => { return emitIfElifElseStatement($stmt, ctx, indent); }
         %%| CPPAssembly::SwitchStatement => { abort; }
-        %%| CPPAssembly::MatchStatement => { abort; }
+        | CPPAssembly::MatchStatement => { return emitMatchStatement($stmt, ctx, indent); }
         %%| CPPAssembly::AbortStatement => { abort; }
         | CPPAssembly::AssertStatement => { return emitAssertStatement($stmt, ctx, indent); }
         %%| CPPAssembly::ValidateStatement => { abort; }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -736,6 +736,7 @@ function emitIfTestExpression(exp: CPPAssembly::IfTestExpression, i: String, t: 
     return String::concat("( ", ite, " )");
 }
 
+%% TODO: Both this and convert maybe special case will need to handle abstract concepts
 function getSubtypeCount(tk: CPPAssembly::TypeKey, ctx: Context): Nat, CPPAssembly::AbstractNominalTypeDecl {
     let concretetype = ctx.asm.lookupNominalTypeDeclaration(tk);
     if(concretetype)@<CPPAssembly::DatatypeTypeDecl> {
@@ -747,7 +748,7 @@ function getSubtypeCount(tk: CPPAssembly::TypeKey, ctx: Context): Nat, CPPAssemb
 }
 
 %% Handles special case convert where we have two member entities (this is the false case as well)
-function doConvertMaybeSpecialCase(tk: CPPAssembly::TypeKey, ctx: Context): (|String, String|) {
+function doConvertMaybeSpecialCase(tk: CPPAssembly::TypeKey, itest: CPPAssembly::ITest, ctx: Context): (|String, String|) {
     let n, concretetype = getSubtypeCount(tk, ctx);
 
     if(n == 2n) {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -726,11 +726,30 @@ function emitConstructorExpression(exp: CPPAssembly::ConstructorExpression, ctx:
 function emitIfTestExpression(exp: CPPAssembly::IfTestExpression, i: String, t: String, e: String, ctx: Context): String {
     let itest = String::concat(i, emitITestAsTest(exp.itest, exp.texp.etype, ctx)); %% Likely doesnt work if the itest is just bool
 
-    return String::concat(itest, " ? ", t, " : ", e);
+    let ite = String::concat(itest, " ? (", t, ") : (", e, ")");
+    return String::concat("( ", ite, " )");
 }
 
+%% We do this whole generating binding name fiasco quite a lot, would be good to move to general function
 function emitIfBinderExpression(exp: CPPAssembly::IfBinderExpression, i: String, t: String, e: String, ctx: Context): String {
-    abort; %% TODO: Not Implemented (need to put bindings in a lambda in emission)
+    let capture = String::concat("[&]() -> ", emitTypeKey(exp.etype.tkeystr, false, ctx), " { ");
+    let etype = exp.texp.etype; 
+    let bname = emitVarIdentifier(exp.binder.srcname);
+
+    let itest = String::concat(i, emitITestAsTest(exp.itest, exp.texp.etype, ctx));
+
+    let tconvert = emitITestAsConvert(exp.itest.isnot, exp.itest, etype.tkeystr, none, ctx);
+    let tbindtype = String::concat("[[maybe_unused]] ", tconvert.1, " ");
+    let treassign = String::concat(tbindtype, bname, " = ", i, tconvert.0, "; ");
+    let texp = String::concat(capture, treassign, "return ", t, "; }() ");
+
+    let fconvert = emitITestAsConvert(!exp.itest.isnot, exp.itest, etype.tkeystr, some(etype.tkeystr), ctx); 
+    let fbindtype = String::concat("[[maybe_unused]] ", fconvert.1, " ");
+    let freassign = String::concat(fbindtype, bname, " = ", i, fconvert.0, "; ");
+    let fexp = String::concat(capture, freassign, "return ", e, "; }() ");
+
+    let ibe = String::concat( itest, " ? (", texp, ") : (", fexp, ")");
+    return String::concat( "( ", ibe, " )");
 }
 
 function emitIfExpression(exp: CPPAssembly::IfExpression, ctx: Context): String {
@@ -739,7 +758,10 @@ function emitIfExpression(exp: CPPAssembly::IfExpression, ctx: Context): String 
     let elseexp = emitExpression(exp.elseexp, ctx);
 
     match(exp)@ {
-        CPPAssembly::IfSimpleExpression => { return String::concat(texp, " ? ", thenexp, " : ", elseexp); }
+        CPPAssembly::IfSimpleExpression => { 
+            let ise = String::concat(texp, " ? (", thenexp, ") : (", elseexp, ")");
+            return String::concat("( ", ise, " )");
+        }
         | CPPAssembly::IfTestExpression => { return emitIfTestExpression($exp, texp, thenexp, elseexp, ctx); }
         | CPPAssembly::IfBinderExpression => { return emitIfBinderExpression($exp, texp, thenexp, elseexp, ctx); }
     }
@@ -1017,6 +1039,7 @@ function emitAssertStatement(stmt: CPPAssembly::AssertStatement, ctx: Context, i
     return String::concat(full_indent, "𝐚𝐬𝐬𝐞𝐫𝐭(", cond, ");");
 } 
 
+%% Wouldnt be awful idea to have this be more generic (not just binding type, but none and some too)
 function tryGenerateBindType(bind: Option<CPPAssembly::BinderInfo>, expr: String, fromtype: CPPAssembly::TypeKey, totype: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
     let full_indent = String::concat("    ", indent);
     if(bind)@none {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -86,6 +86,12 @@ function emitSpecialTemplate(name: String): String {
     return final;
 }
 
+function emitBindVar(bname: CPPAssembly::VarIdentifier, convert: String, converttype: String, exp: String): String { 
+    let name = emitVarIdentifier(bname); 
+    let tbindtype = String::concat("[[maybe_unused]] ", converttype, " ");
+    return String::concat(tbindtype, name, " = ", exp, convert, "; ");
+}
+
 function findFieldOffset(tk: CPPAssembly::TypeKey, fname: CPPAssembly::Identifier, ctx: Context): Nat {
     return ctx.asm.lookupNominalTypeDeclaration(tk).saturatedBFieldInfo
         .reduce<(|Nat, Bool|)>((|0n, false|), fn(acc, f) => {
@@ -730,22 +736,45 @@ function emitIfTestExpression(exp: CPPAssembly::IfTestExpression, i: String, t: 
     return String::concat("( ", ite, " )");
 }
 
-%% We do this whole generating binding name fiasco quite a lot, would be good to move to general function
+function getSubtypeCount(tk: CPPAssembly::TypeKey, ctx: Context): Nat, CPPAssembly::AbstractNominalTypeDecl {
+    let concretetype = ctx.asm.lookupNominalTypeDeclaration(tk);
+    if(concretetype)@<CPPAssembly::DatatypeTypeDecl> {
+        return $concretetype.associatedMemberEntityDecls.size(), concretetype;
+    }
+    else {
+        return 0n, concretetype;
+    }
+}
+
+%% Handles special case convert where we have two member entities (this is the false case as well)
+function doConvertMaybeSpecialCase(tk: CPPAssembly::TypeKey, ctx: Context): (|String, String|) {
+    let n, concretetype = getSubtypeCount(tk, ctx);
+
+    if(n == 2n) {
+        let othermember = concretetype@<CPPAssembly::DatatypeTypeDecl>
+            .associatedMemberEntityDecls.find(
+                pred(ets) => !ctx.asm.areTypesSame(ets, itest@<CPPAssembly::ITestType>.ttype)).tkeystr;
+
+        return emitITestAsConvert(itest.isnot, itest, tk, some(othermember), ctx);         
+    }
+    else {
+        return emitITestAsConvert(!itest.isnot, itest, tk, some(tk), ctx); 
+    }
+}
+
+%% TODO: We should format this a bit better as these expressions get quite long
 function emitIfBinderExpression(exp: CPPAssembly::IfBinderExpression, i: String, t: String, e: String, ctx: Context): String {
     let capture = String::concat("[&]() -> ", emitTypeKey(exp.etype.tkeystr, false, ctx), " { ");
     let etype = exp.texp.etype; 
-    let bname = emitVarIdentifier(exp.binder.srcname);
 
     let itest = String::concat(i, emitITestAsTest(exp.itest, exp.texp.etype, ctx));
 
     let tconvert = emitITestAsConvert(exp.itest.isnot, exp.itest, etype.tkeystr, none, ctx);
-    let tbindtype = String::concat("[[maybe_unused]] ", tconvert.1, " ");
-    let treassign = String::concat(tbindtype, bname, " = ", i, tconvert.0, "; ");
+    let treassign = emitBindVar(exp.binder.srcname, tconvert.0, tconvert.1, i);
     let texp = String::concat(capture, treassign, "return ", t, "; }() ");
 
-    let fconvert = emitITestAsConvert(!exp.itest.isnot, exp.itest, etype.tkeystr, some(etype.tkeystr), ctx); 
-    let fbindtype = String::concat("[[maybe_unused]] ", fconvert.1, " ");
-    let freassign = String::concat(fbindtype, bname, " = ", i, fconvert.0, "; ");
+    let fconvert = doConvertMaybeSpecialCase(etype.tkeystr, exp.itest, ctx);
+    let freassign = emitBindVar(exp.binder.srcname, fconvert.0, fconvert.1, i);
     let fexp = String::concat(capture, freassign, "return ", e, "; }() ");
 
     let ibe = String::concat( itest, " ? (", texp, ") : (", fexp, ")");
@@ -966,41 +995,18 @@ function emitIfElseBinderStatement(stmt: CPPAssembly::IfElseBinderStatement, ctx
     let etype = stmt.cond.etype;
     let itest = String::concat(expr, emitITestAsTest(stmt.itest, etype, ctx));
 
-    let bname = emitVarIdentifier(stmt.binder.srcname); 
     let tconvert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, stmt.cond.etype.tkeystr, none, ctx); 
-    let treasign = String::concat(bname, " = ", expr, tconvert.0);
-    let tbassign = String::concat(full_indent, "[[maybe_unused]] ", tconvert.1, " ", treasign, ";%n;");
+    let treassign = emitBindVar(stmt.binder.srcname, tconvert.0, tconvert.1, expr);
 
-    var n: Nat;
-    let concretetype = ctx.asm.lookupNominalTypeDeclaration(etype.tkeystr);
-    if(concretetype)@<CPPAssembly::DatatypeTypeDecl> {
-        n = $concretetype.associatedMemberEntityDecls.size();
-    }
-    else {
-        n = 0n;
-    }
-
-    var fbassign: String;
-    if(n == 2n) { %% If only two member entities implicitly convert to entity that we are not
-        let othermember = concretetype@<CPPAssembly::DatatypeTypeDecl>
-            .associatedMemberEntityDecls.find(pred(ets) => !ctx.asm.areTypesSame(ets, stmt.itest@<CPPAssembly::ITestType>.ttype)).tkeystr;
-
-        let fconvert = emitITestAsConvert(stmt.itest.isnot, stmt.itest, etype.tkeystr, some(othermember), ctx); 
-        let freasign = String::concat(bname, " = ", expr, fconvert.0);
-        fbassign = String::concat(full_indent, "[[maybe_unused]] ", fconvert.1, " ", freasign, ";%n;");
-    }
-    else {
-        let fconvert = emitITestAsConvert(!stmt.itest.isnot, stmt.itest, etype.tkeystr, some(etype.tkeystr), ctx); 
-        let freasign = String::concat(bname, " = ", expr, fconvert.0);
-        fbassign = String::concat(full_indent, "[[maybe_unused]] ", fconvert.1, " ", freasign, ";%n;");
-    }
+    let fconvert = doConvertMaybeSpecialCase(etype.tkeystr, stmt.itest, ctx);
+    let freassign = emitBindVar(stmt.binder.srcname, fconvert.0, fconvert.1, expr);
 
     let trueBlock = emitBlockStatement(stmt.trueBlock, ctx, indent);
     let falseBlock = emitBlockStatement(stmt.falseBlock, ctx, indent);
-    let elseBlockText = String::concat(indent, "else {%n;", fbassign, falseBlock, indent, "}%n;");
+    let elseBlockText = String::concat(indent, "else {%n;", freassign, falseBlock, indent, "}%n;");
     
     let ifstmt = String::concat(indent, "if( ", itest, " ) {%n;"); 
-    return String::concat(ifstmt, tbassign, trueBlock, indent, "}%n;", elseBlockText);
+    return String::concat(ifstmt, treassign, trueBlock, indent, "}%n;", elseBlockText);
 }
 
 function emitIfElseStatement(stmt: CPPAssembly::IfElseStatement, ctx: Context, indent: String): String {
@@ -1039,7 +1045,6 @@ function emitAssertStatement(stmt: CPPAssembly::AssertStatement, ctx: Context, i
     return String::concat(full_indent, "𝐚𝐬𝐬𝐞𝐫𝐭(", cond, ");");
 } 
 
-%% Wouldnt be awful idea to have this be more generic (not just binding type, but none and some too)
 function tryGenerateBindType(bind: Option<CPPAssembly::BinderInfo>, expr: String, fromtype: CPPAssembly::TypeKey, totype: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
     let full_indent = String::concat("    ", indent);
     if(bind)@none {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -640,6 +640,19 @@ entity CPPTransformer {
         return CPPAssembly::MatchStatement { sval, bindinfo, matchflow, stmt.mustExhaustive };
     }
 
+    method transformSwitchStatement(stmt: BSQAssembly::SwitchStatement): CPPAssembly::SwitchStatement {
+        let sval = this.transformExpressionToCpp(stmt.sval);
+        let switchflow = stmt.switchflow.map<(|Option<CPPAssembly::Expression>, CPPAssembly::BlockStatement|)>( fn(sf) => {
+            return (|if(sf.0)none then none else some(this.transformExpressionToCpp(sf.0@some)), 
+                this.transformBlockStatement(sf.1)|);
+        });
+        
+        %% Not sure if this is needed for emission 
+        let optypes = stmt.optypes.map<CPPAssembly::TypeSignature>(fn(t) => this.convertTypeSignature(t));
+
+        return CPPAssembly::SwitchStatement { sval, switchflow, stmt.mustExhaustive, optypes };
+    }
+
     method transformStatementToCpp(stmt: BSQAssembly::Statement): CPPAssembly::Statement {
         match(stmt)@ {
             BSQAssembly::EmptyStatement => { return CPPAssembly::EmptyStatement{ }; }
@@ -658,7 +671,7 @@ entity CPPTransformer {
             | BSQAssembly::IfStatement => { return this.transformIfStatement[recursive]($stmt); }
             | BSQAssembly::IfElseStatement => { return this.transformIfElseStatement[recursive]($stmt); }
             | BSQAssembly::IfElifElseStatement => { return this.transformIfElifElseStatement[recursive]($stmt); }
-            | BSQAssembly::SwitchStatement => { abort; }
+            | BSQAssembly::SwitchStatement => { return this.transformSwitchStatement($stmt); }
             | BSQAssembly::MatchStatement => { return this.transformMatchStatement($stmt); }
             | BSQAssembly::AbortStatement => { abort; }
             | BSQAssembly::AssertStatement => { return this.transformAssertStatement($stmt); } 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -629,6 +629,17 @@ entity CPPTransformer {
         return CPPAssembly::AssertStatement{ exp };
     }
 
+    method transformMatchStatement(stmt: BSQAssembly::MatchStatement): CPPAssembly::MatchStatement {
+        let sval = this.transformExpressionToCpp(stmt.sval);
+        let bindinfo = if(stmt.bindInfo)none then none 
+            else some(this.transformBinderInfo(stmt.bindInfo@some));
+        let matchflow = stmt.matchflow.map<(|CPPAssembly::TypeSignature, CPPAssembly::BlockStatement|)>( fn(mf) => {
+            return (|this.convertTypeSignature(mf.0), this.transformBlockStatement(mf.1)|);
+        });
+        
+        return CPPAssembly::MatchStatement { sval, bindinfo, matchflow, stmt.mustExhaustive };
+    }
+
     method transformStatementToCpp(stmt: BSQAssembly::Statement): CPPAssembly::Statement {
         match(stmt)@ {
             BSQAssembly::EmptyStatement => { return CPPAssembly::EmptyStatement{ }; }
@@ -648,7 +659,7 @@ entity CPPTransformer {
             | BSQAssembly::IfElseStatement => { return this.transformIfElseStatement[recursive]($stmt); }
             | BSQAssembly::IfElifElseStatement => { return this.transformIfElifElseStatement[recursive]($stmt); }
             | BSQAssembly::SwitchStatement => { abort; }
-            | BSQAssembly::MatchStatement => { abort; }
+            | BSQAssembly::MatchStatement => { return this.transformMatchStatement($stmt); }
             | BSQAssembly::AbortStatement => { abort; }
             | BSQAssembly::AssertStatement => { return this.transformAssertStatement($stmt); } 
             | BSQAssembly::ValidateStatement => { abort; }

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -383,6 +383,11 @@ entity ConstantSimplification {
         return e[exp=nexp];
     }
 
+    recursive method processCreateDirectExpression(e: CreateDirectExpression): Expression {
+        let nexp = this.processUnaryArg[recursive](e.exp);
+        return e[exp=nexp];
+    }
+
     recursive method processPostfixInvokeStatic(op: PostfixInvokeStatic): PostfixInvokeStatic {
         let ninfo = this.processInvokeArgumentInfoStatic[recursive](op.argsinfo);
         return op[argsinfo=ninfo];
@@ -763,7 +768,7 @@ entity ConstantSimplification {
             | CoerceNarrowTypeExpression => { return this.processCoerceNarrowTypeExpression[recursive]($e); }
             | CoerceWidenTypeExpression => { return this.processCoerceWidenTypeExpression[recursive]($e); }
             | SafeConvertExpression => { return this.processSafeConvertExpression[recursive]($e); }
-            | CreateDirectExpression => { abort; }
+            | CreateDirectExpression => { return this.processCreateDirectExpression[recursive]($e); }
             | PostfixOp => { return this.processPostfixOp[recursive]($e); }
             | UnaryExpression => { return this.processUnaryExpression[recursive]($e); }
             | BinaryArithExpression => { return this.processBinaryArithExpression[recursive]($e); }
@@ -981,9 +986,24 @@ entity ConstantSimplification {
         }
     }
 
+    recursive method processSwitchStatement(s: SwitchStatement): Statement {
+        let nsv = this.processExpression[recursive](s.sval);
+
+        let nflow = s.switchflow.map<(|Option<Expression>, BlockStatement|)>(fn(mb) => {
+            let ne = if(mb.0)none then none else some(this.processExpression[recursive](mb.0@some));
+            let nb = this.processBlockStatement[recursive](mb.1);
+            return (|ne, nb|);
+        });
+            
+        return s[sval=nsv, switchflow=nflow];
+    }
+
     recursive method processStatement(s: Statement): Statement {
         match(s)@ {
-            VariableDeclarationStatement => {
+            EmptyStatement => { 
+                return s; 
+            }
+            | VariableDeclarationStatement => {
                 return s;
             }
             | VariableMultiDeclarationStatement => {
@@ -1007,6 +1027,7 @@ entity ConstantSimplification {
             | VariableMultiAssignmentImplicitStatement => {
                 return $s[exp = this.processExpression($exp)];
             }
+            | VariableRetypeStatement => { abort; }
             | ReturnVoidStatement => {
                 return s;
             }
@@ -1024,6 +1045,9 @@ entity ConstantSimplification {
             }
             | IfElifElseStatement => {
                 return this.processIfElifElseStatement[recursive]($s);
+            }
+            | SwitchStatement => { 
+                return this.processSwitchStatement[recursive]($s);
             }
             | MatchStatement => {
                 return this.processMatchStatement[recursive]($s);

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -375,6 +375,12 @@ entity ExplicitifyTransform {
         return e[exp=nexp];
     }
 
+    recursive method processCreateDirectExpression(e: CreateDirectExpression, vmap: VarMapping): Expression {
+        let nexp = this.processUnaryArg[recursive](e.exp, vmap);
+
+        return e[exp=nexp];
+    }
+
     recursive method processPostfixInvokeStatic(op: PostfixInvokeStatic, vmap: VarMapping): PostfixInvokeStatic {
         let smdecl = this.assembly.staticmethods.get(op.resolvedTrgt);
         let nargs = this.processInvokeArgumentInfoStatic[recursive](op.sinfo, smdecl.params, op.argsinfo, vmap);
@@ -588,7 +594,7 @@ entity ExplicitifyTransform {
             | CoerceNarrowTypeExpression => { return this.processCoerceNarrowTypeExpression[recursive]($e, vmap); }
             | CoerceWidenTypeExpression => { return this.processCoerceWidenTypeExpression[recursive]($e, vmap); }
             | SafeConvertExpression => { return this.processSafeConvertExpression[recursive]($e, vmap); }
-            | CreateDirectExpression => { abort; }
+            | CreateDirectExpression => { return this.processCreateDirectExpression[recursive]($e, vmap); }
             | PostfixOp => { return this.processPostfixOp[recursive]($e, vmap); }
             | UnaryExpression => { return this.processUnaryExpression[recursive]($e, vmap); }
             | BinaryArithExpression => { return this.processBinaryArithExpression[recursive]($e, vmap); }
@@ -696,6 +702,16 @@ entity ExplicitifyTransform {
         return s[sval=nsv, matchflow=nflow];
     }
 
+    recursive method processSwitchStatement(s: SwitchStatement, vmap: VarMapping): Statement {
+        let nsv = this.processExpression[recursive](s.sval, vmap);
+        let nflow = s.switchflow.map[recursive]<(|Option<Expression>, BlockStatement|)>(fn(mb) => {
+            return (|if(mb.0)none then none else some(this.processExpression[recursive](mb.0@some, vmap)), 
+                this.processBlockStatement[recursive](mb.1, vmap)|);
+        });
+
+        return s[sval=nsv, switchflow=nflow];
+    }
+
     recursive method processStatement(s: Statement, vmap: VarMapping): Statement {
         match(s)@ {
             EmptyStatement => {
@@ -733,6 +749,7 @@ entity ExplicitifyTransform {
             | VariableMultiAssignmentImplicitStatement => {
                 return $s[exp=this.processExpression($s.exp, vmap)];
             }
+            | VariableRetypeStatement => { abort; }
             | ReturnVoidStatement => {
                 return s;
             }
@@ -754,6 +771,9 @@ entity ExplicitifyTransform {
             | IfElifElseStatement => {
                 return this.processIfElifElseStatement[recursive]($s, vmap);
             }
+            | SwitchStatement => { 
+                return this.processSwitchStatement[recursive]($s, vmap); 
+            }
             | MatchStatement => {
                 return this.processMatchStatement[recursive]($s, vmap);
             }
@@ -765,6 +785,10 @@ entity ExplicitifyTransform {
                 let nc = this.processExplicitBoolConvertAsNeeded(nr);
                 return $s[cond = nc];
             }
+            | ValidateStatement => { abort; }
+            | DebugStatement => { abort; }
+            | UpdateDirectStatement => { abort; }
+            | UpdateIndirectStatement => { abort; }
             | BlockStatement => {
                 return this.processBlockStatement[recursive]($s, vmap);
             }

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -1495,7 +1495,7 @@ class BSQIREmitter {
     private emitSwitchStatement(stmt: SwitchStatement, fmt: BsqonCodeFormatter): string {
         const sbase = this.emitStatementBase(stmt);
         const sval = this.emitExpression(stmt.sval);
-        const switchflow = stmt.switchflow.slice(1).map((e) => {
+        const switchflow = stmt.switchflow.map((e) => {
             const cond = e.lval !== undefined ? `some(${this.emitExpression(e.lval.exp)})` : "none";
             const body = this.emitBlockStatement(e.value, fmt);
             return `(|${cond}, ${body}|)`;

--- a/test/cppoutput/if_exp/basic_if.test.js
+++ b/test/cppoutput/if_exp/basic_if.test.js
@@ -9,22 +9,19 @@ describe ("CPP Emit Evaluate -- Simple if-expression", () => {
         runMainCode("public function main(): Int { return if(2n != 2n) then 2i else 3i; }", "3_i");
     });
 
-    it("should exec expressions w/ itest", function () {
-        
-        // Need to add ifTestExpression support to cpp emitter
-        
-        //runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)!none then 2i else 3i; }", "2_i");
-        //runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)some then 2i else 3i; }", "2_i");
-        //runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)<Some<Int>> then 2i else 3i; }", "2_i");
+    it("should exec expressions w/ itest", function () {        
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)!none then 2i else 3i; }", "2_i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)some then 2i else 3i; }", "2_i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); return if(x)<Some<Int>> then 2i else 3i; }", "2_i");
 
-        //runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if(x)@!none then $x else 3i; }", "1i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if(x)@!none then $x else 3i; }", "1_i");
         runMainCode("public function main(): Int { let x: Int = 1i; return if(x < 3i) then 0i else x; }", "0_i");
         
-        //runMainCode("public function main(): Int { let x: Int = 1i; return if(if(x < 3i) then none else some(x))@!none then $_ else 3i; }", "3i");
-        //runMainCode("public function main(): Int { let x: Int = 5i; return if(if(x < 3i) then none else some(x))@!none then $_ else 3i; }", "5i");
+        runMainCode("public function main(): Int { let x: Int = 1i; return if(if(x < 3i) then none else some(x))@!none then $_ else 3i; }", "3_i");
+        runMainCode("public function main(): Int { let x: Int = 5i; return if(if(x < 3i) then none else some(x))@!none then $_ else 3i; }", "5_i");
         
-        //runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if($y = x)@<Some<Int>> then $y.value else 3i; }", "1i");
-        //runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if($y = x)@some then $y else 3i; }", "1i");
-        //runMainCode("public function main(): Int { let x: Option<Int> = none; return if($y = x)@some then $y else 3i; }", "3i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if($y = x)@<Some<Int>> then $y.value else 3i; }", "1_i");
+        runMainCode("public function main(): Int { let x: Option<Int> = some(1i); return if($y = x)@some then $y else 3i; }", "1_i");
+        runMainCode("public function main(): Int { let x: Option<Int> = none; return if($y = x)@some then $y else 3i; }", "3_i");
     });
 });

--- a/test/cppoutput/match_stmts/simple_match.test.js
+++ b/test/cppoutput/match_stmts/simple_match.test.js
@@ -1,0 +1,24 @@
+"use strict";
+
+import { runMainCode, runMainCodeError } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";
+
+describe ("Exec -- match Statement", () => {
+    it("should exec simple match", function () {
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); match(x) { None => { return 0i; } | _ => { return 1i; } } }", "1_i");
+        runMainCode("public function main(): Int { let x: Option<Int> = none; match(x) { None => { return 0i; } | _ => { return 1i; } } }", "0_i");
+        
+        runMainCode("datatype Foo of F1 {} | F2 {}; public function main(): Int { let x: Foo = F1{}; match(x) { F1 => { return 0i; } | F2 => { return 1i; } } }", "0_i");
+    });
+
+    it("should exec fail simple match", function () {
+        runMainCodeError("datatype Foo of F1 {} | F2 {} | F3 {}; public function main(): Int { let x: Foo = F3{}; match(x) { F1 => { return 0i; } | F2 => { return 1i; } } }", 'Assertion failed! Or perhaps over/underflow?\n');
+    });
+
+    it("should exec binder match", function () {
+        runMainCode("public function main(): Int { let x: Option<Int> = some(3i); match(x)@ { None => { return 0i; } | _ => { return 1i; } } }", "1_i");
+        
+        runMainCode("datatype Foo of F1 {} | F2 { g: Int }; public function main(): Int { let x: Foo = F1{}; match(x)@ { F1 => { return 0i; } | F2 => { return $x.g; } } }", "0_i");
+        runMainCode("datatype Foo of F1 {} | F2 { g: Int }; public function main(): Int { let x: Foo = F2{5i}; match(x)@ { F1 => { return 0i; } | F2 => { return $x.g; } } }", "5_i");
+    });
+});

--- a/test/cppoutput/match_stmts/simple_switch.test.js
+++ b/test/cppoutput/match_stmts/simple_switch.test.js
@@ -1,0 +1,21 @@
+"use strict";
+
+import { runMainCode, runMainCodeError } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("Exec -- switch Statement", () => {
+    it("should exec simple switch", function () {
+        runMainCode("public function main(): Int { let x = 3i; switch(x) { 0i => { return 0i; } | _ => { return 1i; } } }", "1_i");
+        runMainCode("public function main(): Int { let x = 0i; switch(x) { 0i => { return 0i; } | _ => { return 1i; } } }", "0_i");
+    });
+
+    it("should exec fail simple switch", function () {
+        runMainCodeError("public function main(): Int { let x = 3i; switch(x) { 0i => { return 0i; } | 1i => { return 1i; } } }",'Assertion failed! Or perhaps over/underflow?\n');
+    });
+
+    it("should exec enum switch", function () {
+        runMainCode("enum Foo { f, g } public function main(): Int { let x = Foo#f; switch(x) { Foo#f => { return 0i; } | _ => { return 1i; } } }", "0_i");
+        runMainCode("enum Foo { f, g } public function main(): Int { let x = Foo#f; switch(x) { Foo#f => { return 0i; } | Foo#g => { return 1i; } } }", "0_i");
+        runMainCode("enum Foo { f, g } public function main(): Int { let x = Foo#g; switch(x) { Foo#f => { return 0i; } | Foo#g => { return 1i; } } }", "1_i");
+    });
+});


### PR DESCRIPTION
Added support for cpp emission of `MatchStatement`, `SwitchStatement`, and `IfBinderExpression` . 

Some bosque code like so 
```
public function main(): Int {
    let x: Option<Int> = some(3i);
    let y: Option<Int> = if(x)@some then some(3i) else none;
    match(y)@ {
        None => { return 0i; }
        | Some<Int> => {
            let tmp = $y.value;
            switch(tmp) {
                3i => { return if(tmp > 2i) then tmp else 0i; }
                | _ => { return 0i; }
            }
        }
    }
}
```

Will now emit in cpp
```
namespace Main {
    __CoreCpp::Int main() noexcept;
    __CoreCpp::Int main() noexcept  {
        Core::OptionᐸIntᐳ x = Core::OptionᐸIntᐳ{ &Core::SomeᐸIntᐳType, Core::SomeᐸIntᐳ{ 3_i} };
        Core::OptionᐸIntᐳ y = ( x.typeinfo != &NoneType 
            ? ([&]() -> Core::OptionᐸIntᐳ { [[maybe_unused]] __CoreCpp::Int $x = x.access<Core::SomeᐸIntᐳ>().value; return Core::OptionᐸIntᐳ{ &Core::SomeᐸIntᐳType, Core::SomeᐸIntᐳ{ 3_i} }; }() ) 
            : ([&]() -> Core::OptionᐸIntᐳ { [[maybe_unused]] __CoreCpp::None $x = x.accessnone(); return Core::OptionᐸIntᐳ{ &NoneType }; }() ) );
        if(y.typeinfo == &NoneType) {
            [[maybe_unused]] __CoreCpp::None $y = y.access<__CoreCpp::None>();
            return 0_i;
        }
        else if(y.typeinfo == &Core::SomeᐸIntᐳType) {
            [[maybe_unused]] Core::SomeᐸIntᐳ $y = y.access<Core::SomeᐸIntᐳ>();
            __CoreCpp::Int tmp = $y.value;
            if( tmp == 3_i ) {
                return ( (tmp > 2_i) ? (tmp) : (0_i) );
            }
            else if( true ) {
                return 0_i;
            }
            else {
                𝐚𝐛𝐨𝐫𝐭;
            }
        }
        else {
            𝐚𝐛𝐨𝐫𝐭;
        }
    }
}
```