### PR TITLE
Rework Type Info Emission

### DIFF
--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -155,6 +155,9 @@ entity DatatypeTypeDecl provides AbstractConceptTypeDecl {
     field associatedMemberEntityDecls: List<NominalTypeSignature>;
 }
 
+%%
+%% TODO: I believe Tagged can be removed, but needs some thought first
+%%
 enum Tag {
     Value,
     Ref,

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -155,9 +155,7 @@ entity DatatypeTypeDecl provides AbstractConceptTypeDecl {
     field associatedMemberEntityDecls: List<NominalTypeSignature>;
 }
 
-%%
-%% TODO: I believe Tagged can be removed, but needs some thought first
-%%
+%% I believe tagged can be removed
 enum Tag {
     Value,
     Ref,
@@ -172,11 +170,6 @@ entity TypeInfo {
     field ptrmask: CString;
     field typekey: TypeKey;
     field tag: Tag;
-
-    method update(ntypesize: Nat, nslotsize: Nat, nptrmask: CString): TypeInfo {
-        return this[typesize = $typesize + ntypesize, slotsize = $slotsize + nslotsize, 
-            ptrmask = CString::concat($ptrmask, nptrmask)];
-    }
 }
 
 datatype MethodDecl provides AbstractInvokeDecl using {

--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -169,6 +169,11 @@ entity TypeInfo {
     field ptrmask: CString;
     field typekey: TypeKey;
     field tag: Tag;
+
+    method update(ntypesize: Nat, nslotsize: Nat, nptrmask: CString): TypeInfo {
+        return this[typesize = $typesize + ntypesize, slotsize = $slotsize + nslotsize, 
+            ptrmask = CString::concat($ptrmask, nptrmask)];
+    }
 }
 
 datatype MethodDecl provides AbstractInvokeDecl using {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -273,8 +273,10 @@ function generateAccessorForSpecialTypeConstructor(constype: CPPAssembly::TypeSi
 
         let base = String::concat(needsGCAlloc, econstype);
         let ettype = String::concat(removeCppPrefix(emitTypeSignature(ttype, false, ctx)), "Type");
-        if(ctx.asm.isNominalTypeConcept(ttype.tkeystr)) {
-            return String::concat(base, "{ &", ettype, ", ", eexp, " }");
+        
+        %% Since List<T> is just an alias of Tree<T>, we dont need to explicitly emit List<T> constructor
+        if(ctx.asm.lookupNominalTypeDeclaration(constype.tkeystr))<CPPAssembly::ListTypeDecl> {
+            return eexp;
         }
         else {
             return if(eexp === "") then String::concat(base, "{ &", ettype, " }")
@@ -1323,7 +1325,7 @@ function emitThisType(tk: CPPAssembly::TypeKey, ctx: Context): String {
     let resolved_type = emitTypeKey(tk, false, ctx);
 
     if(ctx.asm.typeinfos.get(tk).tag === CPPAssembly::Tag#Ref) {
-        return String::concat("[[maybe_unused]] const ", resolved_type, "*");
+        return String::concat("[[maybe_unused]] ", resolved_type, "*");
     }
     return String::concat("[[maybe_unused]] ", resolved_type);
 }
@@ -1592,18 +1594,12 @@ function emitConstructableTypeDecl(ctd: CPPAssembly::ConstructableTypeDecl, ctx:
     }
 }
 
-%%
-%% We always emit collection type decls as values, so they arent going to be visible to the GC
-%% This is definetly wrong so we will need to modify their type info generation to correctly
-%% reflcet our types
-%%
-
 function emitCollectionTypeDecl(ctd: CPPAssembly::CollectionTypeDecl, ctx: Context, indent: String): String {
     let nctx = ctx.updateCurrentNamespace(ctd.declaredInNS, ctd.fullns);
-    let ttype = emitTypeSignature(ctd.oftype, false, nctx);
+    let ttype = emitSpecialTemplate(emitTypeSignature(ctd.oftype, false, nctx));
     let resolvedttype = if(ttype.startsWithString("__CoreCpp::")) then ttype.removePrefixString("__CoreCpp::") 
         else ttype;
-    return String::concat(indent, "typedef ListOps::Treeᐸ", emitSpecialTemplate(resolvedttype), "ᐳ ", emitTypeKey(ctd.tkey, false, nctx), ";%n;");
+    return String::concat(indent, "typedef ListOps::Treeᐸ", resolvedttype, "ᐳ ", emitTypeKey(ctd.tkey, false, nctx), ";%n;");
 }
 
 function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
@@ -1613,7 +1609,7 @@ function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, 
         | CPPAssembly::DatatypeMemberEntityTypeDecl => { return emitDatatypeMemberEntityDecl($ant, declaredIn, ctx, indent); }
         | CPPAssembly::PrimitiveConceptTypeDecl => { return emitPrimtiveConceptTypeDecl($ant, ctx, indent); }
         | CPPAssembly::ConstructableTypeDecl => { return emitConstructableTypeDecl($ant, ctx, indent); }
-        | CPPAssembly::CollectionTypeDecl => { return emitCollectionTypeDecl($ant, ctx, indent); } %% I think this should jut emit its typeinfo
+        | CPPAssembly::CollectionTypeDecl => { return emitTypeInfo(ctx.asm.typeinfos.get($ant.tkey), some($ant), ctx, indent); } %% Collection typedef done with fwd decls
         | CPPAssembly::DatatypeTypeDecl => { return emitDatatypeTypeDecl($ant, ctx, indent); } 
         | CPPAssembly::EnumTypeDecl => { return emitEnumTypeDecl($ant, ctx, indent); }
     }
@@ -1753,7 +1749,7 @@ function emitNamespaceDeclFwdDecls(nsdecl: CPPAssembly::NamespaceDecl, ctx: Cont
         .filter(pred(tk) => ctx.asm.collections.has(tk))
         .reduce<String>(ant_fwddecls, fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
-            let fwddecl = emitAbstractNominalTypeDecl(ant, tk, ctx, full_indent); 
+            let fwddecl = emitCollectionTypeDecl(ant@<CPPAssembly::CollectionTypeDecl>, ctx, full_indent); 
             return String::concat(acc, fwddecl);
     });
 
@@ -1792,7 +1788,7 @@ function emitNamespaceDeclTypes(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context
 
     %% Ref and Tagged types
     let other = nsdecl.alltypes
-        .filter(pred(tk) => ctx.asm.typeinfos.get(tk).tag !== CPPAssembly::Tag#Value && !ctx.asm.collections.has(tk))
+        .filter(pred(tk) => ctx.asm.typeinfos.get(tk).tag !== CPPAssembly::Tag#Value)
         .reduce<String>(String::concat(values, "//%n;// Ref and Tagged Type Definitions%n;//%n;"), fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let def = emitAbstractNominalTypeDecl(ant, tk, ctx, full_indent);

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -61,8 +61,21 @@ function emitSpecialThis(): String {
     return "𝐭𝐡𝐢𝐬";
 }    
 
-function getAccessor(tk: CPPAssembly::TypeKey, ctx: Context): String {
-    return if(ctx.asm.typeinfos.get(tk).tag === CPPAssembly::Tag#Ref) then ".access_ref" else ".access";
+%% Probably should name this better
+function generateAccess(tk: CPPAssembly::TypeKey, ctx: Context): String {
+    let tag = ctx.asm.typeinfos.tryGet(tk)@some.tag;
+    switch(tag) {
+        CPPAssembly::Tag#Value => { return "."; }
+        | CPPAssembly::Tag#Ref => { return "->"; }
+        | CPPAssembly::Tag#Tagged => { return "."; } 
+    }
+ }
+
+function getAccessor(basetk: CPPAssembly::TypeKey, accessingtk: CPPAssembly::TypeKey, ctx: Context): String {
+    let accessor = generateAccess(basetk, ctx);
+    return if(ctx.asm.typeinfos.get(accessingtk).tag === CPPAssembly::Tag#Ref) 
+        then String::concat(accessor, "access_ref")
+        else String::concat(accessor, "access");
 }
 
 function removeCommonPrefix(name: String, prefix: String): String {
@@ -254,14 +267,18 @@ function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): String {
 function generateAccessorForSpecialTypeConstructor(constype: CPPAssembly::TypeSignature, ttype: CPPAssembly::TypeSignature, 
     eexp: String, ctx: Context): String {
         let econstype = emitTypeSignature(constype, false, ctx);
+        let needsGCAlloc = if(ctx.asm.typeinfos.get(constype.tkeystr).tag === CPPAssembly::Tag#Ref)
+            then "new " %% TODO: Make this not new! It should be a call to our GC allocator
+            else "";
 
+        let base = String::concat(needsGCAlloc, econstype);
+        let ettype = String::concat(removeCppPrefix(emitTypeSignature(ttype, false, ctx)), "Type");
         if(ctx.asm.isNominalTypeConcept(ttype.tkeystr)) {
-            return String::concat(econstype, "{ ", eexp, " }");
+            return String::concat(base, "{ &", ettype, ", ", eexp, " }");
         }
         else {
-            let ettype = String::concat(removeCppPrefix(emitTypeSignature(ttype, false, ctx)), "Type");
-            return if(eexp === "") then String::concat(econstype, "{ &", ettype, " }")
-                else String::concat(econstype, "{ &", ettype, ", ", eexp, " }");
+            return if(eexp === "") then String::concat(base, "{ &", ettype, " }")
+                else String::concat(base, "{ &", ettype, ", ", eexp, " }");
         }
 }
 
@@ -508,12 +525,13 @@ function emitPostfixAccessFromName(op: CPPAssembly::PostfixAccessFromName, ctx: 
     if(ctx.asm.collections.has(op.baseType.tkeystr)) {
         return "";
     }
+
     if(ctx.asm.isNominalTypeConcept(op.baseType.tkeystr)) {
         let e = ctx.asm.lookupNominalTypeDeclaration(op.baseType.tkeystr)@<CPPAssembly::AbstractConceptTypeDecl>;
         let canresolve, offset = canUseDirectFieldAccess(e, op.name, ctx);
         let ftype = emitTypeSignature(op.ftype, true, ctx);
         
-        let accessor = getAccessor(op.ftype.tkeystr, ctx);
+        let accessor = getAccessor(op.ftype.tkeystr, op.ftype.tkeystr, ctx);
         if(canresolve) {
             return String::concat(accessor, "<", ftype, ", ", String::fromCString(offset.toCString()), ">()");
         }
@@ -524,12 +542,9 @@ function emitPostfixAccessFromName(op: CPPAssembly::PostfixAccessFromName, ctx: 
             return String::concat(accessor, "vlookup<", ftype, enumentry, ">(", args); 
         }
     }
-
-    switch(op_tinfo.tag) {
-        CPPAssembly::Tag#Value => { return String::concat(".", ident); }
-        | CPPAssembly::Tag#Ref => { return String::concat("->", ident); }
-        | CPPAssembly::Tag#Tagged => { return String::concat(".", ident); } 
-    }
+    
+    let accessor = generateAccess(op.declaredInType.tkeystr, ctx);
+    return String::concat(accessor, ident);
 }
 
 %% For now we assume this is only used for accessing elist fields
@@ -579,10 +594,11 @@ function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSi
     }
     else {
         %% T-type is concrete case
+        let accessor = String::concat(generateAccess(baseType.tkeystr, ctx), "typeinfo");
         if(ctx.asm.isNominalTypeConcrete(it.ttype.tkeystr)) {
             let ttype = emitTypeSignature(it.ttype, false, ctx);
-            return if(it.isnot) then String::concat(".typeinfo != &", ttype, "Type")
-                else String::concat(".typeinfo == &", ttype, "Type");
+            return if(it.isnot) then String::concat(accessor, " != &", ttype, "Type")
+                else String::concat(accessor, " == &", ttype, "Type");
         }
         else {
             abort; %% Handle case where both are abstract (vtable lookup likely)
@@ -591,15 +607,17 @@ function emitITestType(it: CPPAssembly::ITestType, baseType: CPPAssembly::TypeSi
 }
 
 function emitITestSome(it: CPPAssembly::ITestSome, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
+    let accessor = String::concat(generateAccess(baseType.tkeystr, ctx), "typeinfo");
     return if(it.isnot) 
-        then ".typeinfo == &NoneType" 
-        else ".typeinfo != &NoneType";
+        then String::concat(accessor, " == &NoneType") 
+        else String::concat(accessor, " != &NoneType");
 }
 
 function emitITestNone(it: CPPAssembly::ITestNone, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
+    let accessor = String::concat(generateAccess(baseType.tkeystr, ctx), "typeinfo");
     return if(it.isnot) 
-        then ".typeinfo != &NoneType" 
-        else ".typeinfo == &NoneType";
+        then String::concat(accessor, " != &NoneType") 
+        else String::concat(accessor, " == &NoneType");
 }
 
 function emitITestAsTest(it: CPPAssembly::ITest, baseType: CPPAssembly::TypeSignature, ctx: Context): String {
@@ -616,8 +634,8 @@ function emitITestAsConvertNone(isnot: Bool, fromtype: CPPAssembly::TypeKey, ctx
     if(isnot) {
         return emitITestAsConvertSome(false, fromtype, ctx);
     }
-    else {
-        return (|String::concat(getAccessor(fromtype, ctx), "none()"), "__CoreCpp::None" |);
+    else { %% I dont love this but it works
+        return (|String::concat(getAccessor(fromtype, CPPAssembly::TypeKey::from('__CoreCpp::None'), ctx), "none()"), "__CoreCpp::None" |);
     }
 }
 
@@ -629,7 +647,7 @@ function emitITestAsConvertSome(isnot: Bool, fromtype: CPPAssembly::TypeKey, ctx
             return emitITestAsConvertNone(false, fromtype, ctx);
         }
         else {
-            return (|String::concat(getAccessor($ant.someType.tkeystr, ctx), "<", emitTypeSignature($ant.someType, true, ctx), ">().value"),
+            return (|String::concat(getAccessor(fromtype, $ant.someType.tkeystr, ctx), "<", emitTypeSignature($ant.someType, true, ctx), ">().value"),
                 emitTypeKey($ant.oftype.tkeystr, true, ctx)|);
         }
     }
@@ -643,8 +661,8 @@ function emitITestAsConvertType(isnot: Bool, fromtype: CPPAssembly::TypeKey, tot
     let emittotype = emitTypeKey(ttype, false, ctx);
 
     %% We want to make sure we return the totype as a possible field here(our access method handles ref case)
-    return if(fromtype.value === ttype.value) then (|"", emittotype|) 
-        else (|String::concat(getAccessor(ttype, ctx), "<", emittotype, ">()"), emitTypeKey(ttype, true, ctx)|);
+    return if(fromtype.value === ttype.value) then (|"", emitTypeKey(ttype, true, ctx)|) 
+        else (|String::concat(getAccessor(fromtype, totype, ctx), "<", emittotype, ">()"), emitTypeKey(ttype, true, ctx)|);
 }
 
 function emitITestAsConvert(isnot: Bool, itc: CPPAssembly::ITest, fromtype: CPPAssembly::TypeKey, totype: Option<CPPAssembly::TypeKey>, ctx: Context): (|String, String|) { %% Convert, Emitted type
@@ -867,7 +885,7 @@ function emitNarrowedTypeExpression(exp: CPPAssembly::CoerceNarrowTypeExpression
     let emitexp = emitExpression(exp.exp, ctx);   
 
     if(ctx.asm.isNominalTypeConcept(exp.srctype.tkeystr)) {
-        return String::concat(emitexp, getAccessor(exp.trgttype.tkeystr, ctx), "<", tottype, ">()");
+        return String::concat(emitexp, getAccessor(exp.srctype.tkeystr, exp.trgttype.tkeystr, ctx), "<", tottype, ">()");
     }
     else {
         return emitexp;
@@ -877,7 +895,7 @@ function emitNarrowedTypeExpression(exp: CPPAssembly::CoerceNarrowTypeExpression
 function emitSafeConvertExpression(exp: CPPAssembly::SafeConvertExpression, ctx: Context): String {
     let tottype = emitTypeSignature(exp.trgttype, false, ctx);
 
-   return String::concat(emitExpression(exp.exp, ctx), getAccessor(exp.trgttype.tkeystr, ctx), "<", tottype, ">()");
+   return String::concat(emitExpression(exp.exp, ctx), getAccessor(exp.srctype.tkeystr, exp.trgttype.tkeystr, ctx), "<", tottype, ">()");
 }
 
 function emitCreateDirectExpression(exp: CPPAssembly::CreateDirectExpression, ctx: Context): String {
@@ -1171,7 +1189,8 @@ function emitMatchStatement(stmt: CPPAssembly::MatchStatement, ctx: Context, ind
     let fullfull_indent = String::concat("    ", full_indent);
 
     let expr = emitExpression(stmt.sval, ctx);
-    let sval = String::concat(expr, ".typeinfo == &");
+    let accessor = generateAccess(stmt.sval.etype.tkeystr, ctx);
+    let sval = String::concat(expr, accessor, "typeinfo == &");
     var bind: String;
 
     let matchflow = stmt.matchflow.mapIdx<String>(fn(mf, ii) => {
@@ -1573,6 +1592,12 @@ function emitConstructableTypeDecl(ctd: CPPAssembly::ConstructableTypeDecl, ctx:
     }
 }
 
+%%
+%% We always emit collection type decls as values, so they arent going to be visible to the GC
+%% This is definetly wrong so we will need to modify their type info generation to correctly
+%% reflcet our types
+%%
+
 function emitCollectionTypeDecl(ctd: CPPAssembly::CollectionTypeDecl, ctx: Context, indent: String): String {
     let nctx = ctx.updateCurrentNamespace(ctd.declaredInNS, ctd.fullns);
     let ttype = emitTypeSignature(ctd.oftype, false, nctx);
@@ -1588,7 +1613,7 @@ function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, 
         | CPPAssembly::DatatypeMemberEntityTypeDecl => { return emitDatatypeMemberEntityDecl($ant, declaredIn, ctx, indent); }
         | CPPAssembly::PrimitiveConceptTypeDecl => { return emitPrimtiveConceptTypeDecl($ant, ctx, indent); }
         | CPPAssembly::ConstructableTypeDecl => { return emitConstructableTypeDecl($ant, ctx, indent); }
-        | CPPAssembly::CollectionTypeDecl => { return emitCollectionTypeDecl($ant, ctx, indent); }
+        | CPPAssembly::CollectionTypeDecl => { return emitCollectionTypeDecl($ant, ctx, indent); } %% I think this should jut emit its typeinfo
         | CPPAssembly::DatatypeTypeDecl => { return emitDatatypeTypeDecl($ant, ctx, indent); } 
         | CPPAssembly::EnumTypeDecl => { return emitEnumTypeDecl($ant, ctx, indent); }
     }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -180,11 +180,6 @@ function convertLambdaTypeSignature(lts: CPPAssembly::LambdaTypeSignature, ctx: 
 
 function emitTypeSignature(ts: CPPAssembly::TypeSignature, shouldCheckTag: Bool, ctx: Context): String {
     if(ts)@<CPPAssembly::EListTypeSignature> {
-
-        %%
-        %% We may need to generate a typedef for our tuples instead
-        %%
-
         if(!shouldCheckTag) {
             return emitSpecialTemplate(String::fromCString($ts.tkeystr.value));
         }
@@ -1673,8 +1668,17 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     });
 
     %% Will need nsdecl consts too, this is just ConstMemberDecls 
-    let consts = nsdecl.typeconsts
+    let consts_fwddecls = nsdecl.typeconsts
         .reduce<String>(String::concat(subns, "//%n;// Constants%n;//%n;"), fn(acc, s) => {
+            let tc = ctx.asm.typeconsts.get(s);
+            let def = emitConstMemberForwardDecl(tc, ctx, full_indent);
+            return String::concat(acc, def);
+    });
+
+
+    %% Will need nsdecl consts too, this is just ConstMemberDecls 
+    let consts = nsdecl.typeconsts
+        .reduce<String>(String::concat(consts_fwddecls, "//%n;// Constants%n;//%n;"), fn(acc, s) => {
             let tc = ctx.asm.typeconsts.get(s);
             let def = emitConstMemberDecl(tc, ctx, full_indent);
             return String::concat(acc, def);
@@ -1713,7 +1717,7 @@ function emitNamespaceDeclFwdDecls(nsdecl: CPPAssembly::NamespaceDecl, ctx: Cont
     });
 
     let ant_fwddecls = nsdecl.alltypes
-        .filter(pred(tk) => ctx.asm.typeinfos.get(tk).tag !== CPPAssembly::Tag#Value && !ctx.asm.collections.has(tk))
+        .filter(pred(tk) => !ctx.asm.collections.has(tk) && !ctx.asm.enums.has(tk))
         .reduce<String>("", fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let fwddecl = emitAbstractNominalForwardDeclaration(ant, ctx, full_indent); 
@@ -1728,16 +1732,7 @@ function emitNamespaceDeclFwdDecls(nsdecl: CPPAssembly::NamespaceDecl, ctx: Cont
             return String::concat(acc, fwddecl);
     });
 
-    %% Will need nsdecl consts too, this is just ConstMemberDecls 
-    let types = nsdecl.typeconsts
-        .reduce<String>(String::concat(collections, "//%n;// Constants%n;//%n;"), fn(acc, s) => {
-            let tc = ctx.asm.typeconsts.get(s);
-            let def = emitConstMemberForwardDecl(tc, ctx, full_indent);
-            return String::concat(acc, def);
-    });
-
-
-    return String::concat(subns_fwddecls, types, indent, "}%n;");
+    return String::concat(subns_fwddecls, collections, indent, "}%n;");
 }
 
 %%

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1647,7 +1647,7 @@ recursive function emitFuncForwardDeclarations(nsdecl: CPPAssembly::NamespaceDec
 
     let subns_fwddecls = nsdecl.subns.reduce<String>("", fn(acc, nsname, subns) => {
         let ns = String::concat(indent, "namespace ", String::fromCString(nsname), " {%n;");
-        return String::concat(ns, emitFuncForwardDeclarations[recursive](subns, ctx, full_indent), indent, "}%n;");
+        return String::concat(acc, ns, emitFuncForwardDeclarations[recursive](subns, ctx, full_indent), indent, "}%n;");
     });
 
     %% Emit our method and func fwd decls
@@ -1672,9 +1672,17 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
         return String::concat(acc, emitNamespaceDecl[recursive](decl, ctx, full_indent));
     });
 
+    %% Will need nsdecl consts too, this is just ConstMemberDecls 
+    let consts = nsdecl.typeconsts
+        .reduce<String>(String::concat(subns, "//%n;// Constants%n;//%n;"), fn(acc, s) => {
+            let tc = ctx.asm.typeconsts.get(s);
+            let def = emitConstMemberDecl(tc, ctx, full_indent);
+            return String::concat(acc, def);
+    });
+
     %% Emit methods after all type defintions to prevent types not being fully defined but used
     let methods = nsdecl.alltypes
-        .reduce<String>(subns, fn(acc, tk) => {
+        .reduce<String>(consts, fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let func = emitMethods(ant, tk, ctx, full_indent);
             return String::concat(acc, func);
@@ -1721,10 +1729,11 @@ function emitNamespaceDeclFwdDecls(nsdecl: CPPAssembly::NamespaceDecl, ctx: Cont
     });
 
     %% Will need nsdecl consts too, this is just ConstMemberDecls 
-    let types = nsdecl.typeconsts.reduce<String>(String::concat(collections, "//%n;// Constants%n;//%n;"), fn(acc, s) => {
-        let tc = ctx.asm.typeconsts.get(s);
-        let def = emitConstMemberForwardDecl(tc, ctx, full_indent);
-        return String::concat(acc, def);
+    let types = nsdecl.typeconsts
+        .reduce<String>(String::concat(collections, "//%n;// Constants%n;//%n;"), fn(acc, s) => {
+            let tc = ctx.asm.typeconsts.get(s);
+            let def = emitConstMemberForwardDecl(tc, ctx, full_indent);
+            return String::concat(acc, def);
     });
 
 
@@ -1770,16 +1779,9 @@ function emitNamespaceDeclTypes(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context
             return String::concat(acc, def);
     });
 
-    %% Will need nsdecl consts too, this is just ConstMemberDecls 
-    let types = nsdecl.typeconsts.reduce<String>(String::concat(other, "//%n;// Constants%n;//%n;"), fn(acc, s) => {
-        let tc = ctx.asm.typeconsts.get(s);
-        let def = emitConstMemberDecl(tc, ctx, full_indent);
-        return String::concat(acc, def);
-    });
-
     %% Only support static methods for now
     let method_fwddecls = nsdecl.staticmethods
-        .reduce<String>(String::concat(types, "//%n;// All Methods%n;//%n;"), fn(acc, mtkey) => {
+        .reduce<String>(String::concat(other, "//%n;// All Methods%n;//%n;"), fn(acc, mtkey) => {
             return String::concat(acc, emitMethodForwardDeclaration(ctx.asm.staticmethods.get(mtkey.0), mtkey.1, ctx, full_indent));
     });
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -747,19 +747,10 @@ function emitConstructorEListExpression(exp: CPPAssembly::ConstructorEListExpres
 }
 
 function emitConstructorPrimaryListExpression(exp: CPPAssembly::ConstructorPrimaryListExpression, ctx: Context): String {
-    var nctx: Context;
-    if(exp.elemtype)<CPPAssembly::EListTypeSignature> {
-        nctx = ctx;
-    }
-    else { 
-        let ttype = ctx.asm.lookupNominalTypeDeclaration(exp.elemtype.tkeystr);
-        nctx = ctx.updateCurrentNamespace(ttype.declaredInNS, ttype.fullns);
-    }
-
     let args = emitArguments(exp.args, ctx);
     let ns = "Core::ListOps::"; %% So long as lists impl stays in Core::ListOps this will hold 
 
-    let name = removeCppPrefix(emitTypeSignature(exp.elemtype, true, nctx));
+    let name = emitSpecialTemplate(removeCppPrefix(String::fromCString(exp.elemtype.tkeystr.value)));
     let ofttype = String::concat("ᐸ", name, "ᐳ");
     switch(exp.args.size()) {
         0n => { return String::concat(ns, "s_list_create_empty", ofttype, "()"); }
@@ -911,7 +902,7 @@ function emitAccessStaticFieldExpression(exp: CPPAssembly::AccessStaticFieldExpr
     let typeconst = ctx.asm.typeconsts.get(exp.resolvedname);
     let ns = emitTypeSignature(typeconst.declaredInType, false, ctx);
 
-    return String::concat(ns, "ᘏ", emitIdentifier(typeconst.name));
+    return String::concat(ns, "ᘏ", emitIdentifier(typeconst.name), "()");
 }
 
 function emitBinKeyEqExpression(exp: CPPAssembly::BinKeyEqExpression, opertype: String, ctx: Context): String {
@@ -1315,12 +1306,12 @@ function genLambdaTemplate(templates: String, indent: String): String {
 
 %% Determine whether to emit this param as const this* or this
 function emitThisType(tk: CPPAssembly::TypeKey, ctx: Context): String {
-    let resolved_type = String::concat("[[maybe_unused]] ", emitTypeKey(tk, false, ctx));
+    let resolved_type = emitTypeKey(tk, false, ctx);
 
     if(ctx.asm.typeinfos.get(tk).tag === CPPAssembly::Tag#Ref) {
-        return String::concat("const ", resolved_type, "*");
+        return String::concat("[[maybe_unused]] const ", resolved_type, "*");
     }
-    return resolved_type;
+    return String::concat("[[maybe_unused]] ", resolved_type);
 }
 
 function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
@@ -1329,13 +1320,11 @@ function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::Typ
 
     let name = generateMethodName(m.ikey, declaredIn, nctx);
     let params, templates = emitParameters(m.params, nctx);
-    let rtype = emitTypeSignature(m.resultType, false, ctx);
+    let rtype = emitTypeSignature(m.resultType, true, ctx);
     let this_type = emitThisType(declaredIn, nctx);    
 
     let template = genLambdaTemplate(templates, indent); 
-    let pre = if(rtype === "__CoreCpp::Bool") 
-        then String::concat(template, indent, rtype, " ", name)
-        else String::concat(template, indent, "const ", rtype, " ", name);
+    let pre = String::concat(template, indent, rtype, " ", name);
 
     var params_impl: String;
     if(params === "") {
@@ -1463,8 +1452,7 @@ function emitMethodForwardDeclaration(m: CPPAssembly::MethodDecl, declaredIn: CP
         let params, templates = emitParameters(m.params, nctx);
         let template = genLambdaTemplate(templates, indent);
 
-        let first = if(rtype !== "__CoreCpp::Bool") then String::concat(indent, "const ", rtype, " ", name, "(")
-            else String::concat(indent, rtype, " ", name, "(");
+        let first = String::concat(indent, rtype, " ", name, "(");
 
         if(params === "") {
             let tmp = String::concat(template, first);
@@ -1595,7 +1583,7 @@ function emitCollectionTypeDecl(ctd: CPPAssembly::CollectionTypeDecl, ctx: Conte
     let ttype = emitTypeSignature(ctd.oftype, false, nctx);
     let resolvedttype = if(ttype.startsWithString("__CoreCpp::")) then ttype.removePrefixString("__CoreCpp::") 
         else ttype;
-    return String::concat(indent, "typedef ListOps::Treeᐸ", resolvedttype, "ᐳ ", emitTypeKey(ctd.tkey, false, nctx), ";%n;");
+    return String::concat(indent, "typedef ListOps::Treeᐸ", emitSpecialTemplate(resolvedttype), "ᐳ ", emitTypeKey(ctd.tkey, false, nctx), ";%n;");
 }
 
 function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
@@ -1611,23 +1599,29 @@ function emitAbstractNominalTypeDecl(ant: CPPAssembly::AbstractNominalTypeDecl, 
     }
 }
 
-%%
-%% TODO: We should move the definition to the source file. Defining them in the header is a bad idea.
-%% We will also need to be careful about the order these emit in as its possible one const could
-%% contain in its definition another const
-%%
+function getConstMemberBase(cmd: CPPAssembly::ConstMemberDecl, ctx: Context): String, String {    
+    let rtype = emitTypeSignature(cmd.declaredType, true, ctx);
+
+    return rtype, emitSpecialTemplate(emitResolvedNamespace(ctx.fullns_list, cmd.resolvedname)); 
+}
+
+%% These two are good cantidates for force inline
 function emitConstMemberDecl(cmd: CPPAssembly::ConstMemberDecl, ctx: Context, indent: String): String {
     let nctx = ctx.updateCurrentNamespace(cmd.declaredInNS, cmd.fullns);
     
     let exp = emitExpression(cmd.value, nctx);
-    let rtype = emitTypeSignature(cmd.declaredType, true, nctx);
-    let name = emitTypeSignature(cmd.declaredType, false, nctx);
+    let rtype, fullname = getConstMemberBase(cmd, nctx);
 
-    %% Not 100% about removing previx, fixes bug for emitting "one" and "zero" constmember decls
-    let fullname = removeCppPrefix(String::concat(name, "ᘏ", emitIdentifier(cmd.name)));
+    let pre = String::concat(indent, "inline ", rtype, " ", fullname, "() { return ");
+    return String::concat(pre, exp, "; }%n;");
+}
 
-    let pre = String::concat(indent, rtype, " ", fullname, " = ");
-    return String::concat(pre, exp, ";%n;");
+function emitConstMemberForwardDecl(cmd: CPPAssembly::ConstMemberDecl, ctx: Context, indent: String): String {
+    let nctx = ctx.updateCurrentNamespace(cmd.declaredInNS, cmd.fullns);
+    
+    let rtype, fullname = getConstMemberBase(cmd, nctx);   
+    
+    return String::concat(indent, "inline ", rtype, " ", fullname, "();%n;");
 }
 
 function emitSomeTypeDecl(std: CPPAssembly::SomeTypeDecl, ctx: Context, indent: String): String {
@@ -1726,7 +1720,15 @@ function emitNamespaceDeclFwdDecls(nsdecl: CPPAssembly::NamespaceDecl, ctx: Cont
             return String::concat(acc, fwddecl);
     });
 
-    return String::concat(subns_fwddecls, collections, indent, "}%n;");
+    %% Will need nsdecl consts too, this is just ConstMemberDecls 
+    let types = nsdecl.typeconsts.reduce<String>(String::concat(collections, "//%n;// Constants%n;//%n;"), fn(acc, s) => {
+        let tc = ctx.asm.typeconsts.get(s);
+        let def = emitConstMemberForwardDecl(tc, ctx, full_indent);
+        return String::concat(acc, def);
+    });
+
+
+    return String::concat(subns_fwddecls, types, indent, "}%n;");
 }
 
 %%
@@ -1768,7 +1770,7 @@ function emitNamespaceDeclTypes(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context
             return String::concat(acc, def);
     });
 
-    %% Will ns nsdecl consts too, this is just ConstMemberDecls 
+    %% Will need nsdecl consts too, this is just ConstMemberDecls 
     let types = nsdecl.typeconsts.reduce<String>(String::concat(other, "//%n;// Constants%n;//%n;"), fn(acc, s) => {
         let tc = ctx.asm.typeconsts.get(s);
         let def = emitConstMemberDecl(tc, ctx, full_indent);

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1713,7 +1713,7 @@ function emitNamespaceDeclFwdDecls(nsdecl: CPPAssembly::NamespaceDecl, ctx: Cont
     });
 
     let ant_fwddecls = nsdecl.alltypes
-        .filter(pred(tk) => ctx.asm.typeinfos.get(tk).tag !== CPPAssembly::Tag#Value)
+        .filter(pred(tk) => ctx.asm.typeinfos.get(tk).tag !== CPPAssembly::Tag#Value && !ctx.asm.collections.has(tk))
         .reduce<String>("", fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let fwddecl = emitAbstractNominalForwardDeclaration(ant, ctx, full_indent); 
@@ -1752,7 +1752,7 @@ function emitNamespaceDeclTypes(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context
             return String::concat(acc, emitNamespaceDeclTypes[recursive](decl, ctx, full_indent));
     });
 
-    %% Emit enums and collections first
+    %% Emit enums first
     let enums = nsdecl.alltypes
         .filter(pred(tk) => ctx.asm.enums.has(tk))
         .reduce<String>(String::concat(subns, "//%n;// Value Type Definitions%n;//%n;"), fn(acc, tk) => {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -973,6 +973,8 @@ entity CPPTransformer {
                     return acc.0.update(e.typesize, e.slotsize, e.ptrmask), tic;
                 }
 
+                %% Not right. We should always inline concepts so that the GC knows to explore its
+                %% typeinfo from the '2' ptrmask. The issue we are facing lies elsewere I believe
                 if(this.bsqasm.isNominalTypeConcept(ftype.tkeystr)) {
                     return acc.0.update(8n, 1n, '1'), acc.1;
                 }
@@ -1022,42 +1024,16 @@ entity CPPTransformer {
                 elif(this.bsqasm.constructables.has(typekey)) { 
                     if(ant)@<BSQAssembly::SomeTypeDecl> {
                         let oftypeinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, tic);
-                        let cppoftkey = CPPTransformNameManager::convertTypeKey($ant.oftype.tkeystr);
-                        
-                        %% We should move this logic into a method (maybe "generateTypeTag()?")
-                        var oftypetag: CPPAssembly::Tag;
-                        if($ant.oftype)<BSQAssembly::EListTypeSignature> {
-                            oftypetag = if(this.shouldBeRef(ant.saturatedBFieldInfo, this.bsqasm)) 
-                                then CPPAssembly::Tag#Ref 
-                                else CPPAssembly::Tag#Value;
-                        }
-                        else {
-                            oftypetag = ntic.tinfos.get(cppoftkey).tag;
-                        }
-
-                        let sometinfo = CPPAssembly::TypeInfo{ ntic.tid, oftypeinfo.typesize, oftypeinfo.slotsize, oftypeinfo.ptrmask, cpptkey, oftypetag }; 
+                        let sometinfo = CPPAssembly::TypeInfo{ ntic.tid, oftypeinfo.typesize, oftypeinfo.slotsize, oftypeinfo.ptrmask, cpptkey, CPPAssembly::Tag#Value }; 
 
                         return sometinfo, ntic.update(cpptkey, sometinfo);
                     }
                     abort;
                 }
                 elif(this.bsqasm.collections.has(typekey)) { 
-                    %% Just the underlying datastructure
                     if(ant)@<BSQAssembly::ListTypeDecl> {
                         let oftypeinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, tic);
-                        let cppoftkey = CPPTransformNameManager::convertTypeKey($ant.oftype.tkeystr);
-
-                        var oftypetag: CPPAssembly::Tag;
-                        if($ant.oftype)<BSQAssembly::EListTypeSignature> {
-                            oftypetag = if(this.shouldBeRef(ant.saturatedBFieldInfo, this.bsqasm)) 
-                                then CPPAssembly::Tag#Ref 
-                                else CPPAssembly::Tag#Value;
-                        }
-                        else {
-                            oftypetag = ntic.tinfos.get(cppoftkey).tag;
-                        }
-                        
-                        let listinfo = CPPAssembly::TypeInfo{ ntic.tid, oftypeinfo.typesize, oftypeinfo.slotsize, oftypeinfo.ptrmask, cpptkey, oftypetag };
+                        let listinfo = CPPAssembly::TypeInfo{ ntic.tid, oftypeinfo.typesize, oftypeinfo.slotsize, oftypeinfo.ptrmask, cpptkey, CPPAssembly::Tag#Value };
 
                         return listinfo, ntic.update(cpptkey, listinfo);
                     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -911,11 +911,7 @@ entity CPPTransformer {
     recursive method findEListSize(elist: BSQAssembly::EListTypeSignature, tic: TypeInfoContext): EListInfo, TypeInfoContext {
         return elist.entries
             .reduce<(|EListInfo, TypeInfoContext|)>((|EListInfo{ 0n, 0n, '' }, tic|), fn(acc, e) => {
-                if(e)@<BSQAssembly::EListTypeSignature> {
-                    return this.findEListSize[recursive]($e, acc.1);
-                }
-
-                let tinfo, ntic = this.generateTypeInfo(e.tkeystr, acc.1);
+                let tinfo, ntic = this.generateTypeInfo(none, some(e), acc.1);
                 return acc.0.update(tinfo), ntic;
             });
     }
@@ -975,7 +971,8 @@ entity CPPTransformer {
                         return acc.0.update(8n, 1n, '1'), acc.1;
                     }
 
-                    let ctinfo, ntic = this.generateTypeInfo(ftype.tkeystr, acc.1);
+                    %% We may be able to handle more cases by just calling gentypeinfo
+                    let ctinfo, ntic = this.generateTypeInfo(some(ftype.tkeystr), none, acc.1);
                     if(ctinfo.tag === CPPAssembly::Tag#Ref) {
                         return acc.0.update(8n, 1n, '1'), ntic;
                     }
@@ -984,7 +981,27 @@ entity CPPTransformer {
             });
     }
 
-    recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tic: TypeInfoContext): CPPAssembly::TypeInfo, TypeInfoContext { 
+    recursive method generateTypeInfo(tkey: Option<BSQAssembly::TypeKey>, tsig: Option<BSQAssembly::TypeSignature>, tic: TypeInfoContext): CPPAssembly::TypeInfo, TypeInfoContext { 
+            
+            %%
+            %% This ALMOST works but the flaw is I have no way to handle returning any type info here.
+            %% This will likely take a bit more thoghuth to get just right but without the gc wont
+            %% work with elists...
+            %%
+
+            var typekey: BSQAssembly::TypeKey;
+            if(tsig)@some {
+                let ttsig = $tsig;
+                if(ttsig)@<BSQAssembly::EListTypeSignature> {
+                    return $ttsig.tkeystr, $ttsig.entries
+                        .reduce<TypeInfoContext>(tic, fn(acc, e) => this.generateTypeInfo[recursive](none, some(e), acc));
+                }
+                typekey = ttsig.tkeystr;
+            }
+            else {
+                typekey = tkey@some;
+            }
+            
             let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);
             if(tic.tinfos.has(cpptkey)) {
                 return tic.tinfos.get(cpptkey), tic;
@@ -1013,17 +1030,22 @@ entity CPPTransformer {
                 }
                 elif(this.bsqasm.constructables.has(typekey)) { 
                     if(ant)@<BSQAssembly::SomeTypeDecl> { %% Only support Some<T> for now (are always value too)
-                        let someinfo, ntic = this.generateTypeInfo[recursive]($ant.oftype.tkeystr, tic);
-                        let named_someinfo = CPPAssembly::TypeInfo{ ntic.tid, someinfo.typesize, someinfo.slotsize, someinfo.ptrmask, cpptkey, CPPAssembly::Tag#Value }; 
+                        let someinfo, ntic = this.generateTypeInfo[recursive](none, some($ant.oftype), tic);
+                        let named_someinfo = someinfo[id = ntic.tid, typekey = cpptkey, tag = CPPAssembly::Tag#Value ]; 
 
                         return named_someinfo, ntic.update(cpptkey, named_someinfo);
                     }
                     abort;
                 }
                 elif(this.bsqasm.collections.has(typekey)) { 
-                    %% I believe we dont need to emit typeinfo explicitly since these are just a wrapper around a data structure
-                    let tmplisttinfo = CPPAssembly::TypeInfo{ tic.tid, 0n, 0n, '', cpptkey, CPPAssembly::Tag#Value };
-                    return tmplisttinfo, tic.update(cpptkey, tmplisttinfo);
+                    %% Just the underlying datastructure
+                    if(ant)@<BSQAssembly::ListTypeDecl> {
+                        let ttype, ntic = this.generateTypeInfo[recursive](none, some($ant.oftype.tkeystr), tic);
+                        let listtype = ttype[id = ntic.tid, typekey = cpptkey];
+                        
+                        return listtype, ntic.update(cpptkey, listtype);
+                    }
+                    abort;
                 }
                 elif(this.bsqasm.stringoftypedecls.has(typekey)) {
                     abort;
@@ -1047,7 +1069,7 @@ entity CPPTransformer {
                 }
                 elif(this.bsqasm.pconcepts.has(typekey)) {
                     if(ant)@<BSQAssembly::OptionTypeDecl> {
-                        let pcinfo, ntic = this.generateTypeInfo[recursive]($ant.someType.tkeystr, tic);
+                        let pcinfo, ntic = this.generateTypeInfo[recursive](none, some($ant.someType), tic);
                         let named_pcinfo = CPPAssembly::TypeInfo{ ntic.tid, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, 
                             CString::concat('2', pcinfo.ptrmask), cpptkey, CPPAssembly::Tag#Tagged };
 
@@ -1449,12 +1471,12 @@ entity CPPTransformer {
         let generated_typeinfos_concrete = bsqasm.allconcretetypes
             .reduce<TypeInfoContext>( 
                 TypeInfoContext{ Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>{}, 1n }, fn(acc, tkey) => {
-                    return transformer.generateTypeInfo(tkey, acc).1;
+                    return transformer.generateTypeInfo(some(tkey), none, acc).1;
             });
 
         let generated_typeinfos_abstract = bsqasm.allabstracttypes
             .reduce<TypeInfoContext>( generated_typeinfos_concrete, fn(acc, tkey) => {
-                return transformer.generateTypeInfo(tkey, acc).1;
+                return transformer.generateTypeInfo(some(tkey), none, acc).1;
         });
 
         return CPPAssembly::Assembly {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -916,7 +916,7 @@ entity CPPTransformer {
             if(subant)@<BSQAssembly::AbstractEntityTypeDecl> {
                 let finfo, ntic = this.generateFieldInfo(none, some(subtk), acc.2);
 
-                %% If already a ref keep it like so
+                %% If already a ref do not update
                 var tag = acc.1;
                 if(this.shouldBeRef($subant.saturatedBFieldInfo, this.bsqasm)) {
                     tag = CPPAssembly::Tag#Ref;
@@ -940,6 +940,7 @@ entity CPPTransformer {
                     if(f)@<BSQAssembly::EListTypeSignature> {
                         return this.generateEListInfo[recursive]($f, acc.1);
                     }
+
                     var finfo, ntic = this.generateFieldInfo(some(f), none, acc.1);
                     let tag = if(this.shouldBeRef(this.bsqasm.lookupNominalTypeDeclaration(f.tkeystr).saturatedBFieldInfo, this.bsqasm)) 
                         then CPPAssembly::Tag#Ref 
@@ -1072,7 +1073,9 @@ entity CPPTransformer {
                     if(ant)@<BSQAssembly::OptionTypeDecl> {
                         let pcinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, tic);
                         let ptrmask = CPPTransformNameManager::repeatCString('0', pcinfo.slotsize, '2');
-                        let ntag = if(pcinfo.slotsize > reftypeThreshold) then CPPAssembly::Tag#Ref else CPPAssembly::Tag#Value;
+                        let ntag = if(pcinfo.slotsize > reftypeThreshold || pcinfo.ptrmask.containsString('1')) 
+                            then CPPAssembly::Tag#Ref 
+                            else CPPAssembly::Tag#Value;
                         let pctinfo = CPPAssembly::TypeInfo{ ntic.tid, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, ptrmask, cpptkey, ntag };
 
                         return pctinfo, ntic.update(cpptkey, pctinfo);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -129,15 +129,13 @@ entity TypeInfoContext {
     }
 }
 
-%% Not used as typeinfo, stores info about entire elist to make typegen for elist as field case easier
-entity EListInfo {
+entity FieldInfo {
     field typesize: Nat;
     field slotsize: Nat;
     field ptrmask: CString;
 
-    method update(tinfo: CPPAssembly::TypeInfo): EListInfo {
-        return this[typesize = $typesize + tinfo.typesize, slotsize = $slotsize + tinfo.slotsize, 
-            ptrmask = CString::concat($ptrmask, tinfo.ptrmask)];
+    method update(typesize: Nat, slotsize: Nat, ptrmask: CString): FieldInfo {
+        return this[typesize = $typesize + typesize, slotsize = $slotsize + slotsize, ptrmask = CString::concat($ptrmask, ptrmask)];
     }
 }
 
@@ -908,36 +906,16 @@ entity CPPTransformer {
         });
     }
 
-    recursive method findEListSize(elist: BSQAssembly::EListTypeSignature, tic: TypeInfoContext): EListInfo, TypeInfoContext {
-        return elist.entries
-            .reduce<(|EListInfo, TypeInfoContext|)>((|EListInfo{ 0n, 0n, '' }, tic|), fn(acc, e) => {
-                let tinfo, ntic = this.generateTypeInfo(none, some(e), acc.1);
-                return acc.0.update(tinfo), ntic;
-            });
-    }
-
     %% Explore all subtypes and find largest possible field slot size (generating subtype tinfo when necessary)
     method findLargestSubtype(cur: BSQAssembly::AbstractConceptTypeDecl, tic: TypeInfoContext): Nat, TypeInfoContext {
         return cur.subtypes.reduce<(|Nat, TypeInfoContext|)>((|0n, tic|), fn(acc, subtk) => {              
             let subant = this.bsqasm.lookupNominalTypeDeclaration(subtk);
 
             if(subant)@<BSQAssembly::AbstractEntityTypeDecl> {
-                let field_size, ntic = $subant.saturatedBFieldInfo
-                    .reduce<(|Nat, TypeInfoContext|)>((|0n, acc.1|), fn(nacc, f) => { 
-                        let ftype = f.ftype;
-                        let cpptk = CPPTransformNameManager::convertTypeKey(ftype.tkeystr);
-                        
-                        if(ftype)@<BSQAssembly::EListTypeSignature> {
-                            let elistsize, elisttic = this.findEListSize($ftype, nacc.1);
-                            return nacc.0 + elistsize.slotsize, elisttic;
-                        }
-                        
-                        let finfo, ftic = this.generateNominalConcreteTypeInfo(ftype.tkeystr, cpptk, nacc.1);
-                        return nacc.0 + finfo.slotsize, ftic;
-                    });
+                let finfo, ntic = this.generateFieldInfo(none, some(subtk), acc.1);
 
-                if(field_size > acc.0) {
-                    return field_size, ntic;
+                if(finfo.slotsize > acc.0) {
+                    return finfo.slotsize, ntic;
                 }
                 return acc.0, ntic;
             }
@@ -946,68 +924,73 @@ entity CPPTransformer {
         });
     }
 
-    method generateNominalConcreteTypeInfo(bsqtk: BSQAssembly::TypeKey, cpptk: CPPAssembly::TypeKey, tic: TypeInfoContext): CPPAssembly::TypeInfo, TypeInfoContext {
-        if(tic.tinfos.has(cpptk)) {
-            return tic.tinfos.get(cpptk), tic;
-        } 
-        
-        let bsqant = this.bsqasm.lookupNominalTypeDeclaration(bsqtk);
-        let tag = if(this.shouldBeRef(bsqant.saturatedBFieldInfo, this.bsqasm)) 
-            then CPPAssembly::Tag#Ref 
-            else CPPAssembly::Tag#Value; 
-        
-        return bsqant.saturatedBFieldInfo
-            .reduce<(|CPPAssembly::TypeInfo, TypeInfoContext|)>(
-                (|CPPAssembly::TypeInfo{ tic.tid, 0n, 0n, '', cpptk, tag }, tic|), fn(acc, f) => {
-                    let ftype = f.ftype;
-                    
-                    %% Always check for elist first, isNominalTypeConcept fails on elist tkey
-                    if(ftype)@<BSQAssembly::EListTypeSignature> {
-                        let finfo, ntic = this.findEListSize($ftype, acc.1);
-                        return acc.0.update(finfo.typesize, finfo.slotsize, finfo.ptrmask), ntic;
+    recursive method generateEListInfo(elist: BSQAssembly::EListTypeSignature, tic: TypeInfoContext): FieldInfo, TypeInfoContext {
+        return elist.entries
+            .reduce<(|FieldInfo, TypeInfoContext|)>((|FieldInfo{ 0n, 0n, '' }, tic|), 
+                fn(acc, f) => {
+                    %% If elist contains elist we should explore its entries BEFORE trying to generate field info
+                    if(f)@<BSQAssembly::EListTypeSignature> {
+                        return this.generateEListInfo[recursive]($f, acc.1);
+                    }
+                    var finfo, ntic = this.generateFieldInfo(some(f), none, acc.1);
+                    let tag = if(this.shouldBeRef(this.bsqasm.lookupNominalTypeDeclaration(f.tkeystr).saturatedBFieldInfo, this.bsqasm)) 
+                        then CPPAssembly::Tag#Ref 
+                        else CPPAssembly::Tag#Value;
+                    if(tag === CPPAssembly::Tag#Ref) {
+                        finfo = FieldInfo{ 8n, 1n, '1' };
                     }
 
-                    if(this.bsqasm.isNominalTypeConcept(ftype.tkeystr)) {
-                        return acc.0.update(8n, 1n, '1'), acc.1;
-                    }
+                    return acc.0.update(finfo.typesize, finfo.slotsize, finfo.ptrmask), ntic;
+                }
+            );
+    }
 
-                    %% We may be able to handle more cases by just calling gentypeinfo
-                    let ctinfo, ntic = this.generateTypeInfo(some(ftype.tkeystr), none, acc.1);
-                    if(ctinfo.tag === CPPAssembly::Tag#Ref) {
-                        return acc.0.update(8n, 1n, '1'), ntic;
-                    }
-                    
-                    return acc.0.update(ctinfo.typesize, ctinfo.slotsize, ctinfo.ptrmask), ntic;
+    recursive method generateFieldInfo(tsig: Option<BSQAssembly::TypeSignature>, tkey: Option<BSQAssembly::TypeKey>, tic: TypeInfoContext): FieldInfo, TypeInfoContext {
+        var resolvedtkey: BSQAssembly::TypeKey;
+        if(tsig)@some { 
+            let sometsig = $tsig;
+            if(sometsig)@<BSQAssembly::EListTypeSignature> { %% Always check for elist first, isNominalTypeConcept/Concrete fails on elist tkey
+                return this.generateEListInfo($sometsig, tic);
+            }
+            resolvedtkey = sometsig.tkeystr;
+        }
+        else {
+            resolvedtkey = tkey@some;
+        }
+
+        %% Primitives/Enums don't have saturated fields so return early
+        if(this.bsqasm.isPrimtitiveType(resolvedtkey) || this.bsqasm.enums.has(resolvedtkey)) {
+            let ptinfo, ntic = this.generateTypeInfo(resolvedtkey, tic);
+            return FieldInfo{ ptinfo.typesize, ptinfo.slotsize, ptinfo.ptrmask }, ntic;
+        }
+
+        let ant = this.bsqasm.lookupNominalTypeDeclaration(resolvedtkey);
+        return ant.saturatedBFieldInfo
+            .reduce<(|FieldInfo, TypeInfoContext|)>((|FieldInfo{ 0n, 0n, '' }, tic|), fn(acc, finfo) => {
+                let ftype = finfo.ftype;
+                if(ftype)@<BSQAssembly::EListTypeSignature> {
+                    let e, tic = this.generateEListInfo($ftype, acc.1);
+                    return acc.0.update(e.typesize, e.slotsize, e.ptrmask), tic;
+                }
+
+                if(this.bsqasm.isNominalTypeConcept(ftype.tkeystr)) {
+                    return acc.0.update(8n, 1n, '1'), acc.1;
+                }
+
+                let tinfo, ntic = this.generateTypeInfo(ftype.tkeystr, acc.1);
+                if(tinfo.tag === CPPAssembly::Tag#Ref) {
+                    return acc.0.update(8n, 1n, '1'), ntic;
+                }
+                return acc.0.update(tinfo.typesize, tinfo.slotsize, tinfo.ptrmask), ntic;
             });
     }
 
-    recursive method generateTypeInfo(tkey: Option<BSQAssembly::TypeKey>, tsig: Option<BSQAssembly::TypeSignature>, tic: TypeInfoContext): CPPAssembly::TypeInfo, TypeInfoContext { 
-            
-            %%
-            %% This ALMOST works but the flaw is I have no way to handle returning any type info here.
-            %% This will likely take a bit more thoghuth to get just right but without the gc wont
-            %% work with elists...
-            %%
-
-            var typekey: BSQAssembly::TypeKey;
-            if(tsig)@some {
-                let ttsig = $tsig;
-                if(ttsig)@<BSQAssembly::EListTypeSignature> {
-                    return $ttsig.tkeystr, $ttsig.entries
-                        .reduce<TypeInfoContext>(tic, fn(acc, e) => this.generateTypeInfo[recursive](none, some(e), acc));
-                }
-                typekey = ttsig.tkeystr;
-            }
-            else {
-                typekey = tkey@some;
-            }
-            
+    recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tic: TypeInfoContext): CPPAssembly::TypeInfo, TypeInfoContext { 
             let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);
             if(tic.tinfos.has(cpptkey)) {
                 return tic.tinfos.get(cpptkey), tic;
             }
-
-            let ant = this.bsqasm.lookupNominalTypeDeclaration(typekey);
+            
             if(this.bsqasm.isPrimtitiveType(typekey)) {
                 var matchedType: CPPAssembly::TypeInfo;
                 switch(typekey) {
@@ -1023,27 +1006,60 @@ entity CPPTransformer {
 
                 return matchedType, tic.update(cpptkey, matchedType);
             }
-            elif(this.bsqasm.isNominalTypeConcrete(typekey)) {            
+             
+            let ant = this.bsqasm.lookupNominalTypeDeclaration(typekey);
+            let tag = if(this.shouldBeRef(ant.saturatedBFieldInfo, this.bsqasm)) 
+                then CPPAssembly::Tag#Ref 
+                else CPPAssembly::Tag#Value;
+
+            if(this.bsqasm.isNominalTypeConcrete(typekey)) {            
                 if(this.bsqasm.entities.has(typekey) || this.bsqasm.datamembers.has(typekey)) {
-                    let e, ntic = this.generateNominalConcreteTypeInfo(typekey, cpptkey, tic);
-                    return e, ntic.update(cpptkey, e);
+                    let finfo, ntic = this.generateFieldInfo(none, some(typekey), tic);
+                    var einfo = CPPAssembly::TypeInfo{ ntic.tid, finfo.typesize, finfo.slotsize, finfo.ptrmask, cpptkey, tag };
+                    
+                    return einfo, ntic.update(cpptkey, einfo);
                 }
                 elif(this.bsqasm.constructables.has(typekey)) { 
-                    if(ant)@<BSQAssembly::SomeTypeDecl> { %% Only support Some<T> for now (are always value too)
-                        let someinfo, ntic = this.generateTypeInfo[recursive](none, some($ant.oftype), tic);
-                        let named_someinfo = someinfo[id = ntic.tid, typekey = cpptkey, tag = CPPAssembly::Tag#Value ]; 
+                    if(ant)@<BSQAssembly::SomeTypeDecl> {
+                        let oftypeinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, tic);
+                        let cppoftkey = CPPTransformNameManager::convertTypeKey($ant.oftype.tkeystr);
+                        
+                        %% We should move this logic into a method (maybe "generateTypeTag()?")
+                        var oftypetag: CPPAssembly::Tag;
+                        if($ant.oftype)<BSQAssembly::EListTypeSignature> {
+                            oftypetag = if(this.shouldBeRef(ant.saturatedBFieldInfo, this.bsqasm)) 
+                                then CPPAssembly::Tag#Ref 
+                                else CPPAssembly::Tag#Value;
+                        }
+                        else {
+                            oftypetag = ntic.tinfos.get(cppoftkey).tag;
+                        }
 
-                        return named_someinfo, ntic.update(cpptkey, named_someinfo);
+                        let sometinfo = CPPAssembly::TypeInfo{ ntic.tid, oftypeinfo.typesize, oftypeinfo.slotsize, oftypeinfo.ptrmask, cpptkey, oftypetag }; 
+
+                        return sometinfo, ntic.update(cpptkey, sometinfo);
                     }
                     abort;
                 }
                 elif(this.bsqasm.collections.has(typekey)) { 
                     %% Just the underlying datastructure
                     if(ant)@<BSQAssembly::ListTypeDecl> {
-                        let ttype, ntic = this.generateTypeInfo[recursive](none, some($ant.oftype.tkeystr), tic);
-                        let listtype = ttype[id = ntic.tid, typekey = cpptkey];
+                        let oftypeinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, tic);
+                        let cppoftkey = CPPTransformNameManager::convertTypeKey($ant.oftype.tkeystr);
+
+                        var oftypetag: CPPAssembly::Tag;
+                        if($ant.oftype)<BSQAssembly::EListTypeSignature> {
+                            oftypetag = if(this.shouldBeRef(ant.saturatedBFieldInfo, this.bsqasm)) 
+                                then CPPAssembly::Tag#Ref 
+                                else CPPAssembly::Tag#Value;
+                        }
+                        else {
+                            oftypetag = ntic.tinfos.get(cppoftkey).tag;
+                        }
                         
-                        return listtype, ntic.update(cpptkey, listtype);
+                        let listinfo = CPPAssembly::TypeInfo{ ntic.tid, oftypeinfo.typesize, oftypeinfo.slotsize, oftypeinfo.ptrmask, cpptkey, oftypetag };
+
+                        return listinfo, ntic.update(cpptkey, listinfo);
                     }
                     abort;
                 }
@@ -1061,24 +1077,22 @@ entity CPPTransformer {
             elif(this.bsqasm.isNominalTypeConcept(typekey)) {
                 if(this.bsqasm.concepts.has(typekey) || this.bsqasm.datatypes.has(typekey)) {
                     let mfc, ntic = this.findLargestSubtype(ant@<BSQAssembly::AbstractConceptTypeDecl>, tic);
-                    let ptr_mask = CPPTransformNameManager::repeatCString('0', mfc, '2');
-                    let matchedType = CPPAssembly::TypeInfo{ ntic.tid, 8n + (mfc * 8n), mfc + 1n, ptr_mask, cpptkey, CPPAssembly::Tag#Tagged }; 
+                    let ptrmask = CPPTransformNameManager::repeatCString('0', mfc, '2');
+                    let matchedType = CPPAssembly::TypeInfo{ ntic.tid, 8n + (mfc * 8n), mfc + 1n, ptrmask, cpptkey, CPPAssembly::Tag#Tagged }; 
                     
                     return matchedType, ntic.update(cpptkey, matchedType);
 
                 }
                 elif(this.bsqasm.pconcepts.has(typekey)) {
                     if(ant)@<BSQAssembly::OptionTypeDecl> {
-                        let pcinfo, ntic = this.generateTypeInfo[recursive](none, some($ant.someType), tic);
-                        let named_pcinfo = CPPAssembly::TypeInfo{ ntic.tid, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, 
-                            CString::concat('2', pcinfo.ptrmask), cpptkey, CPPAssembly::Tag#Tagged };
+                        let pcinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, tic);
+                        let ptrmask = CPPTransformNameManager::repeatCString('0', pcinfo.slotsize, '2');
+                        let pctinfo = CPPAssembly::TypeInfo{ ntic.tid, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, 
+                            ptrmask, cpptkey, CPPAssembly::Tag#Tagged };
 
-                        %% Same as calculating Some<T> typeinfo
-                        return named_pcinfo, ntic.update(cpptkey, named_pcinfo);
+                        return pctinfo, ntic.update(cpptkey, pctinfo);
                     }
-                    else {
-                        abort; %% TODO: Support for other primitive concepts! 
-                    }
+                    abort; %% TODO: Support for other primitive concepts! 
                 }
                 else {
                     abort; %% Not a concept
@@ -1471,12 +1485,12 @@ entity CPPTransformer {
         let generated_typeinfos_concrete = bsqasm.allconcretetypes
             .reduce<TypeInfoContext>( 
                 TypeInfoContext{ Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>{}, 1n }, fn(acc, tkey) => {
-                    return transformer.generateTypeInfo(some(tkey), none, acc).1;
+                    return transformer.generateTypeInfo(tkey, acc).1;
             });
 
         let generated_typeinfos_abstract = bsqasm.allabstracttypes
             .reduce<TypeInfoContext>( generated_typeinfos_concrete, fn(acc, tkey) => {
-                return transformer.generateTypeInfo(some(tkey), none, acc).1;
+                return transformer.generateTypeInfo(tkey, acc).1;
         });
 
         return CPPAssembly::Assembly {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -120,6 +120,27 @@ namespace CPPTransformNameManager {
     }
 }
 
+entity TypeInfoContext {
+    field tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>;
+    field tid: Nat;
+
+    method update(ntk: CPPAssembly::TypeKey, ntinfo: CPPAssembly::TypeInfo): TypeInfoContext { 
+        return this[tinfos = $tinfos.insert(ntk, ntinfo), tid = $tid + 1n];
+    }
+}
+
+%% Not used as typeinfo, stores info about entire elist to make typegen for elist as field case easier
+entity EListInfo {
+    field typesize: Nat;
+    field slotsize: Nat;
+    field ptrmask: CString;
+
+    method update(tinfo: CPPAssembly::TypeInfo): EListInfo {
+        return this[typesize = $typesize + tinfo.typesize, slotsize = $slotsize + tinfo.slotsize, 
+            ptrmask = CString::concat($ptrmask, tinfo.ptrmask)];
+    }
+}
+
 entity CPPTransformer {
     field bsqasm: BSQAssembly::Assembly;
 
@@ -887,158 +908,151 @@ entity CPPTransformer {
         });
     }
 
-    %% Finds number of fields handling elist case
-    method getFieldsSize(ant: BSQAssembly::AbstractNominalTypeDecl): Nat {
-        return ant.saturatedBFieldInfo
-            .reduce<Nat>(0n, fn(acc, f) =>  {
-                let ftype = f.ftype;
-                return acc + if(ftype)@<BSQAssembly::EListTypeSignature> 
-                    then $ftype.entries.size() else 1n;
-        });
-    }
+    recursive method findEListSize(elist: BSQAssembly::EListTypeSignature, tic: TypeInfoContext): EListInfo, TypeInfoContext {
+        return elist.entries
+            .reduce<(|EListInfo, TypeInfoContext|)>((|EListInfo{ 0n, 0n, '' }, tic|), fn(acc, e) => {
+                if(e)@<BSQAssembly::EListTypeSignature> {
+                    return this.findEListSize[recursive]($e, acc.1);
+                }
 
-    %% Explore all subtypes and find largest possible field count (generating subtype tinfo when necessary)
-    method findMaxFieldCount(cur: BSQAssembly::AbstractConceptTypeDecl, bsqasm: BSQAssembly::Assembly, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat): 
-        (|Nat, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|) {
-            return cur.subtypes.reduce<(|Nat, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(
-                (|0n, tinfos|), fn(acc, subtk) => {
-                    let subant = bsqasm.lookupNominalTypeDeclaration(subtk);
-                    let subtinfo, ntinfos = this.generateTypeInfo(subtk, acc.1, tid, bsqasm);
-                    if(subant)<BSQAssembly::AbstractEntityTypeDecl> {
-                        let fieldssize = if(subtinfo.tag === CPPAssembly::Tag#Ref) then 1n 
-                            else this.getFieldsSize(subant);
-                        return if(fieldssize > acc.0) then (|fieldssize, ntinfos|) 
-                            else (|acc.0, ntinfos|);
-                    }
-                    else {
-                        return this.findMaxFieldCount[recursive](subant@<BSQAssembly::AbstractConceptTypeDecl>, bsqasm, ntinfos, tid);
-                    }
+                let tinfo, ntic = this.generateTypeInfo(e.tkeystr, acc.1);
+                return acc.0.update(tinfo), ntic;
             });
     }
 
-    method generateNominalConcreteTypeInfo(bsqtk: BSQAssembly::TypeKey, cpptk: CPPAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat, bsqasm: BSQAssembly::Assembly): 
-        (|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|) {
-            let bsqant = bsqasm.lookupNominalTypeDeclaration(bsqtk);
-            let tag = if(this.shouldBeRef(bsqant.saturatedBFieldInfo, bsqasm)) 
-                then CPPAssembly::Tag#Ref 
-                else CPPAssembly::Tag#Value; 
-            
-            let updated = bsqant.saturatedBFieldInfo
-                .reduce<(|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>(
-                    (|CPPAssembly::TypeInfo{ tid, 0n, 0n, '', cpptk, tag }, tinfos|), fn(acc, f) => {
-                        let fieldtype = f.ftype;
+    %% Explore all subtypes and find largest possible field slot size (generating subtype tinfo when necessary)
+    method findLargestSubtype(cur: BSQAssembly::AbstractConceptTypeDecl, tic: TypeInfoContext): Nat, TypeInfoContext {
+        return cur.subtypes.reduce<(|Nat, TypeInfoContext|)>((|0n, tic|), fn(acc, subtk) => {              
+            let subant = this.bsqasm.lookupNominalTypeDeclaration(subtk);
+
+            if(subant)@<BSQAssembly::AbstractEntityTypeDecl> {
+                let field_size, ntic = $subant.saturatedBFieldInfo
+                    .reduce<(|Nat, TypeInfoContext|)>((|0n, acc.1|), fn(nacc, f) => { 
+                        let ftype = f.ftype;
+                        let cpptk = CPPTransformNameManager::convertTypeKey(ftype.tkeystr);
                         
-                        var ntinfo: CPPAssembly::TypeInfo;
-                        if(fieldtype)@<BSQAssembly::EListTypeSignature> {
-                            let esize, eslotsize, eptrmask, ntinfos = $fieldtype.entries
-                                .reduce<(|Nat, Nat, CString, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>((|0n, 0n, acc.0.ptrmask, acc.1|), 
-                                    fn(nacc, entry) => {
-                                        let etinfo = this.generateTypeInfo(entry.tkeystr, nacc.3, tid + 1n, bsqasm);
-                                        return nacc.0 + etinfo.0.typesize, nacc.1 + etinfo.0.slotsize, CString::concat(nacc.2, etinfo.0.ptrmask), etinfo.1;
-                                    });
-                                ntinfo = acc.0[typesize=acc.0.typesize + esize, slotsize=acc.0.slotsize + eslotsize, ptrmask=eptrmask]; 
-                                return ntinfo, ntinfos;
+                        if(ftype)@<BSQAssembly::EListTypeSignature> {
+                            let elistsize, elisttic = this.findEListSize($ftype, nacc.1);
+                            return nacc.0 + elistsize.slotsize, elisttic;
                         }
                         
-                        if(bsqasm.isNominalTypeConcept(fieldtype.tkeystr)) {
-                            ntinfo = acc.0[typesize=acc.0.typesize + 8n, slotsize=acc.0.slotsize + 1n, 
-                                ptrmask=CString::concat(acc.0.ptrmask, '1')];
-                            return ntinfo, acc.1;  
-                        }
-                        
-                        let ctinfo, ntinfos = this.generateTypeInfo(f.ftype.tkeystr, acc.1, tid + 1n, bsqasm);
-                        if(bsqasm.isPrimtitiveType(f.ftype.tkeystr)) {
-                            ntinfo = acc.0[typesize=acc.0.typesize + ctinfo.typesize, slotsize=acc.0.slotsize + ctinfo.slotsize, 
-                                ptrmask=CString::concat(acc.0.ptrmask, ctinfo.ptrmask)];
-                        }
-                        else {
-                            if(ctinfo.tag === CPPAssembly::Tag#Ref) {
-                                ntinfo = acc.0[typesize=acc.0.typesize + 8n, slotsize=acc.0.slotsize + 1n, 
-                                    ptrmask=CString::concat(acc.0.ptrmask, '1')];
-                            }
-                            else {
-                                ntinfo = acc.0[typesize=acc.0.typesize + ctinfo.typesize, slotsize=acc.0.slotsize + ctinfo.slotsize, 
-                                    ptrmask=CString::concat(acc.0.ptrmask, ctinfo.ptrmask)];
-                            }
-                        }
-                        return ntinfo, ntinfos;
-                     });
-            return updated.0, updated.1.insert(cpptk, updated.0);
+                        let finfo, ftic = this.generateNominalConcreteTypeInfo(ftype.tkeystr, cpptk, nacc.1);
+                        return nacc.0 + finfo.slotsize, ftic;
+                    });
+
+                if(field_size > acc.0) {
+                    return field_size, ntic;
+                }
+                return acc.0, ntic;
+            }
+
+            return this.findLargestSubtype[recursive](subant@<BSQAssembly::AbstractConceptTypeDecl>, acc.1);
+        });
     }
 
-    %%
-    %% TODO: I think it is also possible for there to be repeated tids currently, so we likely need to return the tid of the tinfo we just generated/fetched
-    %%
-    recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat, bsqasm: BSQAssembly::Assembly): 
-        (|CPPAssembly::TypeInfo, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|) { 
+    method generateNominalConcreteTypeInfo(bsqtk: BSQAssembly::TypeKey, cpptk: CPPAssembly::TypeKey, tic: TypeInfoContext): CPPAssembly::TypeInfo, TypeInfoContext {
+        if(tic.tinfos.has(cpptk)) {
+            return tic.tinfos.get(cpptk), tic;
+        } 
+        
+        let bsqant = this.bsqasm.lookupNominalTypeDeclaration(bsqtk);
+        let tag = if(this.shouldBeRef(bsqant.saturatedBFieldInfo, this.bsqasm)) 
+            then CPPAssembly::Tag#Ref 
+            else CPPAssembly::Tag#Value; 
+        
+        return bsqant.saturatedBFieldInfo
+            .reduce<(|CPPAssembly::TypeInfo, TypeInfoContext|)>(
+                (|CPPAssembly::TypeInfo{ tic.tid, 0n, 0n, '', cpptk, tag }, tic|), fn(acc, f) => {
+                    let ftype = f.ftype;
+                    
+                    %% Always check for elist first, isNominalTypeConcept fails on elist tkey
+                    if(ftype)@<BSQAssembly::EListTypeSignature> {
+                        let finfo, ntic = this.findEListSize($ftype, acc.1);
+                        return acc.0.update(finfo.typesize, finfo.slotsize, finfo.ptrmask), ntic;
+                    }
+
+                    if(this.bsqasm.isNominalTypeConcept(ftype.tkeystr)) {
+                        return acc.0.update(8n, 1n, '1'), acc.1;
+                    }
+
+                    let ctinfo, ntic = this.generateTypeInfo(ftype.tkeystr, acc.1);
+                    if(ctinfo.tag === CPPAssembly::Tag#Ref) {
+                        return acc.0.update(8n, 1n, '1'), ntic;
+                    }
+                    
+                    return acc.0.update(ctinfo.typesize, ctinfo.slotsize, ctinfo.ptrmask), ntic;
+            });
+    }
+
+    recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tic: TypeInfoContext): CPPAssembly::TypeInfo, TypeInfoContext { 
             let cpptkey = CPPTransformNameManager::convertTypeKey(typekey);
-            if(tinfos.has(cpptkey)) {
-                return tinfos.get(cpptkey), tinfos;
+            if(tic.tinfos.has(cpptkey)) {
+                return tic.tinfos.get(cpptkey), tic;
             }
 
-            let cur_tid = tid;
-            let next_tid = tid + 1n;
-
-            let ant = bsqasm.lookupNominalTypeDeclaration(typekey);
-            if(bsqasm.isPrimtitiveType(typekey)) {
+            let ant = this.bsqasm.lookupNominalTypeDeclaration(typekey);
+            if(this.bsqasm.isPrimtitiveType(typekey)) {
                 var matchedType: CPPAssembly::TypeInfo;
                 switch(typekey) {
-                    'None'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{     next_tid, 0n, 0n, '', cpptkey, CPPAssembly::Tag#Value }; }
-                    | 'Bool'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{   next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
-                    | 'Nat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{    next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
-                    | 'Int'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{    next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
-                    | 'BigNat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
-                    | 'BigInt'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ next_tid, 16n, 2n,'00', cpptkey, CPPAssembly::Tag#Value }; }
-                    | 'Float'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{  next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                    'None'<BSQAssembly::TypeKey> =>     { matchedType = CPPAssembly::TypeInfo{ tic.tid, 0n, 0n, '', cpptkey, CPPAssembly::Tag#Value }; }
+                    | 'Bool'<BSQAssembly::TypeKey> =>   { matchedType = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                    | 'Nat'<BSQAssembly::TypeKey> =>    { matchedType = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                    | 'Int'<BSQAssembly::TypeKey> =>    { matchedType = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                    | 'BigNat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                    | 'BigInt'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ tic.tid, 16n, 2n,'00', cpptkey, CPPAssembly::Tag#Value }; }
+                    | 'Float'<BSQAssembly::TypeKey> =>  { matchedType = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
                     | _ => { abort; } %% Not supported by cpp emitter yet!
                 }
-                return matchedType, tinfos.insert(cpptkey, matchedType);
+
+                return matchedType, tic.update(cpptkey, matchedType);
             }
-            elif(bsqasm.isNominalTypeConcrete(typekey)) {            
-                if(bsqasm.entities.has(typekey) || bsqasm.datamembers.has(typekey)) {
-                    return this.generateNominalConcreteTypeInfo(typekey, cpptkey, tinfos, next_tid, bsqasm);
+            elif(this.bsqasm.isNominalTypeConcrete(typekey)) {            
+                if(this.bsqasm.entities.has(typekey) || this.bsqasm.datamembers.has(typekey)) {
+                    let e, ntic = this.generateNominalConcreteTypeInfo(typekey, cpptkey, tic);
+                    return e, ntic.update(cpptkey, e);
                 }
-                elif(bsqasm.constructables.has(typekey)) { 
+                elif(this.bsqasm.constructables.has(typekey)) { 
                     if(ant)@<BSQAssembly::SomeTypeDecl> { %% Only support Some<T> for now (are always value too)
-                        let someinfo = this.generateTypeInfo[recursive]($ant.oftype.tkeystr, tinfos, cur_tid, bsqasm).0;
-                        var named_someinfo = CPPAssembly::TypeInfo{ next_tid, someinfo.typesize, someinfo.slotsize, someinfo.ptrmask, cpptkey, CPPAssembly::Tag#Value }; 
-                        return (| named_someinfo, tinfos.insert(cpptkey, named_someinfo) |);
+                        let someinfo, ntic = this.generateTypeInfo[recursive]($ant.oftype.tkeystr, tic);
+                        let named_someinfo = CPPAssembly::TypeInfo{ ntic.tid, someinfo.typesize, someinfo.slotsize, someinfo.ptrmask, cpptkey, CPPAssembly::Tag#Value }; 
+
+                        return named_someinfo, ntic.update(cpptkey, named_someinfo);
                     }
-                    else {
-                        abort;
-                    }
-                }
-                elif(bsqasm.collections.has(typekey)) { %% Temporary typeinfo while I figure out a good representation (or if one is even needed) 
-                    let tmplisttinfo = CPPAssembly::TypeInfo{ next_tid, 0n, 0n, '', cpptkey, CPPAssembly::Tag#Value };
-                    return (| tmplisttinfo, tinfos.insert(cpptkey, tmplisttinfo) |);
-                }
-                elif(bsqasm.stringoftypedecls.has(typekey)) {
                     abort;
                 }
-                elif(bsqasm.enums.has(typekey)) { %% For now we will assume our enums cannot exceed 8 bytes 
-                    let etdtinfo = CPPAssembly::TypeInfo{ next_tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value };
-                    return (| etdtinfo, tinfos.insert(cpptkey, etdtinfo) |);
+                elif(this.bsqasm.collections.has(typekey)) { 
+                    %% I believe we dont need to emit typeinfo explicitly since these are just a wrapper around a data structure
+                    let tmplisttinfo = CPPAssembly::TypeInfo{ tic.tid, 0n, 0n, '', cpptkey, CPPAssembly::Tag#Value };
+                    return tmplisttinfo, tic.update(cpptkey, tmplisttinfo);
+                }
+                elif(this.bsqasm.stringoftypedecls.has(typekey)) {
+                    abort;
+                }
+                elif(this.bsqasm.enums.has(typekey)) { %% For now we will assume our enums cannot exceed 8 bytes 
+                    let etdtinfo = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value };
+                    return etdtinfo, tic.update(cpptkey, etdtinfo);
                 }
                 else {
                     abort; %% TODO: Type not supported for typeinfo emission!
                 }
             }
-            elif(bsqasm.isNominalTypeConcept(typekey)) {
-                if(bsqasm.concepts.has(typekey) || bsqasm.datatypes.has(typekey)) {
-                    let mfc = this.findMaxFieldCount(ant@<BSQAssembly::AbstractConceptTypeDecl>, bsqasm, tinfos, next_tid);
-                    let ptr_mask = CPPTransformNameManager::repeatCString('0', mfc.0, '2');
-                    let matchedType = CPPAssembly::TypeInfo{ next_tid, 8n + (mfc.0 * 8n), mfc.0 + 1n, ptr_mask, cpptkey, CPPAssembly::Tag#Tagged }; 
-                    return matchedType, mfc.1.insert(cpptkey, matchedType);
+            elif(this.bsqasm.isNominalTypeConcept(typekey)) {
+                if(this.bsqasm.concepts.has(typekey) || this.bsqasm.datatypes.has(typekey)) {
+                    let mfc, ntic = this.findLargestSubtype(ant@<BSQAssembly::AbstractConceptTypeDecl>, tic);
+                    let ptr_mask = CPPTransformNameManager::repeatCString('0', mfc, '2');
+                    let matchedType = CPPAssembly::TypeInfo{ ntic.tid, 8n + (mfc * 8n), mfc + 1n, ptr_mask, cpptkey, CPPAssembly::Tag#Tagged }; 
+                    
+                    return matchedType, ntic.update(cpptkey, matchedType);
 
                 }
-                elif(bsqasm.pconcepts.has(typekey)) {
+                elif(this.bsqasm.pconcepts.has(typekey)) {
                     if(ant)@<BSQAssembly::OptionTypeDecl> {
-                        let pcinfo = this.generateTypeInfo[recursive]($ant.someType.tkeystr, tinfos, cur_tid, bsqasm).0;
-                        let named_pcinfo = CPPAssembly::TypeInfo{ next_tid, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, 
+                        let pcinfo, ntic = this.generateTypeInfo[recursive]($ant.someType.tkeystr, tic);
+                        let named_pcinfo = CPPAssembly::TypeInfo{ ntic.tid, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, 
                             CString::concat('2', pcinfo.ptrmask), cpptkey, CPPAssembly::Tag#Tagged };
 
                         %% Same as calculating Some<T> typeinfo
-                        return (| named_pcinfo, tinfos.insert(cpptkey, named_pcinfo) |);
+                        return named_pcinfo, ntic.update(cpptkey, named_pcinfo);
                     }
                     else {
                         abort; %% TODO: Support for other primitive concepts! 
@@ -1433,17 +1447,14 @@ entity CPPTransformer {
         });
 
         let generated_typeinfos_concrete = bsqasm.allconcretetypes
-            .reduce<(| Nat, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> |)>(
-                (| 0n, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>{} |), fn(acc, tkey) => {
-                    let gen_tinfo = transformer.generateTypeInfo(tkey, acc.1, acc.0, bsqasm);
-                    return (| acc.0 + 1n, gen_tinfo.1 |);
-        });
+            .reduce<TypeInfoContext>( 
+                TypeInfoContext{ Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>{}, 1n }, fn(acc, tkey) => {
+                    return transformer.generateTypeInfo(tkey, acc).1;
+            });
 
         let generated_typeinfos_abstract = bsqasm.allabstracttypes
-            .reduce<(| Nat, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo> |)>(
-                generated_typeinfos_concrete, fn(acc, tkey) => {
-                    let gen_tinfo = transformer.generateTypeInfo(tkey, acc.1, acc.0, bsqasm);
-                    return (| acc.0 + 1n, gen_tinfo.1 |);
+            .reduce<TypeInfoContext>( generated_typeinfos_concrete, fn(acc, tkey) => {
+                return transformer.generateTypeInfo(tkey, acc).1;
         });
 
         return CPPAssembly::Assembly {
@@ -1466,7 +1477,7 @@ entity CPPTransformer {
             pconcepts = transformer_pconcepts,
             concepts = transformer_concepts,
             allmethods = transformer_allmethods, %% Might need to do someting like the funcs, being able to get the ns is nice
-            typeinfos = generated_typeinfos_abstract.1
+            typeinfos = generated_typeinfos_abstract.tinfos
         };
     }
 }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -1,5 +1,7 @@
 namespace CPPEmitter;
 
+const reftypeThreshold: Nat = 4n;
+
 %% Transform Bosque names into cpp representation
 namespace CPPTransformNameManager {
     function convertNamespaceKey(nskey: BSQAssembly::NamespaceKey): CPPAssembly::NamespaceKey {
@@ -178,7 +180,7 @@ entity CPPTransformer {
             return (acc.0 && (asm.isPrimtitiveType(ftype.tkeystr) || asm.enums.has(ftype.tkeystr))), acc.1 + 1n;
         });
 
-        if(primitiveAndSize.1 > 4n || !primitiveAndSize.0) {
+        if(primitiveAndSize.1 > reftypeThreshold || !primitiveAndSize.0) {
             return true;
         }
 
@@ -973,8 +975,7 @@ entity CPPTransformer {
                     return acc.0.update(e.typesize, e.slotsize, e.ptrmask), tic;
                 }
 
-                %% Not right. We should always inline concepts so that the GC knows to explore its
-                %% typeinfo from the '2' ptrmask. The issue we are facing lies elsewere I believe
+                %% If we have a concept as a field we need to make it a ref otherwise a cycle is possible
                 if(this.bsqasm.isNominalTypeConcept(ftype.tkeystr)) {
                     return acc.0.update(8n, 1n, '1'), acc.1;
                 }
@@ -1054,17 +1055,17 @@ entity CPPTransformer {
                 if(this.bsqasm.concepts.has(typekey) || this.bsqasm.datatypes.has(typekey)) {
                     let mfc, ntic = this.findLargestSubtype(ant@<BSQAssembly::AbstractConceptTypeDecl>, tic);
                     let ptrmask = CPPTransformNameManager::repeatCString('0', mfc, '2');
-                    let matchedType = CPPAssembly::TypeInfo{ ntic.tid, 8n + (mfc * 8n), mfc + 1n, ptrmask, cpptkey, CPPAssembly::Tag#Tagged }; 
+                    let ntag = if(mfc > reftypeThreshold) then CPPAssembly::Tag#Ref else CPPAssembly::Tag#Value;
+                    let matchedType = CPPAssembly::TypeInfo{ ntic.tid, 8n + (mfc * 8n), mfc + 1n, ptrmask, cpptkey, ntag }; 
                     
                     return matchedType, ntic.update(cpptkey, matchedType);
-
                 }
                 elif(this.bsqasm.pconcepts.has(typekey)) {
                     if(ant)@<BSQAssembly::OptionTypeDecl> {
                         let pcinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, tic);
                         let ptrmask = CPPTransformNameManager::repeatCString('0', pcinfo.slotsize, '2');
-                        let pctinfo = CPPAssembly::TypeInfo{ ntic.tid, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, 
-                            ptrmask, cpptkey, CPPAssembly::Tag#Tagged };
+                        let ntag = if(pcinfo.slotsize > reftypeThreshold) then CPPAssembly::Tag#Ref else CPPAssembly::Tag#Value;
+                        let pctinfo = CPPAssembly::TypeInfo{ ntic.tid, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, ptrmask, cpptkey, ntag };
 
                         return pctinfo, ntic.update(cpptkey, pctinfo);
                     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -1038,15 +1038,12 @@ entity CPPTransformer {
                     abort;
                 }
                 elif(this.bsqasm.collections.has(typekey)) { 
-                    
-                    %%
-                    %% TODO: Take a look at this, i am skeptical our lists should always be by value.
-                    %% I dont think that makes any sense as they can be super large (well the tree that constructs them)
-                    %%
-                    
+                    %% List<T> is just alias of Tree<T> so we need to get Tree<T>'s typeinfo 
                     if(ant)@<BSQAssembly::ListTypeDecl> {
-                        let oftypeinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, tic);
-                        let listinfo = CPPAssembly::TypeInfo{ ntic.tid, oftypeinfo.typesize, oftypeinfo.slotsize, oftypeinfo.ptrmask, cpptkey, CPPAssembly::Tag#Value };
+                        let treetk = BSQAssembly::TypeKey::from(CString::concat('ListOps::Tree<', $ant.oftype.tkeystr.value, '>'));
+
+                        let treeinfo, ntic = this.generateTypeInfo[recursive](treetk, tic);
+                        let listinfo = CPPAssembly::TypeInfo{ ntic.tid, treeinfo.typesize, treeinfo.slotsize, treeinfo.ptrmask, cpptkey, treeinfo.tag };
 
                         return listinfo, ntic.update(cpptkey, listinfo);
                     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -909,20 +909,26 @@ entity CPPTransformer {
     }
 
     %% Explore all subtypes and find largest possible field slot size (generating subtype tinfo when necessary)
-    method findLargestSubtype(cur: BSQAssembly::AbstractConceptTypeDecl, tic: TypeInfoContext): Nat, TypeInfoContext {
-        return cur.subtypes.reduce<(|Nat, TypeInfoContext|)>((|0n, tic|), fn(acc, subtk) => {              
+    method findLargestSubtype(cur: BSQAssembly::AbstractConceptTypeDecl, tic: TypeInfoContext): Nat, CPPAssembly::Tag, TypeInfoContext {
+        return cur.subtypes.reduce<(|Nat, CPPAssembly::Tag, TypeInfoContext|)>((|0n, CPPAssembly::Tag#Value, tic|), fn(acc, subtk) => {              
             let subant = this.bsqasm.lookupNominalTypeDeclaration(subtk);
 
             if(subant)@<BSQAssembly::AbstractEntityTypeDecl> {
-                let finfo, ntic = this.generateFieldInfo(none, some(subtk), acc.1);
+                let finfo, ntic = this.generateFieldInfo(none, some(subtk), acc.2);
+
+                %% If already a ref keep it like so
+                var tag = acc.1;
+                if(this.shouldBeRef($subant.saturatedBFieldInfo, this.bsqasm)) {
+                    tag = CPPAssembly::Tag#Ref;
+                }
 
                 if(finfo.slotsize > acc.0) {
-                    return finfo.slotsize, ntic;
+                    return finfo.slotsize, tag, ntic;
                 }
-                return acc.0, ntic;
+                return acc.0, tag, ntic;
             }
 
-            return this.findLargestSubtype[recursive](subant@<BSQAssembly::AbstractConceptTypeDecl>, acc.1);
+            return this.findLargestSubtype[recursive](subant@<BSQAssembly::AbstractConceptTypeDecl>, acc.2);
         });
     }
 
@@ -1032,6 +1038,12 @@ entity CPPTransformer {
                     abort;
                 }
                 elif(this.bsqasm.collections.has(typekey)) { 
+                    
+                    %%
+                    %% TODO: Take a look at this, i am skeptical our lists should always be by value.
+                    %% I dont think that makes any sense as they can be super large (well the tree that constructs them)
+                    %%
+                    
                     if(ant)@<BSQAssembly::ListTypeDecl> {
                         let oftypeinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, tic);
                         let listinfo = CPPAssembly::TypeInfo{ ntic.tid, oftypeinfo.typesize, oftypeinfo.slotsize, oftypeinfo.ptrmask, cpptkey, CPPAssembly::Tag#Value };
@@ -1053,9 +1065,8 @@ entity CPPTransformer {
             }
             elif(this.bsqasm.isNominalTypeConcept(typekey)) {
                 if(this.bsqasm.concepts.has(typekey) || this.bsqasm.datatypes.has(typekey)) {
-                    let mfc, ntic = this.findLargestSubtype(ant@<BSQAssembly::AbstractConceptTypeDecl>, tic);
+                    let mfc, ntag, ntic = this.findLargestSubtype(ant@<BSQAssembly::AbstractConceptTypeDecl>, tic);
                     let ptrmask = CPPTransformNameManager::repeatCString('0', mfc, '2');
-                    let ntag = if(mfc > reftypeThreshold) then CPPAssembly::Tag#Ref else CPPAssembly::Tag#Value;
                     let matchedType = CPPAssembly::TypeInfo{ ntic.tid, 8n + (mfc * 8n), mfc + 1n, ptrmask, cpptkey, ntag }; 
                     
                     return matchedType, ntic.update(cpptkey, matchedType);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -887,6 +887,16 @@ entity CPPTransformer {
         });
     }
 
+    %% Finds number of fields handling elist case
+    method getFieldsSize(ant: BSQAssembly::AbstractNominalTypeDecl): Nat {
+        return ant.saturatedBFieldInfo
+            .reduce<Nat>(0n, fn(acc, f) =>  {
+                let ftype = f.ftype;
+                return acc + if(ftype)@<BSQAssembly::EListTypeSignature> 
+                    then $ftype.entries.size() else 1n;
+        });
+    }
+
     %% Explore all subtypes and find largest possible field count (generating subtype tinfo when necessary)
     method findMaxFieldCount(cur: BSQAssembly::AbstractConceptTypeDecl, bsqasm: BSQAssembly::Assembly, tinfos: Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>, tid: Nat): 
         (|Nat, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|) {
@@ -896,7 +906,7 @@ entity CPPTransformer {
                     let subtinfo, ntinfos = this.generateTypeInfo(subtk, acc.1, tid, bsqasm);
                     if(subant)<BSQAssembly::AbstractEntityTypeDecl> {
                         let fieldssize = if(subtinfo.tag === CPPAssembly::Tag#Ref) then 1n 
-                            else subant.saturatedBFieldInfo.size();
+                            else this.getFieldsSize(subant);
                         return if(fieldssize > acc.0) then (|fieldssize, ntinfos|) 
                             else (|acc.0, ntinfos|);
                     }
@@ -924,7 +934,7 @@ entity CPPTransformer {
                                 .reduce<(|Nat, Nat, CString, Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>|)>((|0n, 0n, acc.0.ptrmask, acc.1|), 
                                     fn(nacc, entry) => {
                                         let etinfo = this.generateTypeInfo(entry.tkeystr, nacc.3, tid + 1n, bsqasm);
-                                        return etinfo.0.typesize, etinfo.0.slotsize, CString::concat(nacc.2, etinfo.0.ptrmask), etinfo.1;
+                                        return nacc.0 + etinfo.0.typesize, nacc.1 + etinfo.0.slotsize, CString::concat(nacc.2, etinfo.0.ptrmask), etinfo.1;
                                     });
                                 ntinfo = acc.0[typesize=acc.0.typesize + esize, slotsize=acc.0.slotsize + eslotsize, ptrmask=eptrmask]; 
                                 return ntinfo, ntinfos;


### PR DESCRIPTION
After taking a deeper look at how I was handling our emission of type info I realized there were quite a few areas for improvements and some that were simply wrong. 

I was not handling elist as field (or really in general) correctly for emission and had some inconsistencies with how the pointer masks were being generated. And the concept case was not correct, I had them always emitting as value which could cause us to be copying massive amounts of data all over the place. The collection types now emit their type info explicitly which is the same as their underlying data structure (with the typekey and id being different).

I took a look at nbodys emission (which emits correctly and runs now!) and I believe all type info is looking much better and should put us in a good spot to start working in the gc.