### PR TITLE
Emit Allocators for GC and Setup Build

### DIFF
--- a/build/build_cppemit.js
+++ b/build/build_cppemit.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { exec } from "node:child_process";
+import { exec, execSync } from "node:child_process";
 
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -12,6 +12,7 @@ const bsqdir = path.dirname(__dirname);
 const cmdpath = path.join(bsqdir, "bin/src/cmd/bosque.js");
 
 const binoutdir = path.join(bsqdir, "bin/cppemit");
+const cppruntimedir = path.join(bsqdir, "bin/cppruntime");
 
 const allsrcdirs = [
     path.join(bsqdir, "src/bsqir/asm"),
@@ -31,6 +32,8 @@ for(let i = 0; i < allsrcdirs.length; ++i) {
         }
     }
 }
+
+execSync(`make gc`, {cwd: cppruntimedir});
 
 exec(`node ${cmdpath} --namespace CPPEmitter --output ${binoutdir} ${allsources.join(" ")}`, {cwd: bsqdir}, (err, stdout, stderr) => {
     if(err !== null) {

--- a/build/resource_copy.js
+++ b/build/resource_copy.js
@@ -26,6 +26,7 @@ copyResourceDir("core/", "core/");
 copyResourceDir("backend/jsemitter/runtime/", "jsruntime/");
 copyResourceDir("backend/smtcore/runtime/", "smtruntime/");
 copyResourceDir("backend/cpp/runtime/", "cppruntime/");
+copyResourceDir("backend/cpp/gc/", "cppruntime/gc/");
 
 copyResourceDir("samples/", "samples/");
 

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -9,17 +9,19 @@ int wrap_setjmp() {
         std::cout << "Assertion failed! Or perhaps over/underflow?" << std::endl;
         return EXIT_FAILURE;
     }
+
+    gtl_info.initializeGC<sizeof(allocs) / sizeof(allocs[1])>(allocs);
+
+    // Calling our emitted main is hardcoded for now
+    __CoreCpp::MainType ret = Main::main();
+    std::cout << __CoreCpp::to_string(ret) << std::endl;
+
     return 0;
 }
 
 int main() {
     INIT_LOCKS();   
     InitBSQMemoryTheadLocalInfo();
-    gtl_info.initializeGC<sizeof(allocs) / sizeof(allocs[1])>(allocs);
-
-    // Calling our emitted main is hardcoded for now
-    __CoreCpp::MainType ret = Main::main();
-    std::cout << __CoreCpp::to_string(ret) << std::endl;
 
     return wrap_setjmp();
 }

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -1,3 +1,7 @@
+#include "emit.hpp"
+
+//CODE
+
 int main() {
     if(setjmp(__CoreCpp::info.error_handler)) { 
         // We may want to pass in some source info here and perhaps expression causing failure

--- a/src/backend/cpp/runtime/emit.cpp
+++ b/src/backend/cpp/runtime/emit.cpp
@@ -2,16 +2,24 @@
 
 //CODE
 
-int main() {
+// Prevents longjmp clobbering rbp in the gc
+int wrap_setjmp() {
     if(setjmp(__CoreCpp::info.error_handler)) { 
         // We may want to pass in some source info here and perhaps expression causing failure
         std::cout << "Assertion failed! Or perhaps over/underflow?" << std::endl;
         return EXIT_FAILURE;
     }
-   
+    return 0;
+}
+
+int main() {
+    INIT_LOCKS();   
+    InitBSQMemoryTheadLocalInfo();
+    gtl_info.initializeGC<sizeof(allocs) / sizeof(allocs[1])>(allocs);
+
     // Calling our emitted main is hardcoded for now
     __CoreCpp::MainType ret = Main::main();
     std::cout << __CoreCpp::to_string(ret) << std::endl;
 
-    return 0;
+    return wrap_setjmp();
 }

--- a/src/backend/cpp/runtime/emit.hpp
+++ b/src/backend/cpp/runtime/emit.hpp
@@ -1,0 +1,3 @@
+#include "cppruntime.hpp"
+#include "gc/src/runtime/memory/gc.h"
+#include "gc/src/runtime/memory/threadinfo.h"

--- a/src/backend/cpp/runtime/makefile
+++ b/src/backend/cpp/runtime/makefile
@@ -36,6 +36,14 @@ MEMORY_OBJS=$(OUT_OBJ)allocator.o $(OUT_OBJ)threadinfo.o $(OUT_OBJ)gc.o
 
 all: $(OUT_EXE)memex
 
+# Only builds the GC by executing a temporary file that does nothing
+gc: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(SUPPORT_OBJS) $(MEMORY_OBJS)
+	@mkdir -p $(OUT_EXE)
+	@echo "int main() { return 0; }" > $(OUT_EXE)gcmain.cpp
+	$(CC) $(CFLAGS) -o $(OUT_EXE)gctest $(SUPPORT_OBJS) $(MEMORY_OBJS) $(OUT_EXE)gcmain.cpp
+	@rm $(OUT_EXE)gcmain.cpp
+	@rm $(OUT_EXE)gctest
+
 $(OUT_EXE)memex: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(SUPPORT_OBJS) $(MEMORY_OBJS) $(CPPEMIT_DIR)emit.cpp
 	@mkdir -p $(OUT_EXE)
 	$(CC) $(CFLAGS) -o $(OUT_EXE)memex $(SUPPORT_OBJS) $(MEMORY_OBJS) $(CPPEMIT_DIR)emit.cpp

--- a/src/backend/cpp/runtime/makefile
+++ b/src/backend/cpp/runtime/makefile
@@ -1,14 +1,15 @@
 MAKE_PATH=$(realpath $(dir $(lastword $(MAKEFILE_LIST))))
-BUILD_DIR=$(MAKE_PATH)/
-BIN_DIR=$(MAKE_PATH)/../bin/
-SRC_DIR=$(MAKE_PATH)/../src/
+GC_PATH=$(MAKE_PATH)/gc
+BUILD_DIR=$(GC_PATH)/build/
+SRC_DIR=$(GC_PATH)/src/
+CPPEMIT_DIR=$(MAKE_PATH)/
 
 RUNTIME_DIR=$(SRC_DIR)runtime/
 SUPPORT_DIR=$(SRC_DIR)runtime/support/
 MEMORY_DIR=$(SRC_DIR)runtime/memory/
 
-OUT_EXE=$(BUILD_DIR)output/
-OUT_OBJ=$(BUILD_DIR)output/obj/
+OUT_EXE=$(MAKE_PATH)/output/
+OUT_OBJ=$(MAKE_PATH)/output/obj/
 
 TEST_DIR=$(MAKE_PATH)/../test/
 MEMORY_TEST_DIR=$(MAKE_PATH)/../test/memory/
@@ -35,19 +36,9 @@ MEMORY_OBJS=$(OUT_OBJ)allocator.o $(OUT_OBJ)threadinfo.o $(OUT_OBJ)gc.o
 
 all: $(OUT_EXE)memex
 
-test: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(SUPPORT_OBJS) $(MEMORY_OBJS)
-	@if [ -z "$(TEST)" ]; then \
-		echo "Error: Please specify a test file with TEST=<filename>."; \
-		exit 1; \
-	fi
+$(OUT_EXE)memex: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(SUPPORT_OBJS) $(MEMORY_OBJS) $(CPPEMIT_DIR)emit.cpp
 	@mkdir -p $(OUT_EXE)
-	$(CC) $(CFLAGS) -o $(OUT_EXE)$(TEST) $(SUPPORT_OBJS) $(MEMORY_OBJS) $(TEST_DIR)$(TEST).cpp
-	@echo "Running test: $(TEST)"
-	@$(OUT_EXE)$(TEST)
-
-$(OUT_EXE)memex: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(SUPPORT_OBJS) $(MEMORY_OBJS) $(MEMORY_TEST_DIR)memex.cpp
-	@mkdir -p $(OUT_EXE)
-	$(CC) $(CFLAGS) -o $(OUT_EXE)memex $(SUPPORT_OBJS) $(MEMORY_OBJS) $(MEMORY_TEST_DIR)memex.cpp
+	$(CC) $(CFLAGS) -o $(OUT_EXE)memex $(SUPPORT_OBJS) $(MEMORY_OBJS) $(CPPEMIT_DIR)emit.cpp
 
 $(OUT_OBJ)gc.o: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(MEMORY_DIR)gc.cpp
 	@mkdir -p $(OUT_OBJ)
@@ -70,4 +61,4 @@ $(OUT_OBJ)common.o: $(SUPPORT_HEADERS) $(RUNTIME_DIR)common.cpp
 	$(CC) $(CFLAGS) -o $(OUT_OBJ)common.o -c $(RUNTIME_DIR)common.cpp
 
 clean:
-	rm -rf $(OUT_EXE)* $(OUT_OBJ)*.o $(BIN_DIR)*
+	rm -rf $(OUT_EXE)

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -37,6 +37,10 @@ entity Context {
     }
 }
 
+function natToString(nat: Nat): String {
+    return String::fromCString(nat.toCString());
+}
+
 function emitEnclosedParen(s: CString): String {
     return String::fromCString(CString::concat('"', s, '"'));
 }
@@ -1829,6 +1833,23 @@ function emitAssembly(asm: CPPAssembly::Assembly): String {
         return String::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, ""));
     });
 
+    %% Various size allocators needed for the GC
+    var allocs, allocslist, allocmap = asm.typeinfos
+        .reduce<(|String, List<String>, Map<Nat, String>|)>((|"", List<String>{}, Map<Nat, String>{}|), fn(acc, tk, ti) => {
+            if(acc.2.has(ti.slotsize) || ti.slotsize == 0n) {
+                return acc;
+            }
+            
+            let name = String::concat("alloc", natToString(ti.slotsize));
+            let decl = String::concat("GCAllocator ", name);
+            let cons = String::concat(decl, "(", natToString(ti.typesize), ", REAL_ENTRY_SIZE(", natToString(ti.typesize), "), collect);%n;");
+
+            return String::concat(acc.0, cons), acc.1.pushBack(String::concat("&", name)), acc.2.insert(ti.slotsize, name);
+        });
+    let nallocslist = String::concat("GCAllocator* allocs[", natToString(allocmap.size()), "] = {", String::joinAll(", ", allocslist), "};%n;%n;");
+
+    let gcinfo = String::concat(allocs, nallocslist);
+
     %% We use this bold src so we can split our header and src files into two strings in analyzecpp
-    return String::concat(funcfwddecls, "𝐬𝐫𝐜", ns_emission);
+    return String::concat(funcfwddecls, "𝐬𝐫𝐜", gcinfo, ns_emission);
 }

