### PR TITLE
Cleanup Type Funcs

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -137,6 +137,12 @@ entity VariableInitializationStatement provides Statement {
     field exp: Expression;
 }
 
+entity VariableAssignmentStatement provides Statement {
+    field name: Identifier;
+    field vtype: TypeSignature;
+    field exp: Expression;
+}
+
 entity BlockStatement provides Statement {
     field statements: List<Statement>;
     field isScoping: Bool;

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -192,7 +192,6 @@ entity NamespaceFunctionDecl provides AbstractInvokeDecl {
 }
 
 entity TypeFunctionDecl provides AbstractInvokeDecl {
-    field completens: List<CString>;
     field completeikey: InvokeKey;
 }
 

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -192,7 +192,6 @@ entity NamespaceFunctionDecl provides AbstractInvokeDecl {
 }
 
 entity TypeFunctionDecl provides AbstractInvokeDecl {
-    field completeikey: InvokeKey;
 }
 
 %% This is not actively being used but MAY prove some use as the emitter expands so ill leave it 

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <cmath>
 #include <csetjmp>
-#include <variant> // TODO: Need to remove dependency!
 
 #define 𝐚𝐛𝐨𝐫𝐭 (std::longjmp(__CoreCpp::info.error_handler, true))
 #define 𝐚𝐬𝐬𝐞𝐫𝐭(E) if(!(E)) { 𝐚𝐛𝐨𝐫𝐭; }
@@ -703,42 +702,6 @@ constexpr std::string t_to_string(T v) {
     }
 
     return res;
-}
-
-// Will need to support Bosque CString and String eventually
-typedef std::variant<Int, Nat, BigInt, BigNat, Float, bool> MainType; 
-
-//
-// Converts return type of main to string
-//
-std::string to_string(MainType v) {
-    if(std::holds_alternative<bool>(v)) {
-        bool res = std::get<bool>(v);
-        if(!res) {
-            return "false";
-        }
-        return "true";
-    }
-    else if(std::holds_alternative<Int>(v)) {
-        return std::to_string(std::get<Int>(v).get()) + "_i";
-    }
-    else if (std::holds_alternative<Nat>(v)) {
-        return std::to_string(std::get<Nat>(v).get()) + "_n";
-    }
-    else if (std::holds_alternative<Float>(v)) {
-        return std::to_string(std::get<Float>(v).get()) + "_f";
-    }
-    else if(std::holds_alternative<BigInt>(v)) {
-        __int128_t res = std::get<BigInt>(v).get();
-        return t_to_string<__int128_t>(res) + "_I";
-    }
-    else if(std::holds_alternative<BigNat>(v)) {
-        __int128_t res = std::get<BigNat>(v).get();
-        return t_to_string<__uint128_t>(res) + "_N";
-    }
-    else {
-        return "Unable to print main return type!\n";
-    }
 }
 
 } // namespace __CoreCpp

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <cmath>
 #include <csetjmp>
+#include <variant> // TODO: Need to remove dependency!
 
 #define 𝐚𝐛𝐨𝐫𝐭 (std::longjmp(__CoreCpp::info.error_handler, true))
 #define 𝐚𝐬𝐬𝐞𝐫𝐭(E) if(!(E)) { 𝐚𝐛𝐨𝐫𝐭; }
@@ -702,6 +703,42 @@ constexpr std::string t_to_string(T v) {
     }
 
     return res;
+}
+
+// Will need to support Bosque CString and String eventually
+typedef std::variant<Int, Nat, BigInt, BigNat, Float, bool> MainType; 
+
+//
+// Converts return type of main to string
+//
+std::string to_string(MainType v) {
+    if(std::holds_alternative<bool>(v)) {
+        bool res = std::get<bool>(v);
+        if(!res) {
+            return "false";
+        }
+        return "true";
+    }
+    else if(std::holds_alternative<Int>(v)) {
+        return std::to_string(std::get<Int>(v).get()) + "_i";
+    }
+    else if (std::holds_alternative<Nat>(v)) {
+        return std::to_string(std::get<Nat>(v).get()) + "_n";
+    }
+    else if (std::holds_alternative<Float>(v)) {
+        return std::to_string(std::get<Float>(v).get()) + "_f";
+    }
+    else if(std::holds_alternative<BigInt>(v)) {
+        __int128_t res = std::get<BigInt>(v).get();
+        return t_to_string<__int128_t>(res) + "_I";
+    }
+    else if(std::holds_alternative<BigNat>(v)) {
+        __int128_t res = std::get<BigNat>(v).get();
+        return t_to_string<__uint128_t>(res) + "_N";
+    }
+    else {
+        return "Unable to print main return type!\n";
+    }
 }
 
 } // namespace __CoreCpp

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -4,10 +4,8 @@ int main() {
         std::cout << "Assertion failed! Or perhaps over/underflow?" << std::endl;
         return EXIT_FAILURE;
     }
-
-    // Calling our emitted main is hardcoded for now
-    __CoreCpp::MainType ret = Main::main();
-    std::cout << __CoreCpp::to_string(ret) << std::endl;
+    
+    std::cout << Main::main() << std::endl;
 
     return 0;
 }

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -4,8 +4,10 @@ int main() {
         std::cout << "Assertion failed! Or perhaps over/underflow?" << std::endl;
         return EXIT_FAILURE;
     }
