### PR TITLE
C++ Emit List Tests & Bug Fixes

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -142,6 +142,15 @@ entity BlockStatement provides Statement {
     field isScoping: Bool;
 }
 
+entity BinderBlockStatement provides Statement {
+    field binder: BinderInfo;
+    field bexp: Expression;
+    field itest: ITest;
+    
+    field statements: List<Statement>;
+    field isScoping: Bool;
+}
+
 entity ReturnSingleStatement provides Statement {
     field rtype: TypeSignature;
     field value: Expression;

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -280,6 +280,7 @@ public:
 };
 
 typedef uintptr_t None;
+typedef bool Bool;
 
 #define MAX_BSQ_INT ((int64_t(1) << 62) - 1)
 #define MIN_BSQ_INT (-(int64_t(1) << 62) + 1) 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -159,7 +159,7 @@ function emitResolvedTemplates(tk: Option<CPPAssembly::TypeKey>, ik: Option<CPPA
     }
 
     let key = if(tk)@some then emitTypeKeyValue($tk) else emitInvokeKeyValue(resolvedik@some);
-    if(key.startsWithString("__CoreCpp") || key === "bool") { %% No backend impl for bools 
+    if(key.startsWithString("__CoreCpp")) {  
         return key;
     }
     else { 
@@ -268,6 +268,14 @@ function generateAccessorForSpecialTypeConstructor(constype: CPPAssembly::TypeSi
         }
 }
 
+function generateMethodName(m: CPPAssembly::InvokeKey, declaredIn: CPPAssembly::TypeKey, ctx: Context): String {
+    let mdecl = ctx.asm.lookupNominalTypeDeclaration(declaredIn);
+    let mdeclname = emitTypeKey(declaredIn, false, ctx);
+    let basename = String::fromCString(m.value.removePrefixString(declaredIn.value).removePrefixString('::'));
+
+    return String::concat(mdeclname, "ᘏ", emitSpecialTemplate(basename));
+}
+
 %% Given a namespace key (like Main::Foo::Bar), remove all matching prefix strings
 function emitResolvedNamespace(fullns_list: List<CString>, fullns: String): String {
     return fullns_list.reduce<String>(fullns, fn(acc, s) => {
@@ -296,7 +304,7 @@ function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression):
         | "__CoreCpp::Nat" => { return String::concat(val, "_n"); }
         | "__CoreCpp::BigNat" => { return String::concat(val, "_N"); }
         | "__CoreCpp::Float" => { return String::concat(val, "_f"); }
-        | "bool" => { return val; }
+        | "__CoreCpp::Bool" => { return val; }
         | _ => { abort; }
     }
 }
@@ -570,16 +578,12 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, rootexp: 
         then String::concat(ns, "::")
         else ns;
     
-    let name = removeCommonPrefix(ik, tk);
-    let resolvedname = if(name.startsWithString("::")) 
-        then String::concat(resolvedns, emitSpecialTemplate(name.removePrefixString("::")))
-        else String::concat(resolvedns, emitSpecialTemplate(name));
-
+    let name = generateMethodName(op.resolvedTrgt, op.resolvedType.tkeystr, ctx);
     if(args === "") {
-        return String::concat(resolvedname, "(", thisarg, ")");
+        return String::concat(name, "(", thisarg, ")");
     }
     else {
-        return String::concat(resolvedname, "(", thisarg, ", ", args, ")");       
+        return String::concat(name, "(", thisarg, ", ", args, ")");       
     }
 }
 
@@ -1326,14 +1330,14 @@ function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::Typ
     let nctx = ctx.updateCurrentNamespace(m.declaredInNS, m.fullns);
     let full_indent = String::concat("    ", indent);
 
-    let name = m.ikey.value.removePrefixString(declaredIn.value).removePrefixString('::');
+    let name = generateMethodName(m.ikey, declaredIn, nctx);
     let params, templates = emitParameters(m.params, nctx);
     let rtype = emitTypeSignature(m.resultType, false, ctx);
     let this_type = emitThisType(declaredIn, nctx);    
-    let specialName = emitSpecialTemplate(String::fromCString(name));
+    let specialName = emitSpecialTemplate(name);
 
     let template = genLambdaTemplate(templates, indent); 
-    let pre = if(rtype === "bool") 
+    let pre = if(rtype === "__CoreCpp::Bool") 
         then String::concat(template, indent, rtype, " ", specialName)
         else String::concat(template, indent, "const ", rtype, " ", specialName);
 