--- a/src/cmd/analyzecpp.ts
+++ b/src/cmd/analyzecpp.ts
@@ -15,9 +15,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const bosque_dir: string = path.join(__dirname, "../../../");
 const cpp_transform_bin_path = path.join(bosque_dir, "bin/cppemit/CPPEmitter.mjs");
-const cpp_emit_runtime_src_path = path.join(bosque_dir, "bin/cppruntime/emit.cpp");
-const cpp_emit_runtime_header_path = path.join(bosque_dir, "bin/cppruntime/emit.hpp");
-const cpp_runtime_header_path = path.join(bosque_dir, "bin/cppruntime/cppruntime.hpp");
+const cpp_emit_runtime_path = path.join(bosque_dir, "bin/cppruntime/");
+const cpp_emit_runtime_src_path = path.join(cpp_emit_runtime_path, "emit.cpp");
+const cpp_emit_runtime_header_path = path.join(cpp_emit_runtime_path, "emit.hpp");
+const cpp_runtime_header_path = path.join(cpp_emit_runtime_path, "cppruntime.hpp");
+const makefile_path = path.join(cpp_emit_runtime_path, "makefile");
 const gc_path = path.join(bosque_dir, "bin/cppruntime/gc/");
 
 let fullargs = [...process.argv].slice(2);