-    
-    std::cout << Main::main() << std::endl;
+   
+    // Calling our emitted main is hardcoded for now
+    __CoreCpp::MainType ret = Main::main();
+    std::cout << __CoreCpp::to_string(ret) << std::endl;
 
     return 0;
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -756,7 +756,6 @@ function emitConstructorPrimaryListExpression(exp: CPPAssembly::ConstructorPrima
         nctx = ctx.updateCurrentNamespace(ttype.declaredInNS, ttype.fullns);
     }
 
-    %% This is the line that causes us to abort, somethjing with our arguments not emitting
     let args = emitArguments(exp.args, ctx);
     let ns = "Core::ListOps::"; %% So long as lists impl stays in Core::ListOps this will hold 
 
@@ -1612,6 +1611,9 @@ function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, 
     }
 }
 
+%%
+%% TODO: We should extern these in the header then define in the cpp. Defining them in the header is a bad idea
+%%
 function emitConstMemberDecl(cmd: CPPAssembly::ConstMemberDecl, ctx: Context, indent: String): String {
     let nctx = ctx.updateCurrentNamespace(cmd.declaredInNS, cmd.fullns);
     

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -72,19 +72,6 @@ function removeCommonPrefix(name: String, prefix: String): String {
     return name.removePrefixString(prefix);
 }
 
-function emitSpecialTemplate(name: String): String {
-    if(name.startsWithString("__CoreCpp")) {
-        return name;
-    }
-    
-    return name
-        .replaceAllStringOccurrences(" ", "")
-        .replaceAllStringOccurrences("<", "ᐸ")
-        .replaceAllStringOccurrences(",", "ᐧ")
-        .replaceAllStringOccurrences(">", "ᐳ")
-        .replaceAllStringOccurrences("::", "ᘏ");
-}
-
 function emitBindVar(bname: CPPAssembly::VarIdentifier, convert: String, converttype: String, exp: String): String { 
     let name = emitVarIdentifier(bname); 
     let tbindtype = String::concat("[[maybe_unused]] ", converttype, " ");
@@ -138,7 +125,7 @@ function emitResolvedTemplates(tk: Option<CPPAssembly::TypeKey>, ik: Option<CPPA
     var resolvedik: Option<CPPAssembly::InvokeKey>;
     match(ik) {
         Some<CPPAssembly::InvokeKey> => { resolvedik = if(isTypeFunc) 
-            then some(ctx.asm.typefuncs.get(ik@some).completeikey) 
+            then some(ctx.asm.typefuncs.get(ik@some).ikey) 
             else ik; }
         | None => { resolvedik = ik; }
     }
@@ -148,22 +135,13 @@ function emitResolvedTemplates(tk: Option<CPPAssembly::TypeKey>, ik: Option<CPPA
         Some<CPPAssembly::TypeKey> => { declaredInNS = emitNamespaceKey(ctx.asm.lookupNominalTypeDeclaration(tk@some).declaredInNS); }
         | None => { declaredInNS = emitNamespaceKey(ctx.asm.tryLookupInvokeImplDeclaration(ik@some)@some.declaredInNS); }
     }
-    
-    %% If a typefunc we need to create the namespace key from its completens (as tfunc.declaredInNS is lacking "Core::" prefix)
-    var resolvedns: String;
-    match(ik) { 
-        Some<CPPAssembly::InvokeKey> => { resolvedns = if(isTypeFunc) 
-            then String::joinAll("::", convertCStringList(ctx.asm.typefuncs.get(ik@some).completens)) 
-            else declaredInNS; }
-        | None => { resolvedns = declaredInNS; }
-    }
 
     let key = if(tk)@some then emitTypeKeyValue($tk) else emitInvokeKeyValue(resolvedik@some);
     if(key.startsWithString("__CoreCpp")) {  
         return key;
     }
     else { 
-        let ns = String::concat(resolvedns, "::");
+        let ns = String::concat(declaredInNS, "::");
         let resolvedkey = if(ns.startsWithString("Core") && !key.startsWithString("Core")) 
             then String::concat("Core::", key)
             else key;
@@ -175,26 +153,42 @@ function emitResolvedTemplates(tk: Option<CPPAssembly::TypeKey>, ik: Option<CPPA
     }
 }
 
+function emitSpecialTemplate(name: String): String {
+    if(name.startsWithString("__CoreCpp")) {
+        return name;
+    }
+    
+    return name
+        .replaceAllStringOccurrences(" ", "")
+        .replaceAllStringOccurrences("(|", "丨")
+        .replaceAllStringOccurrences("|)", "丨")
+        .replaceAllStringOccurrences("<", "ᐸ")
+        .replaceAllStringOccurrences(",", "ᐧ")
+        .replaceAllStringOccurrences(">", "ᐳ")
+        .replaceAllStringOccurrences("::", "ᘏ");
+}
+
 function convertLambdaTypeSignature(lts: CPPAssembly::LambdaTypeSignature, ctx: Context): String {
     let resolved = emitResolvedNamespace(ctx.fullns_list, emitTypeKeyValue(lts.tkeystr));
 
-    let base = if(resolved.startsWithString("fn")) 
-        then resolved.removePrefixString("fn") 
-        else resolved.removePrefixString("pred");
-    let replace = base
-        .replaceAllStringOccurrences("(", "")
-        .replaceAllStringOccurrences(")", "")
-        .replaceAllStringOccurrences("->", "$")
-        .replaceAllStringOccurrences(">", "ᐳ")
-        .replaceAllStringOccurrences("<", "ᐸ")
-        .replaceAllStringOccurrences(",", "ᐧ")
-        .replaceAllStringOccurrences(" ", "");
+    let replace = emitSpecialTemplate(resolved.replaceAllStringOccurrences("->", "$"))
+        .replaceAllStringOccurrences("(", "_")
+        .replaceAllStringOccurrences(")", "_");
 
-    return String::concat("λ_", replace);
+    return String::concat("λ", replace);
 }
 
 function emitTypeSignature(ts: CPPAssembly::TypeSignature, shouldCheckTag: Bool, ctx: Context): String {
     if(ts)@<CPPAssembly::EListTypeSignature> {
+
+        %%
+        %% We may need to generate a typedef for our tuples instead
+        %%
+
+        if(!shouldCheckTag) {
+            return emitSpecialTemplate(String::fromCString($ts.tkeystr.value));
+        }
+
         let argssizes = $ts.entries.map<String>(fn(e) => {
             let tinfo = ctx.asm.typeinfos.get(e.tkeystr);
             return if(tinfo.tag !== CPPAssembly::Tag#Ref) then String::fromCString(tinfo.slotsize.toCString())
@@ -249,6 +243,14 @@ function emitInvokeKey(ik: CPPAssembly::InvokeKey, ctx: Context): String {
     return emitResolvedNamespace(ctx.fullns_list, emitResolvedTemplates(none, some(ik), ctx)); 
 }
 
+function generateMethodName(m: CPPAssembly::InvokeKey, declaredIn: CPPAssembly::TypeKey, ctx: Context): String {
+    let mdecl = ctx.asm.lookupNominalTypeDeclaration(declaredIn);
+    let mdeclname = emitTypeKey(declaredIn, false, ctx);
+    let basename = String::fromCString(m.value.removePrefixString(declaredIn.value).removePrefixString('::'));
+
+    return String::concat(mdeclname, "ᘏ", emitSpecialTemplate(basename));
+}
+
 function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): String {
     return String::fromCString(nsk.value);
 }
@@ -266,14 +268,6 @@ function generateAccessorForSpecialTypeConstructor(constype: CPPAssembly::TypeSi
             return if(eexp === "") then String::concat(econstype, "{ &", ettype, " }")
                 else String::concat(econstype, "{ &", ettype, ", ", eexp, " }");
         }
-}
-
-function generateMethodName(m: CPPAssembly::InvokeKey, declaredIn: CPPAssembly::TypeKey, ctx: Context): String {
-    let mdecl = ctx.asm.lookupNominalTypeDeclaration(declaredIn);
-    let mdeclname = emitTypeKey(declaredIn, false, ctx);
-    let basename = String::fromCString(m.value.removePrefixString(declaredIn.value).removePrefixString('::'));
-
-    return String::concat(mdeclname, "ᘏ", emitSpecialTemplate(basename));
 }
 
 %% Given a namespace key (like Main::Foo::Bar), remove all matching prefix strings
@@ -746,7 +740,7 @@ function emitConstructorEListExpression(exp: CPPAssembly::ConstructorEListExpres
     if(exp.args.size() > 4n) {
         abort; %% Tuples of size > 4 not supported yet
     }
-    let ceetype = emitTypeSignature(exp.etype, false, ctx);
+    let ceetype = emitTypeSignature(exp.etype, true, ctx);
     let args = String::joinAll(", ", exp.args.map<String>(fn(e) => emitExpression(e, ctx))); 
 
     return String::concat(ceetype, "(", args, ")");
@@ -1371,12 +1365,11 @@ function emitMethods(ant: CPPAssembly::AbstractNominalTypeDecl, declaredIn: CPPA
 
 %% Type funcs are fully resolved before cpp emission so we can group them with nsfuncs
 function emitFunctionDecl(func: CPPAssembly::AbstractInvokeDecl, ctx: Context, indent: String): String {
-    let isTypeFunc = ctx.asm.typefuncs.has(func.ikey);
     let ikey = func.ikey;   
-    let ns = if(isTypeFunc) then ctx.asm.typefuncs.get(func.ikey).completens else func.fullns;
+    let ns = func.fullns;
     let nctx = ctx.updateCurrentNamespace(func.declaredInNS, ns);
 
-    let name = emitInvokeKey(ikey, nctx);
+    var name = emitInvokeKey(ikey, nctx);
     let params, templates = emitParameters(func.params, nctx);
     let rtype = emitTypeSignature(func.resultType, true, nctx); 
 
@@ -1489,8 +1482,7 @@ function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CP
 }
 
 function emitFunctionForwardDeclaration(decl: CPPAssembly::AbstractInvokeDecl, ctx: Context, ident: String): String {
-    let isTypeFunc = ctx.asm.typefuncs.has(decl.ikey);
-    let ns = if(isTypeFunc) then ctx.asm.typefuncs.get(decl.ikey).completens else decl.fullns;
+    let ns = decl.fullns;
     let nctx = ctx.updateCurrentNamespace(decl.declaredInNS, ns);
 
     let ikey = emitInvokeKey(decl.ikey, nctx);
@@ -1501,11 +1493,6 @@ function emitFunctionForwardDeclaration(decl: CPPAssembly::AbstractInvokeDecl, c
     let first = String::concat(template, ident, rtype, " ", ikey);
     return String::concat(first, "(", params, ") noexcept;%n;");
 }
-
-%%
-%% TODO: Need to add lookup methods for these vtables and give this some thought. A lot of this code is repetitive or could be
-%% cleaned up pretty signifigantly. We currently emit a vtable entry for all fields, not just those who are derived. (this may need changed)
-%%
 
 function generateVTableEntry(entry: CPPAssembly::MemberFieldDecl, resolved_name: String, enum_name: String, idx: Nat, ctx: Context, indent: String): String {
     let tinfo = ctx.asm.typeinfos.tryGet(entry.declaredType.tkeystr);
@@ -1630,11 +1617,12 @@ function emitConstMemberDecl(cmd: CPPAssembly::ConstMemberDecl, ctx: Context, in
     
     let exp = emitExpression(cmd.value, nctx);
     let rtype = emitTypeSignature(cmd.declaredType, true, nctx);
+    let name = emitTypeSignature(cmd.declaredType, false, nctx);
 
     %% Not 100% about removing previx, fixes bug for emitting "one" and "zero" constmember decls
-    let name = removeCppPrefix(String::concat(rtype, "ᘏ", emitIdentifier(cmd.name)));
+    let fullname = removeCppPrefix(String::concat(name, "ᘏ", emitIdentifier(cmd.name)));
 
-    let pre = String::concat(indent, rtype, " ", name, " = ");
+    let pre = String::concat(indent, rtype, " ", fullname, " = ");
     return String::concat(pre, exp, ";%n;");
 }
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -553,10 +553,6 @@ function emitPostfixAccessFromIndex(op: CPPAssembly::PostfixAccessFromIndex, acc
 }
 
 function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, rootexp: String, ctx: Context): String {
-    %% We don't want to do any resolution of these keys yet
-    let ik = String::fromCString(op.resolvedTrgt.value);
-    let tk = String::fromCString(op.resolvedType.tkeystr.value);
-
     let args = emitArguments(op.args, ctx);
 
     %% The "this" arguemnt does not exist in explicitify so we handle the coersion here (we manually added it for cpp emission)
@@ -572,12 +568,6 @@ function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, rootexp: 
         thisarg = rootexp;
     } 
 
-    let resolvedtype = ctx.asm.lookupNominalTypeDeclaration(op.resolvedType.tkeystr);
-    let ns = emitResolvedNamespace(ctx.fullns_list, emitNamespaceKey(resolvedtype.declaredInNS));
-    let resolvedns = if(ns !== "" && !ns.endsWithString("::")) 
-        then String::concat(ns, "::")
-        else ns;
-    
     let name = generateMethodName(op.resolvedTrgt, op.resolvedType.tkeystr, ctx);
     if(args === "") {
         return String::concat(name, "(", thisarg, ")");
@@ -763,9 +753,16 @@ function emitConstructorEListExpression(exp: CPPAssembly::ConstructorEListExpres
 }
 
 function emitConstructorPrimaryListExpression(exp: CPPAssembly::ConstructorPrimaryListExpression, ctx: Context): String {
-    let ttype = ctx.asm.lookupNominalTypeDeclaration(exp.elemtype.tkeystr);
-    let nctx = ctx.updateCurrentNamespace(ttype.declaredInNS, ttype.fullns);
+    var nctx: Context;
+    if(exp.elemtype)<CPPAssembly::EListTypeSignature> {
+        nctx = ctx;
+    }
+    else { 
+        let ttype = ctx.asm.lookupNominalTypeDeclaration(exp.elemtype.tkeystr);
+        nctx = ctx.updateCurrentNamespace(ttype.declaredInNS, ttype.fullns);
+    }
 
+    %% This is the line that causes us to abort, somethjing with our arguments not emitting
     let args = emitArguments(exp.args, ctx);
     let ns = "Core::ListOps::"; %% So long as lists impl stays in Core::ListOps this will hold 
 
@@ -1038,6 +1035,13 @@ function emitVariableInitializationStatement(stmt: CPPAssembly::VariableInitiali
     return String::concat(full_indent, " ", name, " = ", exp, ";");
 }
 
+function emitVariableAssignmentStatement(stmt: CPPAssembly::VariableAssignmentStatement, ctx: Context, indent: String): String {
+    let name = emitIdentifier(stmt.name);
+    let exp = emitExpression(stmt.exp, ctx);
+
+    return String::concat(indent, "    ", name, " = ", exp, ";");
+}
+
 function emitBlockStatement(block: CPPAssembly::BlockStatement, ctx: Context, indent: String): String {
     let stmts = block.statements.map<String>(fn(stmt) => emitStatement(stmt, ctx, indent));
     return String::joinAll("%n;", stmts);
@@ -1240,7 +1244,7 @@ function emitStatement(stmt: CPPAssembly::Statement, ctx: Context, indent: Strin
         | CPPAssembly::VariableInitializationStatement => { return emitVariableInitializationStatement($stmt, ctx, indent); }
         %%| CPPAssembly::VariableMultiInitializationExplicitStatement => { abort; }
         %%| CPPAssembly::VariableMultiInitializationImplicitStatement => { abort; }
-        %%| CPPAssembly::VariableAssignmentStatement => { abort; }
+        | CPPAssembly::VariableAssignmentStatement => { return emitVariableAssignmentStatement($stmt, ctx, indent); }
         %%| CPPAssembly::VariableMultiInitializationExplicitStatement => { abort; }
         %%| CPPAssembly::VariableMultiAssignmentImplicitStatement => { abort; }
         %%| CPPAssembly::VariableRetypeStatement => { abort; }
@@ -1504,9 +1508,17 @@ function emitFunctionForwardDeclaration(decl: CPPAssembly::AbstractInvokeDecl, c
 %%
 
 function generateVTableEntry(entry: CPPAssembly::MemberFieldDecl, resolved_name: String, enum_name: String, idx: Nat, ctx: Context, indent: String): String {
-    let tinfo = ctx.asm.typeinfos.tryGet(entry.declaredType.tkeystr)@some;
+    let tinfo = ctx.asm.typeinfos.tryGet(entry.declaredType.tkeystr);
 
-    let id = String::fromCString(tinfo.id.toCString());
+    var id: String;
+    if(tinfo)@none { %% elist case
+        %% Since elists are our special case we should likely reserve a specific id for all elists (say 0n)
+        id = String::fromCString(0n.toCString()); 
+    }
+    else {
+        id = String::fromCString($tinfo.id.toCString());
+    }
+
     let entrytype = String::concat(enum_name, "::", resolved_name, "_", emitIdentifier(entry.name));
     let byteoffset = String::fromCString((idx * 8n).toCString()); %% Woudlnt be a bad idea to make these 8 byte alignment a const
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1612,7 +1612,9 @@ function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, 
 }
 
 %%
-%% TODO: We should extern these in the header then define in the cpp. Defining them in the header is a bad idea
+%% TODO: We should move the definition to the source file. Defining them in the header is a bad idea.
+%% We will also need to be careful about the order these emit in as its possible one const could
+%% contain in its definition another const
 %%
 function emitConstMemberDecl(cmd: CPPAssembly::ConstMemberDecl, ctx: Context, indent: String): String {
     let nctx = ctx.updateCurrentNamespace(cmd.declaredInNS, cmd.fullns);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -851,8 +851,7 @@ entity CPPTransformer {
 
     method transformTypeFunctionDeclToCpp(decl: BSQAssembly::TypeFunctionDecl): CPPAssembly::TypeFunctionDecl {
         let base = this.transformAbstractInvokeDecl(decl);
-        return CPPAssembly::TypeFunctionDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, decl.completens, 
-            CPPTransformNameManager::convertInvokeKey(decl.completeikey) };
+        return CPPAssembly::TypeFunctionDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, CPPTransformNameManager::convertInvokeKey(decl.completeikey) };
     } 
 
     method transformConstMemberDeclToCpp(decl: BSQAssembly::ConstMemberDecl): CPPAssembly::ConstMemberDecl {
@@ -1245,7 +1244,7 @@ entity CPPTransformer {
 
         let transformer_nsdecls_typefuncs = transformer_typefuncs.reduce<Map<CString, CPPAssembly::NamespaceDecl>>( 
             transformer_nsdecls_nsfuncs, fn(acc, ikey, cppfunc) => {
-                return CPPTransformNameManager::getNamespaceDeclMapping(cppfunc.completens, acc,
+                return CPPTransformNameManager::getNamespaceDeclMapping(cppfunc.fullns, acc,
                     fn(decl) => { 
                         let ntypefuncs = decl.typefuncs.pushBack(ikey);
                         return decl[typefuncs=ntypefuncs];
@@ -1301,7 +1300,6 @@ entity CPPTransformer {
                         let ndatatypes = decl.datatypes.pushBack(cpptk);
                         let nalltypes = decl.alltypes.pushBack(cpptk);
                         let ndecl = transformer.updateNSMethods(decl, cppdatatype@<CPPAssembly::AbstractNominalTypeDecl>);
-                        
                         return ndecl[datatypes=ndatatypes, alltypes=nalltypes];
                     });                     
             });

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -851,7 +851,7 @@ entity CPPTransformer {
 
     method transformTypeFunctionDeclToCpp(decl: BSQAssembly::TypeFunctionDecl): CPPAssembly::TypeFunctionDecl {
         let base = this.transformAbstractInvokeDecl(decl);
-        return CPPAssembly::TypeFunctionDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, CPPTransformNameManager::convertInvokeKey(decl.completeikey) };
+        return CPPAssembly::TypeFunctionDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6 };
     } 
 
     method transformConstMemberDeclToCpp(decl: BSQAssembly::ConstMemberDecl): CPPAssembly::ConstMemberDecl {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -962,7 +962,7 @@ entity CPPTransformer {
     recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat, bsqasm: BSQAssembly::Assembly): 
         (|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|) { 
             let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);
-            if(tinfos.has(cpptkey) && tinfos.get(cpptkey).typesize != 5n) { %% 5n???? why did i write this
+            if(tinfos.has(cpptkey)) {
                 return tinfos.get(cpptkey), tinfos;
             }
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -146,11 +146,23 @@ entity CPPTransformer {
     }
 
     method shouldBeRef(fields: List<BSQAssembly::SaturatedFieldInfo>, asm: BSQAssembly::Assembly): Bool {
-        let fieldsPrimitive = fields.reduce<Bool>(true, fn(acc, f) => acc 
-            && (asm.isPrimtitiveType(f.ftype.tkeystr) || asm.enums.has(f.ftype.tkeystr)));
-        if(fields.size() > 4n || !fieldsPrimitive) {
+        let primitiveAndSize = fields.reduce<(|Bool, Nat|)>((|true, 0n|), fn(acc, f) => {
+            let ftype = f.ftype;
+            if(ftype)@<BSQAssembly::EListTypeSignature> {
+                let efields = $ftype.entries.reduce<Bool>(true, fn(nacc, ef) => {
+                    return nacc && (asm.isPrimtitiveType(ef.tkeystr) || asm.enums.has(ef.tkeystr));
+                });
+
+                return acc.0 && efields, acc.1 + $ftype.entries.size();
+            }
+
+            return (acc.0 && (asm.isPrimtitiveType(ftype.tkeystr) || asm.enums.has(ftype.tkeystr))), acc.1 + 1n;
+        });
+
+        if(primitiveAndSize.1 > 4n || !primitiveAndSize.0) {
             return true;
         }
+
         return false;
     }
 
@@ -722,6 +734,14 @@ entity CPPTransformer {
         return CPPAssembly::SwitchStatement { sval, switchflow, stmt.mustExhaustive, optypes };
     }
 
+    method transformVariableAssignmentStatement(stmt: BSQAssembly::VariableAssignmentStatement): CPPAssembly::VariableAssignmentStatement {
+        let name = CPPTransformNameManager::convertIdentifier(stmt.name);
+        let vtype = this.convertTypeSignature(stmt.vtype);
+        let exp = this.transformExpressionToCpp(stmt.exp);
+
+        return CPPAssembly::VariableAssignmentStatement{ name, vtype, exp };
+    }
+
     method transformStatementToCpp(stmt: BSQAssembly::Statement): CPPAssembly::Statement {
         match(stmt)@ {
             BSQAssembly::EmptyStatement => { return CPPAssembly::EmptyStatement{ }; }
@@ -730,7 +750,7 @@ entity CPPTransformer {
             | BSQAssembly::VariableInitializationStatement => { return this.transformVariableInitializationStatementToCpp($stmt); }
             | BSQAssembly::VariableMultiInitializationExplicitStatement => { abort; }
             | BSQAssembly::VariableMultiInitializationImplicitStatement => { abort; }
-            | BSQAssembly::VariableAssignmentStatement => { abort; }
+            | BSQAssembly::VariableAssignmentStatement => { return this.transformVariableAssignmentStatement($stmt); }
             | BSQAssembly::VariableMultiInitializationExplicitStatement => { abort; }
             | BSQAssembly::VariableMultiAssignmentImplicitStatement => { abort; }
             | BSQAssembly::VariableRetypeStatement => { abort; }
@@ -890,47 +910,60 @@ entity CPPTransformer {
     method generateNominalConcreteTypeInfo(bsqtk: BSQAssembly::TypeKey, cpptk: CPPAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat, bsqasm: BSQAssembly::Assembly): 
         (|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|) {
             let bsqant = bsqasm.lookupNominalTypeDeclaration(bsqtk);
-            let tag = if(this.shouldBeRef(bsqant.saturatedBFieldInfo, bsqasm)) then CPPAssembly::Tag#Ref else CPPAssembly::Tag#Value; 
+            let tag = if(this.shouldBeRef(bsqant.saturatedBFieldInfo, bsqasm)) 
+                then CPPAssembly::Tag#Ref 
+                else CPPAssembly::Tag#Value; 
             
             let updated = bsqant.saturatedBFieldInfo
                 .reduce<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(
                     (|CPPAssembly::TypeInfo{ tid, 0n, 0n, '', cpptk, tag }, tinfos|), fn(acc, f) => {
+                        let fieldtype = f.ftype;
+                        
                         var ntinfo: CPPAssembly::TypeInfo;
-                        if(bsqasm.isNominalTypeConcept(f.ftype.tkeystr)) {
+                        if(fieldtype)@<BSQAssembly::EListTypeSignature> {
+                            let esize, eslotsize, eptrmask, ntinfos = $fieldtype.entries
+                                .reduce<(|Nat, Nat, CString, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>((|0n, 0n, acc.0.ptrmask, acc.1|), 
+                                    fn(nacc, entry) => {
+                                        let etinfo = this.generateTypeInfo(entry.tkeystr, nacc.3, tid + 1n, bsqasm);
+                                        return etinfo.0.typesize, etinfo.0.slotsize, CString::concat(nacc.2, etinfo.0.ptrmask), etinfo.1;
+                                    });
+                                ntinfo = acc.0[typesize=acc.0.typesize + esize, slotsize=acc.0.slotsize + eslotsize, ptrmask=eptrmask]; 
+                                return ntinfo, ntinfos;
+                        }
+                        
+                        if(bsqasm.isNominalTypeConcept(fieldtype.tkeystr)) {
                             ntinfo = acc.0[typesize=acc.0.typesize + 8n, slotsize=acc.0.slotsize + 1n, 
                                 ptrmask=CString::concat(acc.0.ptrmask, '1')];
-                            return (|ntinfo, acc.1|);  
+                            return ntinfo, acc.1;  
+                        }
+                        
+                        let ctinfo, ntinfos = this.generateTypeInfo(f.ftype.tkeystr, acc.1, tid + 1n, bsqasm);
+                        if(bsqasm.isPrimtitiveType(f.ftype.tkeystr)) {
+                            ntinfo = acc.0[typesize=acc.0.typesize + ctinfo.typesize, slotsize=acc.0.slotsize + ctinfo.slotsize, 
+                                ptrmask=CString::concat(acc.0.ptrmask, ctinfo.ptrmask)];
                         }
                         else {
-                            let ctinfo, ntinfos = this.generateTypeInfo(f.ftype.tkeystr, acc.1, tid + 1n, bsqasm);
-                            if(bsqasm.isPrimtitiveType(f.ftype.tkeystr)) {
+                            if(ctinfo.tag === CPPAssembly::Tag#Ref) {
+                                ntinfo = acc.0[typesize=acc.0.typesize + 8n, slotsize=acc.0.slotsize + 1n, 
+                                    ptrmask=CString::concat(acc.0.ptrmask, '1')];
+                            }
+                            else {
                                 ntinfo = acc.0[typesize=acc.0.typesize + ctinfo.typesize, slotsize=acc.0.slotsize + ctinfo.slotsize, 
                                     ptrmask=CString::concat(acc.0.ptrmask, ctinfo.ptrmask)];
                             }
-                            else {
-                                if(ctinfo.tag === CPPAssembly::Tag#Ref) {
-                                    ntinfo = acc.0[typesize=acc.0.typesize + 8n, slotsize=acc.0.slotsize + 1n, 
-                                        ptrmask=CString::concat(acc.0.ptrmask, '1')];
-                                }
-                                else {
-                                    ntinfo = acc.0[typesize=acc.0.typesize + ctinfo.typesize, slotsize=acc.0.slotsize + ctinfo.slotsize, 
-                                        ptrmask=CString::concat(acc.0.ptrmask, ctinfo.ptrmask)];
-                                }
-                            }
-                            return (|ntinfo, ntinfos|);
                         }
-                    });
-            return (|updated.0, updated.1.insert(cpptk, updated.0)|);
+                        return ntinfo, ntinfos;
+                     });
+            return updated.0, updated.1.insert(cpptk, updated.0);
     }
 
     %%
-    %% TODO: Handle elist as field special case!
     %% TODO: I think it is also possible for there to be repeated tids currently, so we likely need to return the tid of the tinfo we just generated/fetched
     %%
     recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat, bsqasm: BSQAssembly::Assembly): 
         (|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|) { 
             let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);
-            if(tinfos.has(cpptkey) && tinfos.get(cpptkey).typesize != 5n) {
+            if(tinfos.has(cpptkey) && tinfos.get(cpptkey).typesize != 5n) { %% 5n???? why did i write this
                 return tinfos.get(cpptkey), tinfos;
             }
 

--- a/src/bsqir/asm/assembly.bsq
+++ b/src/bsqir/asm/assembly.bsq
@@ -76,7 +76,6 @@ entity NamespaceFunctionDecl provides FunctionInvokeDecl {
 }
 
 entity TypeFunctionDecl provides FunctionInvokeDecl {
-    field completeikey: InvokeKey; %% For easily grabbing name
 }
 
 datatype MethodDecl provides ExplicitInvokeDecl using {

--- a/src/bsqir/asm/assembly.bsq
+++ b/src/bsqir/asm/assembly.bsq
@@ -76,7 +76,6 @@ entity NamespaceFunctionDecl provides FunctionInvokeDecl {
 }
 
 entity TypeFunctionDecl provides FunctionInvokeDecl {
-    field completens: List<CString>; %% For ns resolution, the fullns field is generally lacking 'Core'
     field completeikey: InvokeKey; %% For easily grabbing name
 }
 

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -1214,8 +1214,7 @@ entity ConstantSimplification {
             body = this.processBodyImpl(typefunc.body),
 
             preconditions = typefunc.preconditions.map<PreConditionDecl>(fn(precond) => this.processPrecondition(precond)),
-            postconditions = typefunc.postconditions.map<PostConditionDecl>(fn(postcond) => this.processPostcondition(postcond)),
-            completeikey = typefunc.completeikey
+            postconditions = typefunc.postconditions.map<PostConditionDecl>(fn(postcond) => this.processPostcondition(postcond))
         }; 
     }
 

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -1215,7 +1215,6 @@ entity ConstantSimplification {
 
             preconditions = typefunc.preconditions.map<PreConditionDecl>(fn(precond) => this.processPrecondition(precond)),
             postconditions = typefunc.postconditions.map<PostConditionDecl>(fn(postcond) => this.processPostcondition(postcond)),
-            completens = typefunc.completens,
             completeikey = typefunc.completeikey
         }; 
     }

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -923,8 +923,7 @@ entity ExplicitifyTransform {
             body = this.processBodyImpl(typefunc.body, VarMapping::createEmpty()),
 
             preconditions = typefunc.preconditions.map<PreConditionDecl>(fn(precond) => this.processPrecondition(precond)),
-            postconditions = typefunc.postconditions.map<PostConditionDecl>(fn(postcond) => this.processPostcondition(postcond)),
-            completeikey = typefunc.completeikey
+            postconditions = typefunc.postconditions.map<PostConditionDecl>(fn(postcond) => this.processPostcondition(postcond))
         };
     }
 

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -924,7 +924,6 @@ entity ExplicitifyTransform {
 
             preconditions = typefunc.preconditions.map<PreConditionDecl>(fn(precond) => this.processPrecondition(precond)),
             postconditions = typefunc.postconditions.map<PostConditionDecl>(fn(postcond) => this.processPostcondition(postcond)),
-            completens = typefunc.completens,
             completeikey = typefunc.completeikey
         };
     }

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -573,10 +573,9 @@ class BSQIREmitter {
 
         // ConstructorStdExpression provides Expression (not AbstractDecl), so we need to emit fullns explicitly
         // Last element is entity name, we cannot properly look this up as fullns is for resolving namespaces
-        let cstrns = exp.ctype.tkeystr.split('::').map(e => `'${e}'`);
-        if(cstrns.length >= 1) {
-            cstrns.pop();
-        }
+        let noname = exp.ctype.tkeystr.split(cdecl.name)[0];
+        let cstrns = noname.split('::').map(e => `'${e}'`);
+
         const fmt_cstrns = `fullns = List<CString>{${cstrns.join(', ')}}`;
 
         const argsinfo = this.emitStdConstructorArgumentInfo(exp.args.args, exp.shuffleinfo);
@@ -1827,20 +1826,10 @@ class BSQIREmitter {
             const ibase = this.emitExplicitInvokeDecl(fdecl, nskey, ikey, fmt);
             this.mapper = omap;
 
-            const nsParts = nskey.split('::');
-            const iParts = ikey.split('::');
-            
-            let i = 0;
-            while(i < nsParts.length && nsParts[i] !== iParts[0]) {
-                i++;
-            }
-            const combinedParts = i == 0 ? iParts : nsParts.slice(0, i).concat(iParts);
+            let template = ikey.split(fdecl.name)[1];
+            let updatedikey = nskey.concat('::', fdecl.name, template);
 
-            const updatedIKey = combinedParts.join("::");
-            const updatedNsKey = `${updatedIKey.split("::").slice(0,-2).join("::")}`; // Does not include type declared in or name
-            let cstrns = updatedNsKey.split('::').map(e => `'${e}'`);
-
-            this.typefuncs.push(`'${ikey}'<BSQAssembly::InvokeKey> => BSQAssembly::TypeFunctionDecl{ ${ibase}, completens=List<CString>{${cstrns}}, completeikey='${updatedIKey}'<BSQAssembly::InvokeKey>}`);
+            this.typefuncs.push(`'${ikey}'<BSQAssembly::InvokeKey> => BSQAssembly::TypeFunctionDecl{ ${ibase}, completeikey='${updatedikey}'<BSQAssembly::InvokeKey>}`);
             this.allfuncs.push(`'${ikey}'<BSQAssembly::InvokeKey>`);        
         }
         else {

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -1826,10 +1826,7 @@ class BSQIREmitter {
             const ibase = this.emitExplicitInvokeDecl(fdecl, nskey, ikey, fmt);
             this.mapper = omap;
 
-            let template = ikey.split(fdecl.name)[1];
-            let updatedikey = nskey.concat('::', fdecl.name, template);
-
-            this.typefuncs.push(`'${ikey}'<BSQAssembly::InvokeKey> => BSQAssembly::TypeFunctionDecl{ ${ibase}, completeikey='${updatedikey}'<BSQAssembly::InvokeKey>}`);
+            this.typefuncs.push(`'${ikey}'<BSQAssembly::InvokeKey> => BSQAssembly::TypeFunctionDecl{ ${ibase} }`);
             this.allfuncs.push(`'${ikey}'<BSQAssembly::InvokeKey>`);        
         }
         else {


### PR DESCRIPTION
Removed the field `completens` and `completeikey` from `TypeFunctionDecl`. I realized that they were completely redundant and it sufficed to just use `fullns` and `ikey` when accessing information in a type func in the cpp transformer/emitter.

You will also see I added `VariableInitilizationStatement` and added support for elists as fields. These were what was left preventing me from emitting nbody. So we are now able to emit nbody but it has quite a few bugs that haven't been fixed, so it cannot run quite yet.