### PR TITLE
Concept Handling Fix

### DIFF
--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -155,7 +155,6 @@ entity DatatypeTypeDecl provides AbstractConceptTypeDecl {
     field associatedMemberEntityDecls: List<NominalTypeSignature>;
 }
 
-%% I believe tagged can be removed
 enum Tag {
     Value,
     Ref,

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -267,11 +267,6 @@ function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): String {
 function generateAccessorForSpecialTypeConstructor(constype: CPPAssembly::TypeSignature, ttype: CPPAssembly::TypeSignature, 
     eexp: String, ctx: Context): String {
         let econstype = emitTypeSignature(constype, false, ctx);
-        let needsGCAlloc = if(ctx.asm.typeinfos.get(ttype.tkeystr).tag === CPPAssembly::Tag#Ref)
-            then "new " %% TODO: Make this not new! It should be a call to our GC allocator
-            else "";
-
-        let base = String::concat(needsGCAlloc, econstype);
         let ettype = String::concat(removeCppPrefix(emitTypeSignature(ttype, false, ctx)), "Type");
         
         %% Since List<T> is just an alias of Tree<T>, we dont need to explicitly emit List<T> constructor
@@ -279,8 +274,8 @@ function generateAccessorForSpecialTypeConstructor(constype: CPPAssembly::TypeSi
             return eexp;
         }
         else {
-            return if(eexp === "") then String::concat(base, "{ &", ettype, " }")
-                else String::concat(base, "{ &", ettype, ", ", eexp, " }");
+            return if(eexp === "") then String::concat(econstype, "{ &", ettype, " }")
+                else String::concat(econstype, "{ &", ettype, ", ", eexp, " }");
         }
 }
 
@@ -1063,7 +1058,6 @@ function emitIfTestStatement(stmt: CPPAssembly::IfTestStatement, ctx: Context, i
     return String::concat(ifstmt, trueBlock, indent, "}");
 }
 
-%% TODO: This is lacking proper redefine for "@@*" itest!
 function emitIfBinderStatement(stmt: CPPAssembly::IfBinderStatement, ctx: Context, indent: String): String {
     let full_indent = String::concat("    ", indent);
     
@@ -1320,7 +1314,6 @@ function genLambdaTemplate(templates: String, indent: String): String {
         else "";
 }
 
-%% Determine whether to emit this param as const this* or this
 function emitThisType(tk: CPPAssembly::TypeKey, ctx: Context): String {
     let resolved_type = emitTypeKey(tk, false, ctx);
 
@@ -1385,13 +1378,9 @@ function emitFunctionDecl(func: CPPAssembly::AbstractInvokeDecl, ctx: Context, i
 }
 
 function emitSaturatedFieldInfo(sfi: CPPAssembly::SaturatedFieldInfo, ctx: Context, indent: String): String {
-    var ftype = emitTypeSignature(sfi.ftype, true, ctx);
-
-    %% Would be better to determine this somewhere more central
-    if(ctx.asm.isNominalTypeConcept(sfi.ftype.tkeystr)) {
-        ftype = String::concat(ftype, "*");
-    }
+    let ftype = emitTypeSignature(sfi.ftype, true, ctx);
     let fname = emitIdentifier(sfi.fname);
+
     return String::concat(indent, ftype, " ", fname, ";%n;");
 }
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -29,8 +29,11 @@ namespace UnicodeCharBuffer {
 
 entity Context {
     field asm: CPPAssembly::Assembly;
-    field fullns_key: CPPAssembly::NamespaceKey; %% Main::Foo::Bar::...
-    field fullns_list: List<CString>; %% ["Main", "Foo", "Bar", ...]
+    field fullns_key: CPPAssembly::NamespaceKey;
+    field fullns_list: List<CString>;
+
+    %% When dealing with tagged types we need to determine whether they were created as ref or value
+    field varmap: Map<CPPAssembly::Identifier, CPPAssembly::Tag>;
 
     method updateCurrentNamespace(new_ns: CPPAssembly::NamespaceKey, new_nsname: List<CString>): Context {
         return Context{ this.asm, new_ns, new_nsname };
@@ -650,7 +653,7 @@ function emitITestAsConvertSome(isnot: Bool, fromtype: CPPAssembly::TypeKey, ctx
         }
         else {
             return (|String::concat(getAccessor(fromtype, $ant.someType.tkeystr, ctx), "<", emitTypeSignature($ant.someType, true, ctx), ">().value"),
-                emitTypeKey($ant.oftype.tkeystr, true, ctx)|);
+                emitTypeSignature($ant.oftype, true, ctx)|);
         }
     }
     else {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -32,11 +32,8 @@ entity Context {
     field fullns_key: CPPAssembly::NamespaceKey;
     field fullns_list: List<CString>;
 
-    %% When dealing with tagged types we need to determine whether they were created as ref or value
-    field varmap: Map<CPPAssembly::Identifier, CPPAssembly::Tag>;
-
     method updateCurrentNamespace(new_ns: CPPAssembly::NamespaceKey, new_nsname: List<CString>): Context {
-        return Context{ this.asm, new_ns, new_nsname };
+        return this[fullns_key = new_ns, fullns_list = new_nsname ];
     }
 }
 
@@ -270,7 +267,7 @@ function emitNamespaceKey(nsk: CPPAssembly::NamespaceKey): String {
 function generateAccessorForSpecialTypeConstructor(constype: CPPAssembly::TypeSignature, ttype: CPPAssembly::TypeSignature, 
     eexp: String, ctx: Context): String {
         let econstype = emitTypeSignature(constype, false, ctx);
-        let needsGCAlloc = if(ctx.asm.typeinfos.get(constype.tkeystr).tag === CPPAssembly::Tag#Ref)
+        let needsGCAlloc = if(ctx.asm.typeinfos.get(ttype.tkeystr).tag === CPPAssembly::Tag#Ref)
             then "new " %% TODO: Make this not new! It should be a call to our GC allocator
             else "";
 
@@ -1388,7 +1385,12 @@ function emitFunctionDecl(func: CPPAssembly::AbstractInvokeDecl, ctx: Context, i
 }
 
 function emitSaturatedFieldInfo(sfi: CPPAssembly::SaturatedFieldInfo, ctx: Context, indent: String): String {
-    let ftype = emitTypeSignature(sfi.ftype, true, ctx);
+    var ftype = emitTypeSignature(sfi.ftype, true, ctx);
+
+    %% Would be better to determine this somewhere more central
+    if(ctx.asm.isNominalTypeConcept(sfi.ftype.tkeystr)) {
+        ftype = String::concat(ftype, "*");
+    }
     let fname = emitIdentifier(sfi.fname);
     return String::concat(indent, ftype, " ", fname, ";%n;");
 }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -1011,10 +1011,9 @@ entity CPPTransformer {
                         return acc.0.update(e.typesize, e.slotsize, e.ptrmask), tic;
                     }
 
-                    %% Generating pointer mask of a concept with subtype containing concept as field
-                    %% First slot for typeinfo, second for pointer to concept
+                    %% Contains enough slots for possible typeinfo ptr and data ptr
                     if(findingLargestField && this.bsqasm.isNominalTypeConcept(ftype.tkeystr)) {
-                        return acc.0.update(16n, 2n, '00'), acc.1;
+                        return acc.0.update(16n, 2n, '00'), acc.1; %% [typeinfo ptr][dataptr]
                     }
 
                     let tinfo, ntic = this.generateTypeInfo(ftype.tkeystr, acc.1);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -187,6 +187,14 @@ entity CPPTransformer {
         return false;
     }
 
+    %% We will have to manually determine if we are tagged (should be easy since tagged is only for concepts)
+    method determineTag(ant: BSQAssembly::AbstractNominalTypeDecl): CPPAssembly::Tag {
+        if(this.shouldBeRef(ant.saturatedBFieldInfo, this.bsqasm)) {
+            return CPPAssembly::Tag#Ref;
+        }
+        return CPPAssembly::Tag#Value;
+    }
+
     recursive method processBinaryArgs(lhs: BSQAssembly::Expression, rhs: BSQAssembly::Expression): CPPAssembly::Expression, CPPAssembly::Expression {
         let cpplhs = this.transformExpressionToCpp[recursive](lhs);
         let cpprhs = this.transformExpressionToCpp[recursive](rhs);
@@ -909,17 +917,18 @@ entity CPPTransformer {
     }
 
     %% Explore all subtypes and find largest possible field slot size (generating subtype tinfo when necessary)
-    method findLargestSubtype(cur: BSQAssembly::AbstractConceptTypeDecl, tic: TypeInfoContext): Nat, CPPAssembly::Tag, TypeInfoContext {
-        return cur.subtypes.reduce<(|Nat, CPPAssembly::Tag, TypeInfoContext|)>((|0n, CPPAssembly::Tag#Value, tic|), fn(acc, subtk) => {              
+    method findLargestSubtypeAndTag(cur: BSQAssembly::AbstractConceptTypeDecl, tic: TypeInfoContext): Nat, CPPAssembly::Tag, TypeInfoContext {
+        let basetag = this.determineTag(cur);
+        return cur.subtypes.reduce<(|Nat, CPPAssembly::Tag, TypeInfoContext|)>((|0n, basetag, tic|), fn(acc, subtk) => {              
             let subant = this.bsqasm.lookupNominalTypeDeclaration(subtk);
 
             if(subant)@<BSQAssembly::AbstractEntityTypeDecl> {
                 let finfo, ntic = this.generateFieldInfo(none, some(subtk), acc.2);
 
-                %% If already a ref do not update
+                %% If all subtypes are not of the same tag we must return tagged 
                 var tag = acc.1;
-                if(this.shouldBeRef($subant.saturatedBFieldInfo, this.bsqasm)) {
-                    tag = CPPAssembly::Tag#Ref;
+                if(tag !== CPPAssembly::Tag#Tagged && this.determineTag($subant) !== tag) {
+                    tag = CPPAssembly::Tag#Tagged;
                 }
 
                 if(finfo.slotsize > acc.0) {
@@ -928,7 +937,7 @@ entity CPPTransformer {
                 return acc.0, tag, ntic;
             }
 
-            return this.findLargestSubtype[recursive](subant@<BSQAssembly::AbstractConceptTypeDecl>, acc.2);
+            return this.findLargestSubtypeAndTag[recursive](subant@<BSQAssembly::AbstractConceptTypeDecl>, acc.2);
         });
     }
 
@@ -1063,7 +1072,7 @@ entity CPPTransformer {
             }
             elif(this.bsqasm.isNominalTypeConcept(typekey)) {
                 if(this.bsqasm.concepts.has(typekey) || this.bsqasm.datatypes.has(typekey)) {
-                    let mfc, ntag, ntic = this.findLargestSubtype(ant@<BSQAssembly::AbstractConceptTypeDecl>, tic);
+                    let mfc, ntag, ntic = this.findLargestSubtypeAndTag(ant@<BSQAssembly::AbstractConceptTypeDecl>, tic);
                     let ptrmask = CPPTransformNameManager::repeatCString('0', mfc, '2');
                     let matchedType = CPPAssembly::TypeInfo{ ntic.tid, 8n + (mfc * 8n), mfc + 1n, ptrmask, cpptkey, ntag }; 
                     
@@ -1073,10 +1082,7 @@ entity CPPTransformer {
                     if(ant)@<BSQAssembly::OptionTypeDecl> {
                         let pcinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, tic);
                         let ptrmask = CPPTransformNameManager::repeatCString('0', pcinfo.slotsize, '2');
-                        let ntag = if(pcinfo.slotsize > reftypeThreshold || pcinfo.ptrmask.containsString('1')) 
-                            then CPPAssembly::Tag#Ref 
-                            else CPPAssembly::Tag#Value;
-                        let pctinfo = CPPAssembly::TypeInfo{ ntic.tid, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, ptrmask, cpptkey, ntag };
+                        let pctinfo = CPPAssembly::TypeInfo{ ntic.tid, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, ptrmask, cpptkey, CPPAssembly::Tag#Tagged };
 
                         return pctinfo, ntic.update(cpptkey, pctinfo);
                     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -185,7 +185,9 @@ entity CPPTransformer {
             }
             tk = ntsig.tkeystr;
         }
-        tk = tkey@some;
+        else {
+            tk = tkey@some;
+        }
         
         let fields = this.bsqasm.lookupNominalTypeDeclaration(tk).saturatedBFieldInfo;
         let primitiveAndBelowThresh = fields.reduce<(|Bool, Nat|)>((|true, 0n|), fn(acc, f) => {
@@ -1010,8 +1012,9 @@ entity CPPTransformer {
                     }
 
                     %% Generating pointer mask of a concept with subtype containing concept as field
+                    %% First slot for typeinfo, second for pointer to concept
                     if(findingLargestField && this.bsqasm.isNominalTypeConcept(ftype.tkeystr)) {
-                        return acc.0.update(8n, 1n, '0'), acc.1;
+                        return acc.0.update(16n, 2n, '00'), acc.1;
                     }
 
                     let tinfo, ntic = this.generateTypeInfo(ftype.tkeystr, acc.1);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -166,30 +166,47 @@ entity CPPTransformer {
         }
     }
 
-    method shouldBeRef(fields: List<BSQAssembly::SaturatedFieldInfo>, asm: BSQAssembly::Assembly): Bool {
-        let primitiveAndSize = fields.reduce<(|Bool, Nat|)>((|true, 0n|), fn(acc, f) => {
+    method checkEListFieldsArePrimitive(elist: BSQAssembly::EListTypeSignature): Bool {
+        return elist.entries
+            .reduce<Bool>(true, fn(acc, ef) => {
+                return acc && (this.bsqasm.isPrimtitiveType(ef.tkeystr) || this.bsqasm.enums.has(ef.tkeystr));
+            });
+    }
+
+    method shouldBeRef(tkey: Option<BSQAssembly::TypeKey>, tsig: Option<BSQAssembly::TypeSignature>): Bool {
+        var tk: BSQAssembly::TypeKey;
+        if(tsig)@some {
+            let ntsig = $tsig;
+            if(ntsig)@<BSQAssembly::EListTypeSignature> {
+                if(!this.checkEListFieldsArePrimitive($ntsig) || $ntsig.entries.size() > reftypeThreshold) {
+                    return true;
+                }
+                return false;
+            }
+            tk = ntsig.tkeystr;
+        }
+        tk = tkey@some;
+        
+        let fields = this.bsqasm.lookupNominalTypeDeclaration(tk).saturatedBFieldInfo;
+        let primitiveAndBelowThresh = fields.reduce<(|Bool, Nat|)>((|true, 0n|), fn(acc, f) => {
             let ftype = f.ftype;
             if(ftype)@<BSQAssembly::EListTypeSignature> {
-                let efields = $ftype.entries.reduce<Bool>(true, fn(nacc, ef) => {
-                    return nacc && (asm.isPrimtitiveType(ef.tkeystr) || asm.enums.has(ef.tkeystr));
-                });
-
-                return acc.0 && efields, acc.1 + $ftype.entries.size();
+                return acc.0 && this.checkEListFieldsArePrimitive($ftype), acc.1 + $ftype.entries.size();
             }
 
-            return (acc.0 && (asm.isPrimtitiveType(ftype.tkeystr) || asm.enums.has(ftype.tkeystr))), acc.1 + 1n;
+            return (acc.0 && (this.bsqasm.isPrimtitiveType(ftype.tkeystr) || this.bsqasm.enums.has(ftype.tkeystr))), acc.1 + 1n;
         });
 
-        if(primitiveAndSize.1 > reftypeThreshold || !primitiveAndSize.0) {
+        if(primitiveAndBelowThresh.1 > reftypeThreshold || !primitiveAndBelowThresh.0) {
             return true;
         }
 
         return false;
     }
 
-    %% We will have to manually determine if we are tagged (should be easy since tagged is only for concepts)
-    method determineTag(ant: BSQAssembly::AbstractNominalTypeDecl): CPPAssembly::Tag {
-        if(this.shouldBeRef(ant.saturatedBFieldInfo, this.bsqasm)) {
+    %% We will have to manually determine if we are tagged 
+    method determineTag(tkey: Option<BSQAssembly::TypeKey>, tsig: Option<BSQAssembly::TypeSignature>): CPPAssembly::Tag {
+        if(this.shouldBeRef(tkey, tsig)) {
             return CPPAssembly::Tag#Ref;
         }
         return CPPAssembly::Tag#Value;
@@ -918,16 +935,16 @@ entity CPPTransformer {
 
     %% Explore all subtypes and find largest possible field slot size (generating subtype tinfo when necessary)
     method findLargestSubtypeAndTag(cur: BSQAssembly::AbstractConceptTypeDecl, tic: TypeInfoContext): Nat, CPPAssembly::Tag, TypeInfoContext {
-        let basetag = this.determineTag(cur);
+        let basetag = this.determineTag(some(cur.tkey), none);
         return cur.subtypes.reduce<(|Nat, CPPAssembly::Tag, TypeInfoContext|)>((|0n, basetag, tic|), fn(acc, subtk) => {              
             let subant = this.bsqasm.lookupNominalTypeDeclaration(subtk);
 
             if(subant)@<BSQAssembly::AbstractEntityTypeDecl> {
-                let finfo, ntic = this.generateFieldInfo(none, some(subtk), acc.2);
+                let finfo, ntic = this.generateFieldInfo(none, some(subtk), true, acc.2);
 
                 %% If all subtypes are not of the same tag we must return tagged 
                 var tag = acc.1;
-                if(tag !== CPPAssembly::Tag#Tagged && this.determineTag($subant) !== tag) {
+                if(tag !== CPPAssembly::Tag#Tagged && this.determineTag(some($subant.tkey), none) !== tag) {
                     tag = CPPAssembly::Tag#Tagged;
                 }
 
@@ -950,8 +967,8 @@ entity CPPTransformer {
                         return this.generateEListInfo[recursive]($f, acc.1);
                     }
 
-                    var finfo, ntic = this.generateFieldInfo(some(f), none, acc.1);
-                    let tag = if(this.shouldBeRef(this.bsqasm.lookupNominalTypeDeclaration(f.tkeystr).saturatedBFieldInfo, this.bsqasm)) 
+                    var finfo, ntic = this.generateFieldInfo(some(f), none, false, acc.1);
+                    let tag = if(this.shouldBeRef(none, some(f))) 
                         then CPPAssembly::Tag#Ref 
                         else CPPAssembly::Tag#Value;
                     if(tag === CPPAssembly::Tag#Ref) {
@@ -963,45 +980,46 @@ entity CPPTransformer {
             );
     }
 
-    recursive method generateFieldInfo(tsig: Option<BSQAssembly::TypeSignature>, tkey: Option<BSQAssembly::TypeKey>, tic: TypeInfoContext): FieldInfo, TypeInfoContext {
-        var resolvedtkey: BSQAssembly::TypeKey;
-        if(tsig)@some { 
-            let sometsig = $tsig;
-            if(sometsig)@<BSQAssembly::EListTypeSignature> { %% Always check for elist first, isNominalTypeConcept/Concrete fails on elist tkey
-                return this.generateEListInfo($sometsig, tic);
+    recursive method generateFieldInfo(tsig: Option<BSQAssembly::TypeSignature>, tkey: Option<BSQAssembly::TypeKey>, 
+        findingLargestField: Bool, tic: TypeInfoContext): FieldInfo, TypeInfoContext {
+            var resolvedtkey: BSQAssembly::TypeKey;
+            if(tsig)@some { 
+                let sometsig = $tsig;
+                if(sometsig)@<BSQAssembly::EListTypeSignature> { %% Always check for elist first, isNominalTypeConcept/Concrete fails on elist tkey
+                    return this.generateEListInfo($sometsig, tic);
+                }
+                resolvedtkey = sometsig.tkeystr;
             }
-            resolvedtkey = sometsig.tkeystr;
-        }
-        else {
-            resolvedtkey = tkey@some;
-        }
+            else {
+                resolvedtkey = tkey@some;
+            }
 
-        %% Primitives/Enums don't have saturated fields so return early
-        if(this.bsqasm.isPrimtitiveType(resolvedtkey) || this.bsqasm.enums.has(resolvedtkey)) {
-            let ptinfo, ntic = this.generateTypeInfo(resolvedtkey, tic);
-            return FieldInfo{ ptinfo.typesize, ptinfo.slotsize, ptinfo.ptrmask }, ntic;
-        }
+            %% Primitives/Enums don't have saturated fields so return early
+            if(this.bsqasm.isPrimtitiveType(resolvedtkey) || this.bsqasm.enums.has(resolvedtkey)) {
+                let ptinfo, ntic = this.generateTypeInfo(resolvedtkey, tic);
+                return FieldInfo{ ptinfo.typesize, ptinfo.slotsize, ptinfo.ptrmask }, ntic;
+            }
 
-        let ant = this.bsqasm.lookupNominalTypeDeclaration(resolvedtkey);
-        return ant.saturatedBFieldInfo
-            .reduce<(|FieldInfo, TypeInfoContext|)>((|FieldInfo{ 0n, 0n, '' }, tic|), fn(acc, finfo) => {
-                let ftype = finfo.ftype;
-                if(ftype)@<BSQAssembly::EListTypeSignature> {
-                    let e, tic = this.generateEListInfo($ftype, acc.1);
-                    return acc.0.update(e.typesize, e.slotsize, e.ptrmask), tic;
-                }
+            let ant = this.bsqasm.lookupNominalTypeDeclaration(resolvedtkey);
+            return ant.saturatedBFieldInfo
+                .reduce<(|FieldInfo, TypeInfoContext|)>((|FieldInfo{ 0n, 0n, '' }, tic|), fn(acc, finfo) => {
+                    let ftype = finfo.ftype;
+                    if(ftype)@<BSQAssembly::EListTypeSignature> {
+                        let e, tic = this.generateEListInfo($ftype, acc.1);
+                        return acc.0.update(e.typesize, e.slotsize, e.ptrmask), tic;
+                    }
 
-                %% If we have a concept as a field we need to make it a ref otherwise a cycle is possible
-                if(this.bsqasm.isNominalTypeConcept(ftype.tkeystr)) {
-                    return acc.0.update(8n, 1n, '1'), acc.1;
-                }
+                    %% Generating pointer mask of a concept with subtype containing concept as field
+                    if(findingLargestField && this.bsqasm.isNominalTypeConcept(ftype.tkeystr)) {
+                        return acc.0.update(8n, 1n, '0'), acc.1;
+                    }
 
-                let tinfo, ntic = this.generateTypeInfo(ftype.tkeystr, acc.1);
-                if(tinfo.tag === CPPAssembly::Tag#Ref) {
-                    return acc.0.update(8n, 1n, '1'), ntic;
-                }
-                return acc.0.update(tinfo.typesize, tinfo.slotsize, tinfo.ptrmask), ntic;
-            });
+                    let tinfo, ntic = this.generateTypeInfo(ftype.tkeystr, acc.1);
+                    if(tinfo.tag === CPPAssembly::Tag#Ref) {
+                        return acc.0.update(8n, 1n, '1'), ntic;
+                    }
+                    return acc.0.update(tinfo.typesize, tinfo.slotsize, tinfo.ptrmask), ntic;
+                });
     }
 
     recursive method generateTypeInfo(typekey: BSQAssembly::TypeKey, tic: TypeInfoContext): CPPAssembly::TypeInfo, TypeInfoContext { 
@@ -1027,22 +1045,22 @@ entity CPPTransformer {
             }
              
             let ant = this.bsqasm.lookupNominalTypeDeclaration(typekey);
-            let tag = if(this.shouldBeRef(ant.saturatedBFieldInfo, this.bsqasm)) 
-                then CPPAssembly::Tag#Ref 
-                else CPPAssembly::Tag#Value;
-
             if(this.bsqasm.isNominalTypeConcrete(typekey)) {            
                 if(this.bsqasm.entities.has(typekey) || this.bsqasm.datamembers.has(typekey)) {
-                    let finfo, ntic = this.generateFieldInfo(none, some(typekey), tic);
-                    var einfo = CPPAssembly::TypeInfo{ ntic.tid, finfo.typesize, finfo.slotsize, finfo.ptrmask, cpptkey, tag };
+                    let finfo, ntic = this.generateFieldInfo(none, some(typekey), false, tic);
+                    var einfo = CPPAssembly::TypeInfo{ ntic.tid, finfo.typesize, finfo.slotsize, finfo.ptrmask, cpptkey, this.determineTag(some(typekey), none) };
                     
                     return einfo, ntic.update(cpptkey, einfo);
                 }
                 elif(this.bsqasm.constructables.has(typekey)) { 
                     if(ant)@<BSQAssembly::SomeTypeDecl> {
-                        let oftypeinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, tic);
-                        let sometinfo = CPPAssembly::TypeInfo{ ntic.tid, oftypeinfo.typesize, oftypeinfo.slotsize, oftypeinfo.ptrmask, cpptkey, CPPAssembly::Tag#Value }; 
-
+                        let oftypeinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, false, tic);
+                        var sometinfo = CPPAssembly::TypeInfo{ ntic.tid, oftypeinfo.typesize, oftypeinfo.slotsize, oftypeinfo.ptrmask, cpptkey, CPPAssembly::Tag#Value }; 
+ 
+                        if(oftypeinfo.slotsize > reftypeThreshold) {
+                            sometinfo = CPPAssembly::TypeInfo{ ntic.tid, 8n, 1n, '1', cpptkey, CPPAssembly::Tag#Value }; 
+                        }
+                        
                         return sometinfo, ntic.update(cpptkey, sometinfo);
                     }
                     abort;
@@ -1080,7 +1098,7 @@ entity CPPTransformer {
                 }
                 elif(this.bsqasm.pconcepts.has(typekey)) {
                     if(ant)@<BSQAssembly::OptionTypeDecl> {
-                        let pcinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, tic);
+                        let pcinfo, ntic = this.generateFieldInfo(some($ant.oftype), none, false, tic);
                         let ptrmask = CPPTransformNameManager::repeatCString('0', pcinfo.slotsize, '2');
                         let pctinfo = CPPAssembly::TypeInfo{ ntic.tid, 8n + pcinfo.typesize, 1n + pcinfo.slotsize, ptrmask, cpptkey, CPPAssembly::Tag#Tagged };
 


### PR DESCRIPTION
This fixes my oversight of making concepts be always reference types, their type is now deduced by the subtype's tag stored in their type info.

Here is an example of typeinfo for `Node<Float>`:
```
    __CoreCpp::TypeInfoBase NodeᐸFloatᐳType = {
        .type_id = 28,
        .type_size = 128, 
        .slot_size = 16,
        .tag = __CoreCpp::Tag::Ref,
        .ptr_mask = "0020000002000000",
        .typekey = "ListOps::Node<Float>",
        .vtable = nullptr
    };

    // Nodes data
    Node { c: Color, count: Nat, l: Tree<Float>, r: Tree<Float> }
```
The data in this pointer mask is laid out like so 

`[color][count][typeinfo for left tree][possible left color][possible left count][possible node typeinfo][possible node pointer] [possible node typeinfo][possible node pointer][typeinfo for right tree] ... `

I believe this works nicely as there is enough space reserved to store a possible `Leaf<Float>` and `BBLeaf<Float>` inline and the possible left and right trees both being `Node<Float>`.

I also ran nbody through asan with these changes and detected no bad writes.