@@ -63,14 +65,14 @@ function copyGC(src: string, dst: string) {
     });
 }
 
-function copyRuntime(outdir: string) {
-    const dir = path.normalize(outdir);
+function copyFile(src: string, dst: string) {
+    const dir = path.normalize(dst);
     if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
     }
 
-    const runtimeDstPath = path.join(dir, path.basename(cpp_runtime_header_path));
-    fs.copyFileSync(cpp_runtime_header_path, runtimeDstPath); 
+    const runtimeDstPath = path.join(dir, path.basename(src));
+    fs.copyFileSync(src, runtimeDstPath); 
 }
 
 function generateCPPFiles(header: string, src: string, outdir: string) {
@@ -110,7 +112,8 @@ function generateCPPFiles(header: string, src: string, outdir: string) {
 
     Status.output("    Copying GC and runtime files...\n");
     try {
-        copyRuntime(outdir);
+        copyFile(cpp_runtime_header_path, outdir);
+        copyFile(makefile_path, outdir);
         copyGC(gc_path, path.join(outdir, "gc/"));
     }
     catch(e) {

--- a/src/cmd/analyzecpp.ts
+++ b/src/cmd/analyzecpp.ts
@@ -21,6 +21,7 @@ const cpp_emit_runtime_header_path = path.join(cpp_emit_runtime_path, "emit.hpp"
 const cpp_runtime_header_path = path.join(cpp_emit_runtime_path, "cppruntime.hpp");
 const makefile_path = path.join(cpp_emit_runtime_path, "makefile");
 const gc_path = path.join(bosque_dir, "bin/cppruntime/gc/");
+const output_path = path.join(bosque_dir, "bin/cppruntime/output/");
 
 let fullargs = [...process.argv].slice(2);
 if(fullargs.length === 0) {
@@ -115,6 +116,7 @@ function generateCPPFiles(header: string, src: string, outdir: string) {
         copyFile(cpp_runtime_header_path, outdir);
         copyFile(makefile_path, outdir);
         copyGC(gc_path, path.join(outdir, "gc/"));
+        copyGC(output_path, path.join(outdir, "output/"));
     }
     catch(e) {
         Status.error("Failed to copy GC and runtime files!\n");


### PR DESCRIPTION
When running the cpp emitter we now emit all necessary allocator sizes for the gc of form 
`GCAllocator allocX(X, REAL_ENTRY_SIZE(X), collect)` (same format as the tests) at the top of the file and any of the necessary setup. And we now copy over the whole gc and `cppruntime.hpp` to `cppout/` when the user runs `analyzecpp.js`.

When the cpp emitter is built we also build all necessary gc obj files (preventing the need to rebuild the gc for every test).