### PR TITLE
CPP List Constructors and Tests

### DIFF
--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -130,7 +130,7 @@ public:
 
     // None constructor
     Boxed(TypeInfoBase* ti) noexcept : typeinfo(ti) {};
-    
+
     template<typename T, uintptr_t I=0>
     constexpr T* access_ref() noexcept {
         return reinterpret_cast<T*>(reinterpret_cast<uintptr_t*>(this->data) + I);   

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -233,6 +233,10 @@ function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): String {
     return String::fromCString(nsk.value);
 }
 
+function generateAccessorForSpecialTypeConstructor(): String {
+    return "";
+}
+
 %% Given a namespace key (like Main::Foo::Bar), remove all matching prefix strings
 function emitResolvedNamespace(fullns_list: List<CString>, fullns: String): String {
     return fullns_list.reduce<String>(fullns, fn(acc, s) => {
@@ -532,13 +536,22 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, rootexp: 
         thisarg = exp;
     } 
 
-    %% Remove abstract nominal we were in
-    var resolvedInvoke = emitSpecialTemplate(ik.removePrefixString(tk).removePrefixString("::"));
+    let resolvedtype = ctx.asm.lookupNominalTypeDeclaration(op.resolvedType.tkeystr);
+    let ns = emitResolvedNamespace(ctx.fullns_list, emitNamespaceKey(resolvedtype.declaredInNS));
+    let resolvedns = if(ns !== "" && !ns.endsWithString("::")) 
+        then String::concat(ns, "::")
+        else ns;
+    
+    let name = String::concat(resolvedns, removeCommonPrefix(ik, tk));
+    let resolvedname = if(name.startsWithString("::")) 
+        then emitSpecialTemplate(name.removePrefixString("::")) 
+        else emitSpecialTemplate(name);
+
     if(args === "") {
-        return String::concat(resolvedInvoke, "(", thisarg, ")");
+        return String::concat(resolvedname, "(", thisarg, ")");
     }
     else {
-         return String::concat(resolvedInvoke, "(", thisarg, ", ", args, ")");       
+         return String::concat(resolvedname, "(", thisarg, ", ", args, ")");       
     }
 }
 
@@ -718,7 +731,19 @@ function emitConstructorEListExpression(exp: CPPAssembly::ConstructorEListExpres
 }
 
 function emitConstructorPrimaryListExpression(exp: CPPAssembly::ConstructorPrimaryListExpression, ctx: Context): String {
-    return "";
+    let args = emitArguments(exp.args, ctx);
+    let ns = "Core::ListOps::"; %% This will always be the case 
+    let ofttype = String::concat("ᐸ", removeCppPrefix(emitTypeSignature(exp.elemtype, true, ctx)), "ᐳ");
+    switch(exp.args.size()) {
+        0n => { return String::concat(ns, "s_list_create_empty", ofttype, "()"); }
+        | 1n => { return String::concat(ns, "s_list_create_1", ofttype, "(", args, ")"); }
+        | 2n => { return String::concat(ns, "s_list_create_2", ofttype, "(", args, ")"); }
+        | 3n => { return String::concat(ns, "s_list_create_3", ofttype, "(", args, ")"); }
+        | 4n => { return String::concat(ns, "s_list_create_4", ofttype, "(", args, ")"); }
+        | 5n => { return String::concat(ns, "s_list_create_5", ofttype, "(", args, ")"); }
+        | 6n => { return String::concat(ns, "s_list_create_6", ofttype, "(", args, ")"); }
+        | _ =>  { abort; }
+    }
 }
 
 function emitConstructorPrimaryMapExpression(exp: CPPAssembly::ConstructorPrimaryMapExpression, ctx: Context): String {
@@ -823,7 +848,6 @@ function emitWidenedTypeExpression(exp: CPPAssembly::CoerceWidenTypeExpression, 
     let tottsig = exp.trgttype;
     let emitexp = emitExpression(exp.exp, ctx);
 
-    let fromtkey_size = String::fromCString(ctx.asm.typeinfos.tryGet(fromtkey)@some.slotsize.toCString()); %% This is T
     let name = emitTypeSignature(tottsig, false, ctx);
 
     let ttype = String::concat(emitTypeSignature(exp.srctype, false, ctx), "Type");
@@ -849,12 +873,20 @@ function emitNarrowedTypeExpression(exp: CPPAssembly::CoerceNarrowTypeExpression
     }
 }
 
+%% I believe this is always a call to access<T>()?
 function emitSafeConvertExpression(exp: CPPAssembly::SafeConvertExpression, ctx: Context): String {
-   return emitExpression(exp.exp, ctx);
+    let tottype = emitTypeSignature(exp.trgttype, false, ctx);
+
+   return String::concat(emitExpression(exp.exp, ctx), getAccessor(exp.trgttype.tkeystr, ctx), "<", tottype, ">()");
 }
 
 function emitCreateDirectExpression(exp: CPPAssembly::CreateDirectExpression, ctx: Context): String {
-   return emitExpression(exp.exp, ctx); 
+    let eexp = emitExpression(exp.exp, ctx); 
+    let name = emitTypeSignature(exp.trgttype, false, ctx);
+    let ttype = String::concat(emitTypeSignature(exp.srctype, false, ctx), "Type");
+
+    return if(eexp === "") then String::concat(name, "{ &", ttype, " }")
+        else String::concat(name, "{ &", ttype, ", ", eexp, " }");
 }
 
 function emitAccessEnumExpression(exp: CPPAssembly::AccessEnumExpression, ctx: Context): String {
@@ -929,7 +961,7 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): String {
         %%| CPPAssembly::TypeDeclPrimitiveFieldAccessExpression => { abort; }
         | CPPAssembly::CoerceWidenTypeExpression => { return emitWidenedTypeExpression($e, ctx); }
         | CPPAssembly::CoerceNarrowTypeExpression => { return emitNarrowedTypeExpression($e, ctx); }
-        | CPPAssembly::SafeConvertExpression => { abort; }
+        | CPPAssembly::SafeConvertExpression => { return emitSafeConvertExpression($e, ctx); }
         | CPPAssembly::CreateDirectExpression => { return emitCreateDirectExpression($e, ctx); }
         | CPPAssembly::PostfixOp => { return emitPostfixOp($e, ctx); }
         | CPPAssembly::UnaryExpression => { return emitUnaryExpression[recursive]($e, ctx); }
@@ -1569,8 +1601,16 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
         return String::concat(acc, emitNamespaceDecl[recursive](decl, ctx, full_indent));
     });
 
+    %% Emit methods after all type defintions to prevent types not being fully defined but used
+    let methods = nsdecl.alltypes
+        .reduce<String>(subns, fn(acc, tk) => {
+            let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
+            let func = emitMethods(ant, tk, ctx, full_indent);
+            return String::concat(acc, func);
+    });
+
     %% Emit functions in current namespace
-    let nsfuncs = nsdecl.nsfuncs.reduce<String>(subns , fn(acc, ikey) => {
+    let nsfuncs = nsdecl.nsfuncs.reduce<String>(methods , fn(acc, ikey) => {
         return String::concat(acc, emitFunctionDecl(ctx.asm.nsfuncs.get(ikey)@<CPPAssembly::AbstractInvokeDecl>, ctx, full_indent)); 
     });
 
@@ -1656,15 +1696,7 @@ function emitNamespaceDeclTypes(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context
             return String::concat(acc, emitMethodForwardDeclaration(ctx.asm.staticmethods.get(mtkey.0), mtkey.1, ctx, full_indent));
     });
 
-    %% Emit methods after all type defintions to prevent types not being fully defined but used
-    let methods = nsdecl.alltypes
-        .reduce<String>(method_fwddecls, fn(acc, tk) => {
-            let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
-            let func = emitMethods(ant, tk, ctx, full_indent);
-            return String::concat(acc, func);
-    });
-
-    return String::concat(methods, indent, "}%n;");
+    return String::concat(method_fwddecls, indent, "}%n;");
 }
 
 function emitAssembly(asm: CPPAssembly::Assembly): String {    
@@ -1694,7 +1726,7 @@ function emitAssembly(asm: CPPAssembly::Assembly): String {
         });
 
 
-    let ns_emission = asm.nsdecls.reduce<String>("//%n;// Emitted Functions%n;//%n;", fn(acc, nsname, nsdecl) => {
+    let ns_emission = asm.nsdecls.reduce<String>("//%n;// Emitted Functions/Methods%n;//%n;", fn(acc, nsname, nsdecl) => {
         return String::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, ""));
     });
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -237,12 +237,12 @@ function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): String {
 function generateAccessorForSpecialTypeConstructor(constype: CPPAssembly::TypeSignature, ttype: CPPAssembly::TypeSignature, 
     eexp: String, ctx: Context): String {
         let econstype = emitTypeSignature(constype, false, ctx);
-        let ettype = String::concat(removeCppPrefix(emitTypeSignature(ttype, false, ctx)), "Type");
 
         if(ctx.asm.isNominalTypeConcept(ttype.tkeystr)) {
             return String::concat(econstype, "{ ", eexp, " }");
         }
         else {
+            let ettype = String::concat(removeCppPrefix(emitTypeSignature(ttype, false, ctx)), "Type");
             return if(eexp === "") then String::concat(econstype, "{ &", ettype, " }")
                 else String::concat(econstype, "{ &", ettype, ", ", eexp, " }");
         }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -239,8 +239,13 @@ function generateAccessorForSpecialTypeConstructor(constype: CPPAssembly::TypeSi
         let econstype = emitTypeSignature(constype, false, ctx);
         let ettype = String::concat(removeCppPrefix(emitTypeSignature(ttype, false, ctx)), "Type");
 
-        return if(eexp === "") then String::concat(econstype, "{ &", ettype, " }")
-            else String::concat(econstype, "{ &", ettype, ", ", eexp, " }");
+        if(ctx.asm.isNominalTypeConcept(ttype.tkeystr)) {
+            return String::concat(econstype, "{ ", eexp, " }");
+        }
+        else {
+            return if(eexp === "") then String::concat(econstype, "{ &", ettype, " }")
+                else String::concat(econstype, "{ &", ettype, ", ", eexp, " }");
+        }
 }
 
 %% Given a namespace key (like Main::Foo::Bar), remove all matching prefix strings
@@ -519,25 +524,24 @@ function emitPostfixAccessFromIndex(op: CPPAssembly::PostfixAccessFromIndex, acc
     return String::concat(acc, ".access<", accessed, ", ", idx, ">()");
 }
 
-function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, rootexp: CPPAssembly::Expression, ctx: Context): String {
+function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, rootexp: String, ctx: Context): String {
     %% We don't want to do any resolution of these keys yet
     let ik = String::fromCString(op.resolvedTrgt.value);
     let tk = String::fromCString(op.resolvedType.tkeystr.value);
 
     let args = emitArguments(op.args, ctx);
-    let erootexp = emitExpression(rootexp, ctx);
 
     %% The "this" arguemnt does not exist in explicitify so we handle the coersion here (we manually added it for cpp emission)
     var thisarg: String;
-    if(!ctx.asm.areTypesSame(rootexp.etype, op.resolvedType)) {
-        let roottinfo = ctx.asm.typeinfos.get(rootexp.etype.tkeystr);
+    if(!ctx.asm.areTypesSame(op.baseType, op.resolvedType)) {
+        let roottinfo = ctx.asm.typeinfos.get(op.baseType.tkeystr);
         let slotsize = if(roottinfo.tag === CPPAssembly::Tag#Tagged) then roottinfo.slotsize - 1n else roottinfo.slotsize;
-        let eexp = if(slotsize == 0n) then "" else erootexp;
+        let eexp = if(slotsize == 0n) then "" else rootexp;
 
-        thisarg = generateAccessorForSpecialTypeConstructor(op.resolvedType, rootexp.etype, eexp, ctx);
+        thisarg = generateAccessorForSpecialTypeConstructor(op.resolvedType, op.baseType, eexp, ctx);
     }
     else {
-        thisarg = erootexp;
+        thisarg = rootexp;
     } 
 
     let resolvedtype = ctx.asm.lookupNominalTypeDeclaration(op.resolvedType.tkeystr);
@@ -663,7 +667,7 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
             | CPPAssembly::PostfixAccessFromIndex => { return emitPostfixAccessFromIndex($op, acc, ctx); }
             | CPPAssembly::PostfixIsTest => { return String::concat(acc, emitITestAsTest($op.ttest, $op.baseType, ctx)); }
             | CPPAssembly::PostfixAsConvert => { return String::concat(acc, emitITestAsConvert($op.ttest.isnot, $op.ttest, $op.baseType.tkeystr, none, ctx).0); }
-            | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, pop.rootExp, ctx); } %% This will not chain method calls :(
+            | CPPAssembly::PostfixInvokeStatic => { return emitPostfixInvokeStatic($op, acc, ctx); } 
             | CPPAssembly::PostfixBoolConstant => { return if($op.value === true) then "true" else "false"; }
             | CPPAssembly::PostfixAccessSomeValue => { return emitPostfixAccessSomeValue($op, acc, pop.rootExp.etype, ctx); }
         }
@@ -853,7 +857,6 @@ function emitWidenedTypeExpression(exp: CPPAssembly::CoerceWidenTypeExpression, 
     return generateAccessorForSpecialTypeConstructor(exp.trgttype, exp.srctype, eexp, ctx);
 }
 
-%% We will need this to help us take "this.f?<Int>" to "false"
 function emitNarrowedTypeExpression(exp: CPPAssembly::CoerceNarrowTypeExpression, ctx: Context): String {
     let tottype = emitTypeSignature(exp.trgttype, false, ctx);
     let emitexp = emitExpression(exp.exp, ctx);   
@@ -873,9 +876,9 @@ function emitSafeConvertExpression(exp: CPPAssembly::SafeConvertExpression, ctx:
 }
 
 function emitCreateDirectExpression(exp: CPPAssembly::CreateDirectExpression, ctx: Context): String {
-    let eexp = emitExpression(exp.exp, ctx);
+    let eexp = emitExpression(exp.exp, ctx); 
 
-    return generateAccessorForSpecialTypeConstructor(exp.trgttype, exp.srctype, eexp, ctx);
+    return generateAccessorForSpecialTypeConstructor(exp.trgttype, exp.exp.etype, eexp, ctx);
 }
 
 function emitAccessEnumExpression(exp: CPPAssembly::AccessEnumExpression, ctx: Context): String {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -233,8 +233,14 @@ function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): String {
     return String::fromCString(nsk.value);
 }
 
-function generateAccessorForSpecialTypeConstructor(): String {
-    return "";
+%% For constructing concepts
+function generateAccessorForSpecialTypeConstructor(constype: CPPAssembly::TypeSignature, ttype: CPPAssembly::TypeSignature, 
+    eexp: String, ctx: Context): String {
+        let econstype = emitTypeSignature(constype, false, ctx);
+        let ettype = String::concat(removeCppPrefix(emitTypeSignature(ttype, false, ctx)), "Type");
+
+        return if(eexp === "") then String::concat(econstype, "{ &", ettype, " }")
+            else String::concat(econstype, "{ &", ettype, ", ", eexp, " }");
 }
 
 %% Given a namespace key (like Main::Foo::Bar), remove all matching prefix strings
@@ -519,21 +525,19 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, rootexp: 
     let tk = String::fromCString(op.resolvedType.tkeystr.value);
 
     let args = emitArguments(op.args, ctx);
-    let exp = emitExpression(rootexp, ctx);
+    let erootexp = emitExpression(rootexp, ctx);
 
     %% The "this" arguemnt does not exist in explicitify so we handle the coersion here (we manually added it for cpp emission)
     var thisarg: String;
     if(!ctx.asm.areTypesSame(rootexp.etype, op.resolvedType)) {
-        let rootexptype = emitTypeSignature(rootexp.etype, false, ctx);
         let roottinfo = ctx.asm.typeinfos.get(rootexp.etype.tkeystr);
-        let targettype = emitTypeKey(op.resolvedType.tkeystr, false, ctx);
-
         let slotsize = if(roottinfo.tag === CPPAssembly::Tag#Tagged) then roottinfo.slotsize - 1n else roottinfo.slotsize;
-        thisarg = if(slotsize == 0n) then String::concat(targettype, "{ &", rootexptype, "Type }")
-            else String::concat(targettype, "{ &", rootexptype, "Type, ", exp, " }"); 
+        let eexp = if(slotsize == 0n) then "" else erootexp;
+
+        thisarg = generateAccessorForSpecialTypeConstructor(op.resolvedType, rootexp.etype, eexp, ctx);
     }
     else {
-        thisarg = exp;
+        thisarg = erootexp;
     } 
 
     let resolvedtype = ctx.asm.lookupNominalTypeDeclaration(op.resolvedType.tkeystr);
@@ -542,16 +546,16 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, rootexp: 
         then String::concat(ns, "::")
         else ns;
     
-    let name = String::concat(resolvedns, removeCommonPrefix(ik, tk));
+    let name = removeCommonPrefix(ik, tk);
     let resolvedname = if(name.startsWithString("::")) 
-        then emitSpecialTemplate(name.removePrefixString("::")) 
-        else emitSpecialTemplate(name);
+        then String::concat(resolvedns, emitSpecialTemplate(name.removePrefixString("::")))
+        else String::concat(resolvedns, emitSpecialTemplate(name));
 
     if(args === "") {
         return String::concat(resolvedname, "(", thisarg, ")");
     }
     else {
-         return String::concat(resolvedname, "(", thisarg, ", ", args, ")");       
+        return String::concat(resolvedname, "(", thisarg, ", ", args, ")");       
     }
 }
 
@@ -842,22 +846,11 @@ function emitIfExpression(exp: CPPAssembly::IfExpression, ctx: Context): String 
     }
 }
 
-%% We are only widening to options for now
 function emitWidenedTypeExpression(exp: CPPAssembly::CoerceWidenTypeExpression, ctx: Context): String {
-    let fromtkey = exp.srctype.tkeystr;
-    let tottsig = exp.trgttype;
-    let emitexp = emitExpression(exp.exp, ctx);
+    let eexp = if(exp.exp?<CPPAssembly::LiteralNoneExpression>) then "" 
+        else emitExpression(exp.exp, ctx);
 
-    let name = emitTypeSignature(tottsig, false, ctx);
-
-    let ttype = String::concat(emitTypeSignature(exp.srctype, false, ctx), "Type");
-
-    if(exp.exp?<CPPAssembly::LiteralNoneExpression>) {
-        return String::concat(name, "{ &", removeCppPrefix(ttype) ," }");
-    }
-
-    return if(emitexp === "") then String::concat(name, "{ &", ttype, " }")
-        else String::concat(name, "{ &", ttype, ", ", emitexp, " }");
+    return generateAccessorForSpecialTypeConstructor(exp.trgttype, exp.srctype, eexp, ctx);
 }
 
 %% We will need this to help us take "this.f?<Int>" to "false"
@@ -873,7 +866,6 @@ function emitNarrowedTypeExpression(exp: CPPAssembly::CoerceNarrowTypeExpression
     }
 }
 
-%% I believe this is always a call to access<T>()?
 function emitSafeConvertExpression(exp: CPPAssembly::SafeConvertExpression, ctx: Context): String {
     let tottype = emitTypeSignature(exp.trgttype, false, ctx);
 
@@ -881,12 +873,9 @@ function emitSafeConvertExpression(exp: CPPAssembly::SafeConvertExpression, ctx:
 }
 
 function emitCreateDirectExpression(exp: CPPAssembly::CreateDirectExpression, ctx: Context): String {
-    let eexp = emitExpression(exp.exp, ctx); 
-    let name = emitTypeSignature(exp.trgttype, false, ctx);
-    let ttype = String::concat(emitTypeSignature(exp.srctype, false, ctx), "Type");
+    let eexp = emitExpression(exp.exp, ctx);
 
-    return if(eexp === "") then String::concat(name, "{ &", ttype, " }")
-        else String::concat(name, "{ &", ttype, ", ", eexp, " }");
+    return generateAccessorForSpecialTypeConstructor(exp.trgttype, exp.srctype, eexp, ctx);
 }
 
 function emitAccessEnumExpression(exp: CPPAssembly::AccessEnumExpression, ctx: Context): String {

--- a/test/cppoutput/elist/elist_const_access.test.js
+++ b/test/cppoutput/elist/elist_const_access.test.js
@@ -3,7 +3,7 @@
 import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
 import { describe, it } from "node:test";
 
-describe ("Exec -- elist decl and access", () => {
+describe ("CPP Emit Evaluate -- elist decl and access", () => {
     it("should exec simple elist", function () {
         runMainCode('public function main(): Int { return (|2i, true|).0; }', "2_i"); 
         runMainCode('public function main(): Bool { return (|2i, true|).1; }', "true"); 

--- a/test/cppoutput/list/list_access.test.js
+++ b/test/cppoutput/list/list_access.test.js
@@ -1,0 +1,44 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("CPP Emit List -- access", () => {
+    it("should get single", function () {
+        runMainCode('public function main(): Int { return List<Int>{1i}.single(); }', "1_i"); 
+    });
+
+    it("should get back", function () {
+        runMainCode('public function main(): Int { return List<Int>{1i}.back(); }', "1_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.back(); }', "2_i"); 
+    });
+
+    it("should get front", function () {
+        runMainCode('public function main(): Int { return List<Int>{1i}.front(); }', "1_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.front(); }', "1_i"); 
+    });
+
+    it("should get index", function () {
+        runMainCode('public function main(): Int { return List<Int>{1i}.get(0n); }', "1_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i, 3i}.get(0n); }', "1_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.get(1n); }', "2_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i, 3i}.get(1n); }', "2_i"); 
+    });
+
+    /*
+    it("should fail get empty", function () {
+        runMainCode('public function main(): Int { return List<Int>{}.back(); }', "(assert (not (is-@Result-err Main@main)))");
+        runMainCode('public function main(): Int { return List<Int>{}.front(); }', "(assert (not (is-@Result-err Main@main)))");
+        runMainCode('public function main(): Int { return List<Int>{}.get(0n); }', "(assert (not (is-@Result-err Main@main)))"); 
+    });
+
+    it("should fail get single", function () {
+        runMainCode('public function main(): Int { return List<Int>{}.single(); }', "(assert (not (is-@Result-err Main@main)))");
+        runMainCode('public function main(): Int { return List<Int>{0i, 5i}.single(); }', "(assert (not (is-@Result-err Main@main)))");
+    });
+
+    it("should fail get out-of-bounds", function () {
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.get(3n); }', "(assert (not (is-@Result-err Main@main)))");
+    });
+    */
+});

--- a/test/cppoutput/list/list_basic.test.js
+++ b/test/cppoutput/list/list_basic.test.js
@@ -1,0 +1,37 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate List -- construct empty and isEmpty", () => {
+    it("should create simple list", function () {
+        runMainCode('public function main(): Bool { return List<Int>{}.empty(); }', "true"); 
+        runMainCode('public function main(): Bool { return List<Int>{1i}.empty(); }', "false"); 
+    });
+
+    it("should isSingle list", function () {
+        runMainCode('public function main(): Bool { return List<Int>{}.isSingle(); }', "false"); 
+        runMainCode('public function main(): Bool { return List<Int>{1i}.isSingle(); }', "true"); 
+        runMainCode('public function main(): Bool { return List<Int>{1i, 2i}.isSingle(); }', "false"); 
+    });
+});
+
+describe ("CPP Emit Evaluate List -- immediate and size", () => {
+    it("should create and size", function () {
+        runMainCode('public function main(): Nat { return List<Int>{}.size(); }', "0_n"); 
+        runMainCode('public function main(): Nat { return List<Int>{1i}.size(); }', "1_n"); 
+        runMainCode('public function main(): Nat { return List<Int>{1i, 2i, 3i}.size(); }', "3_n"); 
+    });
+
+    it("should create and lastIndex", function () {
+        runMainCode('public function main(): Nat { return List<Int>{1i}.lastIndex(); }', "0_n"); 
+        runMainCode('public function main(): Nat { return List<Int>{1i, 2i, 3i}.lastIndex(); }', "2_n"); 
+    });
+
+/*
+    it("smt should error empty lastIndex", function () {
+        runMainCode('public function main(): Nat { return List<Int>{}.lastIndex(); }', ""); 
+    });
+*/
+});
+

--- a/test/cppoutput/list/list_set.test.js
+++ b/test/cppoutput/list/list_set.test.js
@@ -1,0 +1,46 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate List -- set", () => {
+    it("should set back", function () {
+        runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.setBack(5i).size(); }', "2_n"); 
+
+        runMainCode('public function main(): Int { return List<Int>{1i}.setBack(2i).back(); }', "2_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.setBack(5i).back(); }', "5_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.setBack(5i).front(); }', "1_i");
+    });
+
+    it("should set front", function () {
+        runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.setFront(5i).size(); }', "2_n"); 
+
+        runMainCode('public function main(): Int { return List<Int>{1i}.setFront(2i).front(); }', "2_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.setFront(5i).front(); }', "5_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.setFront(5i).back(); }', "2_i"); 
+    });
+
+    it("should set index", function () {
+        runMainCode('public function main(): Nat { return List<Int>{1i}.set(0n, 2i).size(); }', "1_n"); 
+
+        runMainCode('public function main(): Int { return List<Int>{1i}.set(0n, 2i).get(0n); }', "2_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i, 3i}.set(0n, 5i).get(0n); }', "5_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.set(1n, 5i).get(1n); }', "5_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i, 3i}.set(1n, 5i).get(1n); }', "5_i");
+        
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.set(1n, 5i).get(0n); }', "1_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i, 3i}.set(1n, 5i).get(2n); }', "3_i");
+    });
+
+    /*
+    it("should fail set empty smt", function () {
+        runMainCode('public function main(): Int { return List<Int>{}.setBack(1i).get(0n); }', "(assert (not (is-@Result-err Main@main)))");
+        runMainCode('public function main(): Int { return List<Int>{}.setFront(1i).get(0n); }', "(assert (not (is-@Result-err Main@main)))");
+        runMainCode('public function main(): Int { return List<Int>{}.set(0n, 1i).get(0n); }', "(assert (not (is-@Result-err Main@main)))"); 
+    });
+
+    it("should fail set out-of-bounds smt", function () {
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.set(3n, 5i).get(1n); }', "(assert (not (is-@Result-err Main@main)))");
+    });
+    */
+});

--- a/test/cppoutput/list/list_sum.test.js
+++ b/test/cppoutput/list/list_sum.test.js
@@ -1,0 +1,21 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate List -- sum integrals", () => {
+    it("should do simple integral sums", function () {
+        runMainCode('public function main(): Int { return List<Int>{}.sum(); }', "0_i");
+        runMainCode('public function main(): Int { return List<Int>{2i, -1i}.sum(); }', "1_i");
+
+        runMainCode('public function main(): Nat { return List<Nat>{}.sum(); }', "0_n");
+        runMainCode('public function main(): Nat { return List<Nat>{2n, 1n}.sum(); }', "3_n");
+    });
+});
+
+describe ("CPP Emit Evaluate List -- sum float", () => {
+    it("should do simple float sums", function () {
+        runMainCode('public function main(): Bool { let tmp = List<Float>{}.sum(); return (tmp < 0.1f && tmp > -0.1f);}', "true");
+        runMainCode('public function main(): Bool { let tmp = List<Float>{2.0f, -1.0f}.sum(); return (tmp > 0.9f && tmp < 1.1f);}', "true");
+    });
+});


### PR DESCRIPTION
Adds cpp emission for `ConstructorPrimaryListExpression` and tests for access, set, sum, and basic operations. I also moved some of my option construction logic into `generateAccessorForSpecialTypeConstructor()` and fixed `emitPostfixInvokeStatic()` as it was not generating the namespace specifier correctly.