### PR TITLE
CPP Emit Basic Lambdas

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -1,5 +1,10 @@
 namespace CPPAssembly;
 
+entity LambdaParameterSignature {
+    field pname: Identifier;
+    field ptype: TypeSignature;
+}
+
 datatype TypeSignature using {
     %% Source info would be good
     field tkeystr: TypeKey;
@@ -7,6 +12,11 @@ datatype TypeSignature using {
 of
 VoidTypeSignature { }
 | NominalTypeSignature { }
+| LambdaTypeSignature {
+    field isPredLambda: Bool;
+    field params: List<LambdaParameterSignature>;
+    field resultType: TypeSignature;
+}
 | EListTypeSignature {
     field entries: List<TypeSignature>;
 }
@@ -158,6 +168,10 @@ entity AccessVariableExpression provides Expression {
     field layouttype: TypeSignature;
 }
 
+entity AccessCapturedVariableExpression provides Expression {
+    field vname: VarIdentifier;
+}
+
 entity AccessStaticFieldExpression provides Expression {
     field stype: NominalTypeSignature;
     field resolvedname: String; 
@@ -275,6 +289,19 @@ BinLogicAndExpression { }
 | BinLogicIFFExpression { }
 ;
 
+entity LambdaInvokeArgumentInfo {
+    field name: Identifier;
+    field args: List<Expression>;
+}
+
+entity LambdaInvokeExpression provides Expression {
+    field isCapturedLambda: Bool; %% Necessary?
+    field lambda: LambdaTypeSignature;
+
+    field fname: Identifier;
+    field argsinfo: LambdaInvokeArgumentInfo;
+}
+
 concept ConstructorExpression provides Expression {
 }
 
@@ -290,6 +317,12 @@ entity ConstructorStdExpression provides ConstructorPrimaryExpression {
 
 entity ConstructorEListExpression provides ConstructorExpression {
     field args: List<Expression>;
+}
+
+entity ConstructorLambdaExpression provides Expression {
+    %%most of the info is in the etype field (which is a LambdaTypeSignature)
+
+    field body: BodyImplementation;
 }
 
 datatype ConstructorPrimaryCollectionSingletonsExpression provides ConstructorPrimaryExpression using {

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -13,7 +13,8 @@ const basicNominalTypeKeyRE: CRegex = /(${CPPAssembly::namespaceKeyRE}'::')?[_a-
 const nominalTypeKeyRE: CRegex = /(${CPPAssembly::basicNominalTypeKeyRE})/c; %% Will need to handle special scoped type key?
 const elistTypeKeyRE: CRegex = /'(|'.*'|)'/c;
 
-const typeKeyRE: CRegex = /${CPPAssembly::nominalTypeKeyRE}|${CPPAssembly::elistTypeKeyRE}/c;
+const lambdaTypeKeyRE: CRegex = /('fn'|'pred') '('.*')' '->' (${CPPAssembly::nominalTypeKeyRE}|${CPPAssembly::elistTypeKeyRE})/c;
+const typeKeyRE: CRegex = /${CPPAssembly::nominalTypeKeyRE}|${CPPAssembly::elistTypeKeyRE}|${CPPAssembly::lambdaTypeKeyRE}/c;
 type TypeKey = CString of CPPAssembly::typeKeyRE;
 
 %% Optional '<' * '>' allows support for resolved templates on functions or methods

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -176,6 +176,15 @@ function emitResolvedTemplates(tk: Option<CPPAssembly::TypeKey>, ik: Option<CPPA
     }
 }
 
+%% This is 100% not a good way to handle this
+function convertLambdaTypeSignature(lts: CPPAssembly::LambdaTypeSignature, ctx: Context): String {
+    let resolved = emitResolvedNamespace(ctx.fullns_list, emitTypeKeyValue(lts.tkeystr));
+    
+    let first = resolved.replaceAllStringOccurrences("(", "$");
+    let second = first.replaceAllStringOccurrences(")", "$");
+    return second.replaceAllStringOccurrences("->", "$");
+}
+
 function emitTypeSignature(ts: CPPAssembly::TypeSignature, shouldCheckTag: Bool, ctx: Context): String {
     if(ts)@<CPPAssembly::EListTypeSignature> {
         let argssizes = $ts.entries.map<String>(fn(e) => {
@@ -187,6 +196,10 @@ function emitTypeSignature(ts: CPPAssembly::TypeSignature, shouldCheckTag: Bool,
         let n = String::fromCString($ts.entries.size().toCString());
 
         return String::concat("__CoreCpp::Tuple", n, argstemplate);
+    }
+    if(ts)@<CPPAssembly::LambdaTypeSignature> {
+        %% Need to investigate whether templated lambdas are possible
+        return convertLambdaTypeSignature($ts, ctx);
     }
     else {
         return emitTypeKey(ts.tkeystr, shouldCheckTag, ctx);
@@ -920,6 +933,35 @@ function emitBinaryKeyEqExpression(exp: CPPAssembly::BinaryKeyEqExpression, ctx:
     }
 }
 
+function emitLambdaParameters(p: List<CPPAssembly::LambdaParameterSignature>, ctx: Context): String {
+    let params = p.map<String>(fn(param) => {
+        let pname = emitIdentifier(param.pname);
+        let ptype = emitTypeSignature(param.ptype, true, ctx);
+
+        return String::concat(ptype, " ", pname);
+    }); 
+
+    return String::joinAll(", ", params);
+}
+
+function emitConstructorLambdaExpression(exp: CPPAssembly::ConstructorLambdaExpression, ctx: Context): String {
+    let body = String::concat("{ ", emitBodyImplementation(exp.body, ctx, ""), " }");
+    let lambda = exp.etype@<CPPAssembly::LambdaTypeSignature>;
+    let params = emitLambdaParameters(lambda.params, ctx);
+    let rtype = emitTypeSignature(lambda.resultType, true, ctx);
+    %% Likely need to do some explicit handling of isPredLambda case
+
+    return String::concat("[&](", params, ") -> ", rtype, body);
+}
+
+function emitLambdaInvokeExpression(exp: CPPAssembly::LambdaInvokeExpression, ctx: Context): String {
+    let args = emitArguments(exp.argsinfo.args, ctx);
+    let name = emitIdentifier(exp.fname);
+
+    %% Probably will need to construct a namespace specifier here (likely from exp.lambda)
+    return String::concat(name, "( ", args, " )");
+}
+
 function emitExpression(e: CPPAssembly::Expression, ctx: Context): String {
     match(e)@ {
         CPPAssembly::LiteralNoneExpression => { return emitLiteralNoneExpression($e, ctx); }
@@ -935,15 +977,15 @@ function emitExpression(e: CPPAssembly::Expression, ctx: Context): String {
         | CPPAssembly::AccessStaticFieldExpression => { return emitAccessStaticFieldExpression($e, ctx); } 
         | CPPAssembly::AccessEnumExpression => { return emitAccessEnumExpression($e, ctx); }
         | CPPAssembly::AccessVariableExpression => { return emitAccessVariableExpression($e, ctx); }
-        %%| CPPAssembly::AccessCapturedVariableExpression => { abort; }
+        | CPPAssembly::AccessCapturedVariableExpression => { return emitVarIdentifier($e.vname); }
         | CPPAssembly::ConstructorExpression => { return emitConstructorExpression($e, ctx); }
         | CPPAssembly::ConstructorPrimaryExpression => { return emitConstructorPrimaryExpression($e, ctx); }
         %%| CPPAssembly::ConstructorPrimaryCollectionSingletonsExpression => { abort; } 
         %%| CPPAssembly::ConstructorTypeDeclExpression => { abort; }
         %%| CPPAssembly::ConstructorTypeDeclStringExpression => { abort; } 
-        %%| CPPAssembly::ConstructorLambdaExpression => { abort; }
+        | CPPAssembly::ConstructorLambdaExpression => { return emitConstructorLambdaExpression($e, ctx); }
         %%| CPPAssembly::LetExpression => { abort; }
-        %%| CPPAssembly::LambdaInvokeExpression => { abort; } 
+        | CPPAssembly::LambdaInvokeExpression => { return emitLambdaInvokeExpression($e, ctx); } 
         | CPPAssembly::CallNamespaceFunctionExpression => { return emitCallNamespaceFunctionExpression($e, ctx); }
         | CPPAssembly::CallTypeFunctionExpression => { return emitCallTypeFunctionExpression($e, ctx); }      
         %%| CPPAssembly::CallRefInvokeStaticResolveExpression => { abort; }
@@ -1220,21 +1262,37 @@ function emitBodyImplementation(body: CPPAssembly::BodyImplementation, ctx: Cont
         %% | CPPAssembly::PredicateUFBodyImplementation => { abort; }
         CPPAssembly::BuiltinBodyImplementation => { return emitBuiltinBodyImplementation($body, ctx, indent); }
         %% | CPPAssembly::SynthesisBodyImplementation => { abort; }
-        %% | CPPAssembly::ExpressionBodyImplementation => { abort; }
+        | CPPAssembly::ExpressionBodyImplementation => { 
+            return String::concat("return ", emitExpression($body.exp, ctx), ";"); 
+        }
         | CPPAssembly::StandardBodyImplementation => { return emitStandardBodyImplementation($body, ctx, indent); }
         | _ => { abort; }
     }
 }
 
-function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context): String {
+%% If we detect lambda parameters we need to return their signature and emit as a template type
+function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context): String, String {
     let all_params = params.map<String>(fn(param) => {
         let ptype = emitTypeSignature(param.ptype, true, ctx);
         let pident = emitIdentifier(param.pname);
+        let needsRValueRef = if(param.ptype)<CPPAssembly::LambdaTypeSignature> then "&&" else "";
 
-        return String::concat(ptype, " ", pident);
+        return String::concat(ptype, needsRValueRef, " ", pident);
     });
 
-    return String::joinAll(", ", all_params);
+    let lambdatypes = params
+        .filter(pred(p) => p.ptype?<CPPAssembly::LambdaTypeSignature>)
+        .reduce<List<String>>(List<String>{}, fn(acc, param) => {
+            return acc.pushBack(String::concat("typename ", emitTypeSignature(param.ptype, true, ctx)));
+    });
+
+    return String::joinAll(", ", all_params), String::joinAll(", ", lambdatypes);
+}
+
+function genLambdaTemplate(templates: String, indent: String): String {
+    return if(templates !== "")
+        then String::concat(indent, "template <", templates, ">%n;") 
+        else "";
 }
 
 %% Determine whether to emit this param as const this* or this
@@ -1252,14 +1310,15 @@ function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::Typ
     let full_indent = String::concat("    ", indent);
 
     let name = m.ikey.value.removePrefixString(declaredIn.value).removePrefixString('::');
-    let params = emitParameters(m.params, nctx);
+    let params, templates = emitParameters(m.params, nctx);
     let rtype = emitTypeSignature(m.resultType, false, ctx);
     let this_type = emitThisType(declaredIn, nctx);    
     let specialName = emitSpecialTemplate(String::fromCString(name));
-    
+
+    let template = genLambdaTemplate(templates, indent); 
     let pre = if(rtype === "bool") 
-        then String::concat(indent, rtype, " ", specialName)
-        else String::concat(indent, "const ", rtype, " ", specialName);
+        then String::concat(template, indent, rtype, " ", specialName)
+        else String::concat(template, indent, "const ", rtype, " ", specialName);
 
     var params_impl: String;
     if(params === "") {
@@ -1294,10 +1353,11 @@ function emitFunctionDecl(func: CPPAssembly::AbstractInvokeDecl, ctx: Context, i
     let nctx = ctx.updateCurrentNamespace(func.declaredInNS, ns);
 
     let name = emitInvokeKey(ikey, nctx);
-    let params = emitParameters(func.params, nctx);
+    let params, templates = emitParameters(func.params, nctx);
     let rtype = emitTypeSignature(func.resultType, true, nctx); 
 
-    let pre: String = String::concat(indent, rtype, " ", name );
+    let template = genLambdaTemplate(templates, indent);
+    let pre: String = String::concat(template, indent, rtype, " ", name );
     let params_impl: String = String::concat("(", params, ") noexcept ");
 
     return String::concat(pre, params_impl, " {%n;", emitBodyImplementation(func.body, nctx, indent), indent, "}%n;");
@@ -1384,7 +1444,8 @@ function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CP
         let pre = m.ikey.value.removePrefixString(declaredIn.value).removePrefixString('::');
         let rtype = emitTypeSignature(m.resultType, true, nctx);
         let this_type = emitThisType(declaredIn, nctx);
-        let params = emitParameters(m.params, nctx);
+        let params, templates = emitParameters(m.params, nctx);
+        let template = genLambdaTemplate(templates, indent);
 
         let specialName = emitSpecialTemplate(String::fromCString(pre));
 
@@ -1392,11 +1453,12 @@ function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CP
             else String::concat(indent, rtype, " ", specialName, "(");
 
         if(params === "") {
-            return String::concat(first, this_type, " ", emitSpecialThis(), params, ") noexcept;%n;");
+            let tmp = String::concat(template, first);
+            return String::concat(tmp, this_type, " ", emitSpecialThis(), params, ") noexcept;%n;");
         }
         else {
             let base = String::concat(first, this_type, " ");
-            return String::concat(base, emitSpecialThis(), ", ", params, ") noexcept;%n;");           
+            return String::concat(template, base, emitSpecialThis(), ", ", params, ") noexcept;%n;");           
         }
     }
     else {
@@ -1411,9 +1473,10 @@ function emitFunctionForwardDeclaration(decl: CPPAssembly::AbstractInvokeDecl, c
 
     let ikey = emitInvokeKey(decl.ikey, nctx);
     let rtype = emitTypeSignature(decl.resultType, true, nctx); 
-    let params = emitParameters(decl.params, nctx);
+    let params, templates = emitParameters(decl.params, nctx);
 
-    let first = String::concat(ident, rtype, " ", ikey);
+    let template = genLambdaTemplate(templates, ident);
+    let first = String::concat(template, ident, rtype, " ", ikey);
     return String::concat(first, "(", params, ") noexcept;%n;");
 }
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -179,10 +179,11 @@ function emitResolvedTemplates(tk: Option<CPPAssembly::TypeKey>, ik: Option<CPPA
 %% This is 100% not a good way to handle this
 function convertLambdaTypeSignature(lts: CPPAssembly::LambdaTypeSignature, ctx: Context): String {
     let resolved = emitResolvedNamespace(ctx.fullns_list, emitTypeKeyValue(lts.tkeystr));
-    
-    let first = resolved.replaceAllStringOccurrences("(", "$");
-    let second = first.replaceAllStringOccurrences(")", "$");
-    return second.replaceAllStringOccurrences("->", "$");
+
+    let first = resolved.replaceAllStringOccurrences("(", "ᒥ");
+    let second = first.replaceAllStringOccurrences(")", "ᒧ");
+    let third = second.replaceAllStringOccurrences("->", "᐀ᐅ");
+    return third.replaceAllStringOccurrences(",", "ᐧ");
 }
 
 function emitTypeSignature(ts: CPPAssembly::TypeSignature, shouldCheckTag: Bool, ctx: Context): String {
@@ -1275,7 +1276,8 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context):
     let all_params = params.map<String>(fn(param) => {
         let ptype = emitTypeSignature(param.ptype, true, ctx);
         let pident = emitIdentifier(param.pname);
-        let needsRValueRef = if(param.ptype)<CPPAssembly::LambdaTypeSignature> then "&&" else "";
+        let needsRValueRef = if(param.ptype)<CPPAssembly::LambdaTypeSignature> 
+            then String::concat("ᘏ", pident, "&&") else "";
 
         return String::concat(ptype, needsRValueRef, " ", pident);
     });
@@ -1283,7 +1285,8 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context):
     let lambdatypes = params
         .filter(pred(p) => p.ptype?<CPPAssembly::LambdaTypeSignature>)
         .reduce<List<String>>(List<String>{}, fn(acc, param) => {
-            return acc.pushBack(String::concat("typename ", emitTypeSignature(param.ptype, true, ctx)));
+            let name = emitIdentifier(param.pname);
+            return acc.pushBack(String::concat("typename ", emitTypeSignature(param.ptype, true, ctx), "ᘏ", name));
     });
 
     return String::joinAll(", ", all_params), String::joinAll(", ", lambdatypes);

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -77,13 +77,12 @@ function emitSpecialTemplate(name: String): String {
         return name;
     }
     
-    let base = name.replaceAllStringOccurrences(" ", "");
-    let first = base.replaceAllStringOccurrences("<", "ᐸ");
-    let second = first.replaceAllStringOccurrences(",", "ᐧ");
-    let third = second.replaceAllStringOccurrences(">", "ᐳ");
-    let final = third.replaceAllStringOccurrences("::", "ᘏ");
-
-    return final;
+    return name
+        .replaceAllStringOccurrences(" ", "")
+        .replaceAllStringOccurrences("<", "ᐸ")
+        .replaceAllStringOccurrences(",", "ᐧ")
+        .replaceAllStringOccurrences(">", "ᐳ")
+        .replaceAllStringOccurrences("::", "ᘏ");
 }
 
 function emitBindVar(bname: CPPAssembly::VarIdentifier, convert: String, converttype: String, exp: String): String { 
@@ -176,14 +175,17 @@ function emitResolvedTemplates(tk: Option<CPPAssembly::TypeKey>, ik: Option<CPPA
     }
 }
 
-%% This is 100% not a good way to handle this
 function convertLambdaTypeSignature(lts: CPPAssembly::LambdaTypeSignature, ctx: Context): String {
     let resolved = emitResolvedNamespace(ctx.fullns_list, emitTypeKeyValue(lts.tkeystr));
 
-    let first = resolved.replaceAllStringOccurrences("(", "ᒥ");
-    let second = first.replaceAllStringOccurrences(")", "ᒧ");
-    let third = second.replaceAllStringOccurrences("->", "᐀ᐅ");
-    return third.replaceAllStringOccurrences(",", "ᐧ");
+    let replace = resolved
+        .removePrefixString("fn")
+        .replaceAllStringOccurrences("(", "")
+        .replaceAllStringOccurrences(")", "")
+        .replaceAllStringOccurrences("->", "$")
+        .replaceAllStringOccurrences(",", "_");
+
+    return String::concat("λ_", replace);
 }
 
 function emitTypeSignature(ts: CPPAssembly::TypeSignature, shouldCheckTag: Bool, ctx: Context): String {
@@ -199,7 +201,6 @@ function emitTypeSignature(ts: CPPAssembly::TypeSignature, shouldCheckTag: Bool,
         return String::concat("__CoreCpp::Tuple", n, argstemplate);
     }
     if(ts)@<CPPAssembly::LambdaTypeSignature> {
-        %% Need to investigate whether templated lambdas are possible
         return convertLambdaTypeSignature($ts, ctx);
     }
     else {
@@ -945,6 +946,9 @@ function emitLambdaParameters(p: List<CPPAssembly::LambdaParameterSignature>, ct
     return String::joinAll(", ", params);
 }
 
+%%
+%% TODO: body is not going to be formatted correctly - still functionally correct but ugly
+%%
 function emitConstructorLambdaExpression(exp: CPPAssembly::ConstructorLambdaExpression, ctx: Context): String {
     let body = String::concat("{ ", emitBodyImplementation(exp.body, ctx, ""), " }");
     let lambda = exp.etype@<CPPAssembly::LambdaTypeSignature>;
@@ -1277,7 +1281,7 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context):
         let ptype = emitTypeSignature(param.ptype, true, ctx);
         let pident = emitIdentifier(param.pname);
         let needsRValueRef = if(param.ptype)<CPPAssembly::LambdaTypeSignature> 
-            then String::concat("ᘏ", pident, "&&") else "";
+            then String::concat("_", pident, "&&") else "";
 
         return String::concat(ptype, needsRValueRef, " ", pident);
     });
@@ -1286,7 +1290,7 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context):
         .filter(pred(p) => p.ptype?<CPPAssembly::LambdaTypeSignature>)
         .reduce<List<String>>(List<String>{}, fn(acc, param) => {
             let name = emitIdentifier(param.pname);
-            return acc.pushBack(String::concat("typename ", emitTypeSignature(param.ptype, true, ctx), "ᘏ", name));
+            return acc.pushBack(String::concat("typename ", emitTypeSignature(param.ptype, true, ctx), "_", name));
     });
 
     return String::joinAll(", ", all_params), String::joinAll(", ", lambdatypes);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -131,6 +131,16 @@ entity CPPTransformer {
             let args = $tsig.entries.map<CPPAssembly::TypeSignature>(fn(ts) => this.convertTypeSignature[recursive](ts));
             return CPPAssembly::EListTypeSignature{ tk, args };
         }
+        if(tsig)@<BSQAssembly::LambdaTypeSignature> {
+            let params = $tsig.params.map<CPPAssembly::LambdaParameterSignature>(fn(lps) => 
+                CPPAssembly::LambdaParameterSignature { 
+                    CPPTransformNameManager::convertIdentifier(lps.pname), this.convertTypeSignature[recursive](lps.ptype)
+                }
+            );
+            let resultType = this.convertTypeSignature[recursive]($tsig.resultType);
+
+            return CPPAssembly::LambdaTypeSignature{ tk, $tsig.isPredLambda, params, resultType };
+        }
         else {
             return CPPAssembly::NominalTypeSignature{ tk };
         }
@@ -529,6 +539,36 @@ entity CPPTransformer {
         }
     }
 
+    method transformConstructorLambdaExpression(exp: BSQAssembly::ConstructorLambdaExpression): CPPAssembly::ConstructorLambdaExpression {
+        let etype = this.convertTypeSignature(exp.etype);
+        let body = this.transformBodyToCpp(exp.body);
+
+        return CPPAssembly::ConstructorLambdaExpression{ etype, body };
+    }
+
+    method transformLambdaInvokeArgumentInfo(lia: BSQAssembly::LambdaInvokeArgumentInfo): CPPAssembly::LambdaInvokeArgumentInfo {
+        let name = CPPTransformNameManager::convertIdentifier(lia.name);
+        let args = lia.resolvedargs@some.map<CPPAssembly::Expression>(fn(arg) => this.transformExpressionToCpp(arg));
+
+        return CPPAssembly::LambdaInvokeArgumentInfo{ name, args };
+    }
+
+    method transformLambdaInvokeExpression(exp: BSQAssembly::LambdaInvokeExpression): CPPAssembly::LambdaInvokeExpression {
+        let etype = this.convertTypeSignature(exp.etype);
+        let lambda = this.convertTypeSignature(exp.lambda);
+        let fname = CPPTransformNameManager::convertIdentifier(exp.fname);
+        let argsinfo = this.transformLambdaInvokeArgumentInfo(exp.argsinfo);
+
+        return CPPAssembly::LambdaInvokeExpression{ etype, exp.isCapturedLambda, lambda@<CPPAssembly::LambdaTypeSignature>, fname, argsinfo };
+    }
+
+    method transformAccessCapturedVariableExpression(exp: BSQAssembly::AccessCapturedVariableExpression): CPPAssembly::AccessCapturedVariableExpression {
+        let etype = this.convertTypeSignature(exp.etype);       
+        let vname = CPPTransformNameManager::convertVarIdentifier(exp.vname);
+
+        return CPPAssembly::AccessCapturedVariableExpression{ etype, vname };
+    }
+
     recursive method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
         match(expr)@ {
             BSQAssembly::LiteralNoneExpression => { return this.transformLiteralNoneExpression($expr); }
@@ -544,15 +584,15 @@ entity CPPTransformer {
             | BSQAssembly::AccessStaticFieldExpression => { return this.transformAccessStaticFieldExpression($expr); }
             | BSQAssembly::AccessEnumExpression => { return this.transformAccessEnumExpression($expr); }
             | BSQAssembly::AccessVariableExpression => { return this.transformAccessVariableExpression($expr); }
-            | BSQAssembly::AccessCapturedVariableExpression => { abort; }
+            | BSQAssembly::AccessCapturedVariableExpression => { return this.transformAccessCapturedVariableExpression($expr); }
             | BSQAssembly::ConstructorExpression => { return this.transformConstructorExpression($expr); }
             | BSQAssembly::ConstructorPrimaryExpression => { return this.transformConstructorPrimaryExpression($expr); }
             | BSQAssembly::ConstructorPrimaryCollectionSingletonsExpression => { abort; }
             | BSQAssembly::ConstructorTypeDeclExpression => { abort; }
             | BSQAssembly::ConstructorTypeDeclStringExpression => { abort; }
-            | BSQAssembly::ConstructorLambdaExpression => { abort; }
+            | BSQAssembly::ConstructorLambdaExpression => { return this.transformConstructorLambdaExpression($expr); }
             | BSQAssembly::LetExpression => { abort; }
-            | BSQAssembly::LambdaInvokeExpression => { abort; }
+            | BSQAssembly::LambdaInvokeExpression => { return this.transformLambdaInvokeExpression($expr); }
             | BSQAssembly::CallNamespaceFunctionExpression => { return this.transformCallNamespaceFunctionExpression($expr); } 
             | BSQAssembly::CallTypeFunctionExpression => { return this.transformCallTypeFunctionExpression($expr); }
             | BSQAssembly::CallTypeFunctionSpecialExpression => { abort; }
@@ -741,12 +781,17 @@ entity CPPTransformer {
 
     method transformBodyToCpp(body: BSQAssembly::BodyImplementation): CPPAssembly::BodyImplementation {
         match(body)@ {
-            BSQAssembly::StandardBodyImplementation => { 
+            BSQAssembly::AbstractBodyImplementation => { abort; }
+            | BSQAssembly::PredicateUFBodyImplementation => { abort; }
+            | BSQAssembly::BuiltinBodyImplementation => { return CPPAssembly::BuiltinBodyImplementation{ $body.builtin }; }
+            | BSQAssembly::SynthesisBodyImplementation => { abort; } 
+            | BSQAssembly::ExpressionBodyImplementation => { 
+                return CPPAssembly::ExpressionBodyImplementation{ this.transformExpressionToCpp($body.exp) }; 
+            } 
+            | BSQAssembly::StandardBodyImplementation => { 
                 let cppstmts = this.transformStatementListToCpp($body.statements);
                 return CPPAssembly::StandardBodyImplementation{ cppstmts };
             }
-            | BSQAssembly::BuiltinBodyImplementation => { return CPPAssembly::BuiltinBodyImplementation{ $body.builtin }; }
-            | _ => { abort; }
         }
     }
 

--- a/test/cppoutput/lambda/lcalls.test.js
+++ b/test/cppoutput/lambda/lcalls.test.js
@@ -1,0 +1,20 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate -- Lambda calls (no template)", () => {
+    it("should exec simple lambda", function () {
+        runMainCode("function foo(f: fn(Int) -> Int): Int { return f(1i); } public function main(): Int { return foo(fn(x) => { return x + 1i; }); }", "2_i");
+    
+        runMainCode("function foo(f: fn(Int) -> Int): Int { return f(1i); } public function main(): Int { let y = 1i; return foo(fn(x) => { return x + y; }); }", "2_i");
+
+        runMainCode('function foo(f: fn(Int) -> Int): Int { return f(1i); } function bar(g: fn(Int) -> Int, k: Int): Int { return foo(fn(y) => g(y) + k); } public function main(): Int { let y = 1i; return bar(fn(x) => { return x + y; }, 2i); }', "4_i");
+    });
+});
+
+describe ("CPP Emit Evaluate -- Lambda calls (with template)", () => {
+    it("should exec simple lambda template", function () {
+        runMainCode("function foo<T>(x: T, f: fn(T) -> T): T { return f(x); } public function main(): Int { return foo<Int>(3i, fn(x) => x); }", "3_i");
+    });
+});


### PR DESCRIPTION
Adds support for emitting basic lambdas in cpp. In order for our lambdas to be passed in as parameters, I had to declare them as a template type, then their type in the parameter takes an rvalue reference. 

So with these changes,
```
function foo(f: fn(Int) -> Int): Int { 
    return f(1i); 
} 

public function main(): Int { 
    return foo(fn(x) => { return x + 1i; }); 
}
```
⬇️
```
namespace Main {
    template <typename λ_Int$Int_f>
    __CoreCpp::Int foo(λ_Int$Int_f&& f) noexcept  {
        return f( 1_i );
    }
    __CoreCpp::Int main() noexcept  {
        return foo([&](__CoreCpp::Int x) -> __CoreCpp::Int{ return (x + 1_i); });
    }
}
```