@@ -1458,16 +1462,14 @@ function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CP
     let nctx = ctx.updateCurrentNamespace(m.declaredInNS, m.fullns);
 
     if(m)@<CPPAssembly::MethodDeclStatic> {
-        let pre = m.ikey.value.removePrefixString(declaredIn.value).removePrefixString('::');
+        let name = generateMethodName(m.ikey, declaredIn, nctx);
         let rtype = emitTypeSignature(m.resultType, true, nctx);
         let this_type = emitThisType(declaredIn, nctx);
         let params, templates = emitParameters(m.params, nctx);
         let template = genLambdaTemplate(templates, indent);
 
-        let specialName = emitSpecialTemplate(String::fromCString(pre));
-
-        let first = if(rtype !== "bool") then String::concat(indent, "const ", rtype, " ", specialName, "(")
-            else String::concat(indent, rtype, " ", specialName, "(");
+        let first = if(rtype !== "__CoreCpp::Bool") then String::concat(indent, "const ", rtype, " ", name, "(")
+            else String::concat(indent, rtype, " ", name, "(");
 
         if(params === "") {
             let tmp = String::concat(template, first);

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -759,9 +759,14 @@ function emitConstructorEListExpression(exp: CPPAssembly::ConstructorEListExpres
 }
 
 function emitConstructorPrimaryListExpression(exp: CPPAssembly::ConstructorPrimaryListExpression, ctx: Context): String {
+    let ttype = ctx.asm.lookupNominalTypeDeclaration(exp.elemtype.tkeystr);
+    let nctx = ctx.updateCurrentNamespace(ttype.declaredInNS, ttype.fullns);
+
     let args = emitArguments(exp.args, ctx);
-    let ns = "Core::ListOps::"; %% This will always be the case 
-    let ofttype = String::concat("ᐸ", removeCppPrefix(emitTypeSignature(exp.elemtype, true, ctx)), "ᐳ");
+    let ns = "Core::ListOps::"; %% So long as lists impl stays in Core::ListOps this will hold 
+
+    let name = removeCppPrefix(emitTypeSignature(exp.elemtype, true, nctx));
+    let ofttype = String::concat("ᐸ", name, "ᐳ");
     switch(exp.args.size()) {
         0n => { return String::concat(ns, "s_list_create_empty", ofttype, "()"); }
         | 1n => { return String::concat(ns, "s_list_create_1", ofttype, "(", args, ")"); }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -178,12 +178,15 @@ function emitResolvedTemplates(tk: Option<CPPAssembly::TypeKey>, ik: Option<CPPA
 function convertLambdaTypeSignature(lts: CPPAssembly::LambdaTypeSignature, ctx: Context): String {
     let resolved = emitResolvedNamespace(ctx.fullns_list, emitTypeKeyValue(lts.tkeystr));
 
-    let replace = resolved
-        .removePrefixString("fn")
+    let base = if(resolved.startsWithString("fn")) 
+        then resolved.removePrefixString("fn") 
+        else resolved.removePrefixString("pred");
+    let replace = base
         .replaceAllStringOccurrences("(", "")
         .replaceAllStringOccurrences(")", "")
         .replaceAllStringOccurrences("->", "$")
-        .replaceAllStringOccurrences(",", "_");
+        .replaceAllStringOccurrences(",", "_")
+        .replaceAllStringOccurrences(" ", "");
 
     return String::concat("λ_", replace);
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1334,12 +1334,11 @@ function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::Typ
     let params, templates = emitParameters(m.params, nctx);
     let rtype = emitTypeSignature(m.resultType, false, ctx);
     let this_type = emitThisType(declaredIn, nctx);    
-    let specialName = emitSpecialTemplate(name);
 
     let template = genLambdaTemplate(templates, indent); 
     let pre = if(rtype === "__CoreCpp::Bool") 
-        then String::concat(template, indent, rtype, " ", specialName)
-        else String::concat(template, indent, "const ", rtype, " ", specialName);
+        then String::concat(template, indent, rtype, " ", name)
+        else String::concat(template, indent, "const ", rtype, " ", name);
 
     var params_impl: String;
     if(params === "") {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -185,7 +185,9 @@ function convertLambdaTypeSignature(lts: CPPAssembly::LambdaTypeSignature, ctx: 
         .replaceAllStringOccurrences("(", "")
         .replaceAllStringOccurrences(")", "")
         .replaceAllStringOccurrences("->", "$")
-        .replaceAllStringOccurrences(",", "_")
+        .replaceAllStringOccurrences(">", "ᐳ")
+        .replaceAllStringOccurrences("<", "ᐸ")
+        .replaceAllStringOccurrences(",", "ᐧ")
         .replaceAllStringOccurrences(" ", "");
 
     return String::concat("λ_", replace);
@@ -1706,7 +1708,15 @@ function emitNamespaceDeclFwdDecls(nsdecl: CPPAssembly::NamespaceDecl, ctx: Cont
             return String::concat(acc, fwddecl);
     });
 
-    return String::concat(subns_fwddecls, ant_fwddecls, indent, "}%n;");
+    let collections = nsdecl.alltypes
+        .filter(pred(tk) => ctx.asm.collections.has(tk))
+        .reduce<String>(ant_fwddecls, fn(acc, tk) => {
+            let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
+            let fwddecl = emitAbstractNominalTypeDecl(ant, tk, ctx, full_indent); 
+            return String::concat(acc, fwddecl);
+    });
+
+    return String::concat(subns_fwddecls, collections, indent, "}%n;");
 }
 
 %%
@@ -1721,7 +1731,7 @@ function emitNamespaceDeclTypes(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context
             return String::concat(acc, emitNamespaceDeclTypes[recursive](decl, ctx, full_indent));
     });
 
-    %% Emit enums first as they are just integers
+    %% Emit enums and collections first
     let enums = nsdecl.alltypes
         .filter(pred(tk) => ctx.asm.enums.has(tk))
         .reduce<String>(String::concat(subns, "//%n;// Value Type Definitions%n;//%n;"), fn(acc, tk) => {
@@ -1732,7 +1742,7 @@ function emitNamespaceDeclTypes(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context
 
     %% Value types
     let values = nsdecl.alltypes
-        .filter(pred(tk) => ctx.asm.typeinfos.get(tk).tag === CPPAssembly::Tag#Value && !ctx.asm.enums.has(tk))
+        .filter(pred(tk) => ctx.asm.typeinfos.get(tk).tag === CPPAssembly::Tag#Value && !ctx.asm.enums.has(tk) && !ctx.asm.collections.has(tk))
         .reduce<String>(enums, fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let def = emitAbstractNominalTypeDecl(ant, tk, ctx, full_indent);
@@ -1741,7 +1751,7 @@ function emitNamespaceDeclTypes(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context
 
     %% Ref and Tagged types
     let other = nsdecl.alltypes
-        .filter(pred(tk) => ctx.asm.typeinfos.get(tk).tag !== CPPAssembly::Tag#Value)
+        .filter(pred(tk) => ctx.asm.typeinfos.get(tk).tag !== CPPAssembly::Tag#Value && !ctx.asm.collections.has(tk))
         .reduce<String>(String::concat(values, "//%n;// Ref and Tagged Type Definitions%n;//%n;"), fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let def = emitAbstractNominalTypeDecl(ant, tk, ctx, full_indent);
@@ -1773,7 +1783,7 @@ function emitAssembly(asm: CPPAssembly::Assembly): String {
 
     %% Non-value type forward decls
     let fwddecls = asm.nsdecls
-        .reduce<String>(String::concat(primitive_typeinfos, "//%n;// Ref and Tagged Type Forward Declarations%n;//%n;"),
+        .reduce<String>(String::concat(primitive_typeinfos, "//%n;// Ref and Tagged Type Forward Declarations (and collections)%n;//%n;"),
         fn(acc, nsname, nsdecl) => {
             return String::concat(acc, emitNamespaceDeclFwdDecls(nsdecl, ctx, ""));
     });

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -751,6 +751,7 @@ entity CPPTransformer {
             | BSQAssembly::UpdateDirectStatement => { abort; }
             | BSQAssembly::UpdateIndirectStatement => { abort; }
             | BSQAssembly::BlockStatement => { return this.transformBlockStatement($stmt); }
+            | BSQAssembly::BinderBlockStatement => { abort; }
         }
     }
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -13,7 +13,7 @@ namespace CPPTransformNameManager {
     function convertTypeKey(tk: BSQAssembly::TypeKey): CPPAssembly::TypeKey {
         switch(tk.value) {
             'None' => { return CPPAssembly::TypeKey::from('__CoreCpp::None'); }
-            | 'Bool' => { return CPPAssembly::TypeKey::from('bool'); }
+            | 'Bool' => { return CPPAssembly::TypeKey::from('__CoreCpp::Bool'); }
             | 'Nat' => { return CPPAssembly::TypeKey::from('__CoreCpp::Nat'); }
             | 'Int' => { return CPPAssembly::TypeKey::from('__CoreCpp::Int'); }
             | 'BigNat' => { return CPPAssembly::TypeKey::from('__CoreCpp::BigNat'); }
@@ -27,7 +27,7 @@ namespace CPPTransformNameManager {
     function revertTypeKey(tk: CPPAssembly::TypeKey): BSQAssembly::TypeKey {
         switch(tk.value) {
             'None' => { return BSQAssembly::TypeKey::from('None'); }
-            | 'bool' => { return BSQAssembly::TypeKey::from('Bool'); }
+            | '__CoreCpp::Bool' => { return BSQAssembly::TypeKey::from('Bool'); }
             | '__CoreCpp::Nat' => { return BSQAssembly::TypeKey::from('Nat'); }
             | '__CoreCpp::Int' => { return BSQAssembly::TypeKey::from('Int'); }
             | '__CoreCpp::BigNat' => { return BSQAssembly::TypeKey::from('BigNat'); }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -102,7 +102,6 @@ namespace CPPTransformNameManager {
             }            
         }
 
-        %% I THINK this is unreachable
         %% We need to always update the nsdecls map as sub namespaces may change (this handles multiple nsdecls at same depth)
         if(!nsdecls.has(ns_name)) {
             return nsdecls.insert(ns_name, updated_nsdecl);

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -664,7 +664,7 @@ class BSQIREmitter {
    
     private emitCallTypeFunctionExpression(exp: CallTypeFunctionExpression): string {
         const ebase = this.emitExpressionBase(exp);
-        const ikey = EmitNameManager.generateTypeInvokeKey(this.tproc(exp.resolvedDeclType as TypeSignature), exp.name, exp.terms);
+        const ikey = EmitNameManager.generateTypeInvokeKey(this.tproc(exp.resolvedDeclType as TypeSignature), exp.name, exp.terms.map((tt) => this.tproc(new TemplateTypeSignature(SourceInfo.implicitSourceInfo(), tt.tkeystr))) );
         const ttype = this.emitTypeSignature(exp.ttype);
         const resolvedDeclType = this.emitTypeSignature((this.tproc(exp.resolvedDeclType as TypeSignature)) as NominalTypeSignature);
        

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -664,7 +664,7 @@ class BSQIREmitter {
    
     private emitCallTypeFunctionExpression(exp: CallTypeFunctionExpression): string {
         const ebase = this.emitExpressionBase(exp);
-        const ikey = EmitNameManager.generateTypeInvokeKey(this.tproc(exp.resolvedDeclType as TypeSignature), exp.name, exp.terms.map((tt) => this.tproc(new TemplateTypeSignature(SourceInfo.implicitSourceInfo(), tt.tkeystr))) );
+        const ikey = EmitNameManager.generateTypeInvokeKey(this.tproc(exp.resolvedDeclType as TypeSignature), exp.name, exp.terms.map((tt) => this.tproc(new TemplateTypeSignature(SourceInfo.implicitSourceInfo(), tt.tkeystr))) ); 
         const ttype = this.emitTypeSignature(exp.ttype);
         const resolvedDeclType = this.emitTypeSignature((this.tproc(exp.resolvedDeclType as TypeSignature)) as NominalTypeSignature);
        

--- a/test/cppoutput/list/list_append.test.js
+++ b/test/cppoutput/list/list_append.test.js
@@ -23,7 +23,7 @@ describe ("CPP Emit Evaluate List -- append/concat", () => {
         runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.prepend(List<Int>{}).size(); }', "2_n");
         runMainCode('public function main(): Int { return List<Int>{1i, 2i}.prepend(List<Int>{}).back(); }', "2_i");
         runMainCode('public function main(): Nat { return List<Int>{}.prepend(List<Int>{1i, 2i}).size(); }', "2_n"); 
-        runMainCode('public function main(): Int { return List<Int>{}.prepend(List<Int>{1i, 2i}).front(); }', "1_o");
+        runMainCode('public function main(): Int { return List<Int>{}.prepend(List<Int>{1i, 2i}).front(); }', "1_i");
 
         runMainCode('public function main(): Nat { return List<Int>{1i}.prepend(List<Int>{3i, 2i}).size(); }', "3_n"); 
         runMainCode('public function main(): Int { return List<Int>{1i}.prepend(List<Int>{3i, 2i}).back(); }', "1_i"); 

--- a/test/cppoutput/list/list_append.test.js
+++ b/test/cppoutput/list/list_append.test.js
@@ -39,7 +39,7 @@ describe ("CPP Emit Evaluate List -- append/concat", () => {
         runMainCode('public function main(): Int { return List<Int>::concat(List<Int>{}, List<Int>{1i, 2i}).front(); }', "1_i");
 
         runMainCode('public function main(): Nat { return List<Int>::concat(List<Int>{1i}, List<Int>{3i, 2i}).size(); }', "3_n"); 
-        runMainCode('public function main(): Int { return List<Int>::concat(List<Int>{1i}, List<Int>{3i, 2i}).back(); }', "3_i"); 
+        runMainCode('public function main(): Int { return List<Int>::concat(List<Int>{1i}, List<Int>{3i, 2i}).back(); }', "2_i"); 
         runMainCode('public function main(): Int { return List<Int>::concat(List<Int>{1i}, List<Int>{3i, 2i}).front(); }', "1_i"); 
     });
 

--- a/test/cppoutput/list/list_append.test.js
+++ b/test/cppoutput/list/list_append.test.js
@@ -1,0 +1,4 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";

--- a/test/cppoutput/list/list_append.test.js
+++ b/test/cppoutput/list/list_append.test.js
@@ -2,3 +2,57 @@
 
 import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
 import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate List -- append/concat", () => {
+    it("should append", function () {
+        runMainCode('public function main(): Bool { return List<Int>{}.append(List<Int>{}).empty(); }', "true");
+
+        runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.append(List<Int>{}).size(); }', "2_n");
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.append(List<Int>{}).back(); }', "2_i");
+        runMainCode('public function main(): Nat { return List<Int>{}.append(List<Int>{1i, 2i}).size(); }', "2_n"); 
+        runMainCode('public function main(): Int { return List<Int>{}.append(List<Int>{1i, 2i}).front(); }', "1_i");
+
+        runMainCode('public function main(): Nat { return List<Int>{1i}.append(List<Int>{3i, 2i}).size(); }', "3_n"); 
+        runMainCode('public function main(): Int { return List<Int>{1i}.append(List<Int>{3i, 2i}).back(); }', "2_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i}.append(List<Int>{3i, 2i}).front(); }', "1_i"); 
+    });
+
+    it("should prepend", function () {
+        runMainCode('public function main(): Bool { return List<Int>{}.prepend(List<Int>{}).empty(); }', "true");
+
+        runMainCode('public function main(): Nat { return List<Int>{1i, 2i}.prepend(List<Int>{}).size(); }', "2_n");
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i}.prepend(List<Int>{}).back(); }', "2_i");
+        runMainCode('public function main(): Nat { return List<Int>{}.prepend(List<Int>{1i, 2i}).size(); }', "2_n"); 
+        runMainCode('public function main(): Int { return List<Int>{}.prepend(List<Int>{1i, 2i}).front(); }', "1_o");
+
+        runMainCode('public function main(): Nat { return List<Int>{1i}.prepend(List<Int>{3i, 2i}).size(); }', "3_n"); 
+        runMainCode('public function main(): Int { return List<Int>{1i}.prepend(List<Int>{3i, 2i}).back(); }', "1_i"); 
+        runMainCode('public function main(): Int { return List<Int>{1i}.prepend(List<Int>{3i, 2i}).front(); }', "3_i"); 
+    });
+
+    it("should concat", function () {
+        runMainCode('public function main(): Bool { return List<Int>::concat().empty(); }', "true");
+
+        runMainCode('public function main(): Nat { return List<Int>::concat(List<Int>{1i, 2i}, List<Int>{}).size(); }', "2_n");
+        runMainCode('public function main(): Int { return List<Int>::concat(List<Int>{1i, 2i}, List<Int>{}).back(); }', "2_i");
+        runMainCode('public function main(): Nat { return List<Int>::concat(List<Int>{}, List<Int>{1i, 2i}).size(); }', "2_n");
+        runMainCode('public function main(): Int { return List<Int>::concat(List<Int>{}, List<Int>{1i, 2i}).front(); }', "1_i");
+
+        runMainCode('public function main(): Nat { return List<Int>::concat(List<Int>{1i}, List<Int>{3i, 2i}).size(); }', "3_n"); 
+        runMainCode('public function main(): Int { return List<Int>::concat(List<Int>{1i}, List<Int>{3i, 2i}).back(); }', "3_i"); 
+        runMainCode('public function main(): Int { return List<Int>::concat(List<Int>{1i}, List<Int>{3i, 2i}).front(); }', "1_i"); 
+    });
+
+    it("should concatAll", function () {
+        runMainCode('public function main(): Bool { return List<Int>::concatAll(List<List<Int>>{}).empty(); }', "true");
+
+        runMainCode('public function main(): Nat { return List<Int>::concatAll(List<List<Int>>{List<Int>{1i, 2i}, List<Int>{}}).size(); }', "2_n");
+        runMainCode('public function main(): Int { return List<Int>::concatAll(List<List<Int>>{List<Int>{1i, 2i}, List<Int>{}}).back(); }', "2_i");
+        runMainCode('public function main(): Nat { return List<Int>::concatAll(List<List<Int>>{List<Int>{}, List<Int>{1i, 2i}}).size(); }', "2_n"); 
+        runMainCode('public function main(): Int { return List<Int>::concatAll(List<List<Int>>{List<Int>{}, List<Int>{1i, 2i}}).front(); }', "1_i");
+
+        runMainCode('public function main(): Nat { return List<Int>::concatAll(List<List<Int>>{List<Int>{1i}, List<Int>{3i, 2i}}).size(); }', "3_n"); 
+        runMainCode('public function main(): Int { return List<Int>::concatAll(List<List<Int>>{List<Int>{1i}, List<Int>{3i, 2i}}).back(); }', "2_i"); 
+        runMainCode('public function main(): Int { return List<Int>::concatAll(List<List<Int>>{List<Int>{1i}, List<Int>{3i, 2i}}).front(); }', "1_i");  
+    });
+});

--- a/test/cppoutput/list/list_map.test.js
+++ b/test/cppoutput/list/list_map.test.js
@@ -2,3 +2,43 @@
 
 import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
 import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate List -- map basic", () => {
+    it("should do simple maps", function () {
+        runMainCode('public function main(): Nat { return List<Int>{}.map<Bool>(fn(x) => x >= 0i).size(); }', "0_n");
+
+        runMainCode('public function main(): Bool { return List<Int>{1i}.map<Bool>(fn(x) => x >= 0i).front(); }', "true");
+        runMainCode('public function main(): Bool { return List<Int>{1i, -1i}.map<Bool>(fn(x) => x >= 0i).back(); }', "false");
+    });
+
+/*
+    it("should do simple maps w/err", function () {
+        runMainCode('public function main(): Nat { return List<Int>{}.map<Bool>(fn(x) => { assert x != 0i; return x >= 0i; }).size(); }', "(assert (not (= (@Result-ok 0) Main@main)))");
+
+        runMainCode('public function main(): Bool { return List<Int>{1i}.map<Bool>(fn(x) => { assert x != 0i; return x >= 0i; }).front(); }', "(assert (not (= (@Result-ok true) Main@main)))");
+        runMainCode('public function main(): Bool { return List<Int>{1i, 0i, -1i}.map<Bool>(fn(x) => { assert x != 0i; return x >= 0i; }).back(); }', "(assert (not (is-@Result-err Main@main)))");
+    });
+*/
+});
+
+describe ("CPP Emit Evaluate List -- map index basic", () => {
+    it("should do simple maps index", function () {
+        runMainCode('public function main(): Nat { return List<Nat>{}.mapIdx<Bool>(fn(x, i) => x >= i).size(); }', "0_n");
+
+        runMainCode('public function main(): Bool { return List<Nat>{1n}.mapIdx<Bool>(fn(x, i) => x >= i).front(); }', "true");
+        runMainCode('public function main(): Bool { return List<Nat>{1n, 0n}.mapIdx<Bool>(fn(x, i) => x >= i).back(); }', "false");
+
+        runMainCode('public function main(): Nat { return List<Int>{1i, -1i, 3i}.mapIdx<Nat>(fn(x, i) => i).back(); }', "2_n");
+    });
+
+/*
+    it("should do simple maps index w/err", function () {
+        runMainCode('public function main(): Nat { return List<Nat>{}.mapIdx<Bool>(fn(x, i) => { assert x != 0n; return x >= i; }).size(); }', "(assert (not (= (@Result-ok 0) Main@main)))");
+
+        runMainCode('public function main(): Bool { return List<Nat>{1n}.mapIdx<Bool>(fn(x, i) => { assert x != 0n; return x >= i; }).front(); }', "(assert (not (= (@Result-ok true) Main@main)))");
+        runMainCode('public function main(): Bool { return List<Nat>{1n, 0n}.mapIdx<Bool>(fn(x, i) => { assert x != 0n; return x >= i; }).back(); }', "(assert (not (is-@Result-err Main@main)))");
+
+        runMainCode('public function main(): Nat { return List<Int>{1i, -1i, 3i}.mapIdx<Nat>(fn(x, i) => { assert x != 0i; return i; }).back(); }', "(assert (not (= (@Result-ok 2) Main@main)))");
+    });
+*/
+});

--- a/test/cppoutput/list/list_map.test.js
+++ b/test/cppoutput/list/list_map.test.js
@@ -1,0 +1,4 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";

--- a/test/cppoutput/list/list_predof_ops.test.js
+++ b/test/cppoutput/list/list_predof_ops.test.js
@@ -2,3 +2,64 @@
 
 import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
 import { describe, it } from "node:test";
+
+
+describe ("CPP Emit Evaluate List -- allof basic", () => {
+    it("should do simple allof", function () {
+        runMainCode('public function main(): Bool { return List<Int>{}.allOf(pred(x) => x >= 0i); }', "true");
+        runMainCode('public function main(): Bool { return List<Int>{1i, 2i}.allOf(pred(x) => x >= 0i); }', "true");
+
+        runMainCode('public function main(): Bool { return List<Int>{-2i}.allOf(pred(x) => x >= 0i); }', "false");
+        runMainCode('public function main(): Bool { return List<Int>{1i, -1i}.allOf(pred(x) => x >= 0i); }', "false");
+    });
+
+/*
+    it("should smt do simple allof w/err", function () {
+        runMainCode('public function main(): Bool { return List<Int>{1i, 2i}.allOf(pred(x) => { assert x != 0i; return x >= 0i; }); }', "(assert (not (= (@Result-ok true) Main@main)))");
+        runMainCode('public function main(): Bool { return List<Int>{-2i, 1i}.allOf(pred(x) => { assert x != 0i; return x >= 0i; }); }', "(assert (not (= (@Result-ok false) Main@main)))");
+
+        runMainCode('public function main(): Bool { return List<Int>{1i, 0i, 3i}.allOf(pred(x) => { assert x != 0i; return x >= 0i; }); }', "(assert (not (is-@Result-err Main@main)))");
+        runMainCode('public function main(): Bool { return List<Int>{-1i, 0i, 3i}.allOf(pred(x) => { assert x != 0i; return x >= 0i; }); }', "(assert (not (= (@Result-ok false) Main@main)))");
+    });
+*/
+});
+
+describe ("CPP Emit Evaluate List -- noneof basic", () => {
+    it("should do simple noneof", function () {
+        runMainCode('public function main(): Bool { return List<Int>{}.noneOf(pred(x) => x >= 0i); }', "true");
+        runMainCode('public function main(): Bool { return List<Int>{-1i, -2i}.noneOf(pred(x) => x >= 0i); }', "true");
+
+        runMainCode('public function main(): Bool { return List<Int>{2i}.noneOf(pred(x) => x >= 0i); }', "false");
+        runMainCode('public function main(): Bool { return List<Int>{1i, -1i}.noneOf(pred(x) => x >= 0i); }', "false");
+    });
+
+/*
+    it("should smt do simple noneof w/err", function () {
+        runMainCode('public function main(): Bool { return List<Int>{-1i, -2i}.noneOf(pred(x) => { assert x != 0i; return x >= 0i; }); }', "(assert (not (= (@Result-ok true) Main@main)))");
+        runMainCode('public function main(): Bool { return List<Int>{1i, -1i}.noneOf(pred(x) => { assert x != 0i; return x >= 0i; }); }', "(assert (not (= (@Result-ok false) Main@main)))");
+
+        runMainCode('public function main(): Bool { return List<Int>{-1i, 0i, 3i}.noneOf(pred(x) => { assert x != 0i; return x >= 0i; }); }', "(assert (not (is-@Result-err Main@main)))");
+        runMainCode('public function main(): Bool { return List<Int>{1i, 0i, 3i}.noneOf(pred(x) => { assert x != 0i; return x >= 0i; }); }', "(assert (not (= (@Result-ok false) Main@main)))");
+    });
+*/
+});
+
+describe ("CPP Emit Evaluate List -- someof basic", () => {
+    it("should do simple someof", function () {
+        runMainCode('public function main(): Bool { return List<Int>{}.someOf(pred(x) => x >= 0i); }', "false");
+        runMainCode('public function main(): Bool { return List<Int>{-1i, 2i}.someOf(pred(x) => x >= 0i); }', "true");
+
+        runMainCode('public function main(): Bool { return List<Int>{-2i}.someOf(pred(x) => x >= 0i); }', "false");
+        runMainCode('public function main(): Bool { return List<Int>{-1i, -1i}.someOf(pred(x) => x >= 0i); }', "false");
+    });
+
+/*
+    it("should smt do simple someof w/err", function () {
+        runMainCode('public function main(): Bool { return List<Int>{-1i, 2i}.someOf(pred(x) => { assert x != 0i; return x >= 0i; }); }', "(assert (not (= (@Result-ok true) Main@main)))");
+        runMainCode('public function main(): Bool { return List<Int>{-1i, -1i}.someOf(pred(x) => { assert x != 0i; return x >= 0i; }); }', "(assert (not (= (@Result-ok false) Main@main)))");
+
+        runMainCode('public function main(): Bool { return List<Int>{-1i, 0i, 3i}.someOf(pred(x) => { assert x != 0i; return x >= 0i; }); }', "(assert (not (is-@Result-err Main@main)))");
+        runMainCode('public function main(): Bool { return List<Int>{1i, 0i, 3i}.someOf(pred(x) => { assert x != 0i; return x >= 0i; }); }', "(assert (not (= (@Result-ok true) Main@main)))");
+    });
+*/
+});

--- a/test/cppoutput/list/list_predof_ops.test.js
+++ b/test/cppoutput/list/list_predof_ops.test.js
@@ -1,0 +1,4 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";

--- a/test/cppoutput/list/list_reduce.test.js
+++ b/test/cppoutput/list/list_reduce.test.js
@@ -2,3 +2,31 @@
 
 import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
 import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate List -- reduce simple", () => {
+    it("should do simple bool reduce", function () {
+        runMainCode('public function main(): Bool { return List<Int>{}.reduce<Bool>(true, fn(acc, x) => acc && x > 0i); }', "true");
+        runMainCode('public function main(): Bool { return List<Int>{}.reduce<Bool>(false, fn(acc, x) => acc && x > 0i); }', "false");
+
+        runMainCode('public function main(): Bool { return List<Int>{1i, 3i}.reduce<Bool>(true, fn(acc, x) => acc && x > 0i); }', "true");
+        runMainCode('public function main(): Bool { return List<Int>{2i, 0i, 3i}.reduce<Bool>(true, fn(acc, x) => acc && x > 0i); }', "false");
+    });
+
+    it("should do simple int reduce", function () {
+        runMainCode('public function main(): Int { return List<Int>{}.reduce<Int>(0i, fn(acc, x) => acc + x); }', "0_i");
+        runMainCode('public function main(): Int { return List<Int>{}.reduce<Int>(5i, fn(acc, x) => acc + x); }', "5_i");
+
+        runMainCode('public function main(): Int { return List<Int>{1i, 3i}.reduce<Int>(0i, fn(acc, x) => acc + x); }', "4_i");
+        runMainCode('public function main(): Int { return List<Int>{-2i, 0i, 3i}.reduce<Int>(0i, fn(acc, x) => acc + x); }', "1_i");
+    });
+
+/*
+    it("should do simple int reduce smt w/err", function () {
+        runMainCode('public function main(): Bool { return List<Int>{1i, 3i}.reduce<Bool>(true, fn(acc, x) => { assert x != 0i; return acc && x > 0i; }); }', "(assert (not (= (@Result-ok true) Main@main)))");
+        runMainCode('public function main(): Bool { return List<Int>{1i, 0i, 3i}.reduce<Bool>(true, fn(acc, x) => { assert x != 0i; return acc && x > 0i; }); }', "(assert (not (is-@Result-err Main@main)))");
+
+        runMainCode('public function main(): Int { return List<Int>{-2i, 3i}.reduce<Int>(0i, fn(acc, x) => { assert x != 0i; return acc + x; }); }', "(assert (not (= (@Result-ok 1) Main@main)))");
+        runMainCode('public function main(): Int { return List<Int>{-2i, 0i, 3i}.reduce<Int>(0i, fn(acc, x) => { assert x != 0i; return acc + x; }); }', "(assert (not (is-@Result-err Main@main)))");
+    });
+*/
+});

--- a/test/cppoutput/list/list_reduce.test.js
+++ b/test/cppoutput/list/list_reduce.test.js
@@ -1,0 +1,4 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js";
+import { describe, it } from "node:test";


### PR DESCRIPTION
Added tests for cpp list map, reduce, `pred()` flavours, and append/prepend. 

Also fixed a few varrying bugs that prevented the tests I added from working: 
1. In `bsqir_emit`, `CallTypeFunctionExpression` was not emitting resolved templates (e.g. it was emitting `s_list_mapidx` as `s_list_mapidx<U>` and not something like `s_list_mapidx<Int, Nat>` after resolution)
2. Methods now emit with the type they are declared in as a prefix (something like `FooᘏfooᐸIntᐳ`) to prevent possible naming conflicts
3. `CollectionTypeDecl`s emit before any possible usage now, being emitted grouped with our ref type forward decls
4. `Bool` now emits as a `__CoreCpp::Bool` (which is literally just `typedef bool Bool`) as it makes name type transformation easier