### PR TITLE
Cpp Emission of Char Buffers

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -204,6 +204,23 @@ entity LiteralSimpleExpression provides Expression {
     field value: CString;
 }
 
+%% These should just be ropes (eventually)
+entity LiteralCStringExpression provides Expression {
+    field value: CString;
+}
+
+entity LiteralStringExpression provides Expression {
+    field value: CString;
+}
+
+entity LiteralCCharExpression provides Expression {
+    field value: CChar;
+}
+
+entity LiteralUnicodeCharExpression provides Expression {
+    field value: UnicodeChar;
+}
+
 entity LogicActionAndExpression provides Expression {
     field args: List<Expression>;
 }

--- a/src/backend/cpp/runtime/cppruntime.cpp
+++ b/src/backend/cpp/runtime/cppruntime.cpp
@@ -18,56 +18,56 @@ PathStack PathStack::up() const {
 CCharBuffer CCharBuffer::create_empty() {
     return {{}, 0};
 }
-CCharBuffer CCharBuffer::create_1(uint8_t c1) {
+CCharBuffer CCharBuffer::create_1(CChar c1) {
     return {{c1}, 1};
 }
-CCharBuffer CCharBuffer::create_2(uint8_t c1, uint8_t c2) {
+CCharBuffer CCharBuffer::create_2(CChar c1, CChar c2) {
     return {{c1, c2}, 2};
 }
-CCharBuffer CCharBuffer::create_3(uint8_t c1, uint8_t c2, uint8_t c3) {
+CCharBuffer CCharBuffer::create_3(CChar c1, CChar c2, CChar c3) {
     return {{c1, c2, c3}, 3};
 }
-CCharBuffer CCharBuffer::create_4(uint8_t c1, uint8_t c2, uint8_t c3, uint8_t c4) {
+CCharBuffer CCharBuffer::create_4(CChar c1, CChar c2, CChar c3, CChar c4) {
     return {{c1, c2, c3, c4}, 4};
 }
-CCharBuffer CCharBuffer::create_5(uint8_t c1, uint8_t c2, uint8_t c3, uint8_t c4, uint8_t c5) {
+CCharBuffer CCharBuffer::create_5(CChar c1, CChar c2, CChar c3, CChar c4, CChar c5) {
     return {{c1, c2, c3, c4, c5}, 5};
 }
-CCharBuffer CCharBuffer::create_6(uint8_t c1, uint8_t c2, uint8_t c3, uint8_t c4, uint8_t c5, uint8_t c6) {
+CCharBuffer CCharBuffer::create_6(CChar c1, CChar c2, CChar c3, CChar c4, CChar c5, CChar c6) {
     return {{c1, c2, c3, c4, c5, c6}, 6};
 }
-CCharBuffer CCharBuffer::create_7(uint8_t c1, uint8_t c2, uint8_t c3, uint8_t c4, uint8_t c5, uint8_t c6, uint8_t c7) {
+CCharBuffer CCharBuffer::create_7(CChar c1, CChar c2, CChar c3, CChar c4, CChar c5, CChar c6, CChar c7) {
     return {{c1, c2, c3, c4, c5, c6, c7}, 7};
 }
-CCharBuffer CCharBuffer::create_8(uint8_t c1, uint8_t c2, uint8_t c3, uint8_t c4, uint8_t c5, uint8_t c6, uint8_t c7, uint8_t c8) {
+CCharBuffer CCharBuffer::create_8(CChar c1, CChar c2, CChar c3, CChar c4, CChar c5, CChar c6, CChar c7, CChar c8) {
     return {{c1, c2, c3, c4, c5, c6, c7, c8}, 8};
 }
 
 UnicodeCharBuffer UnicodeCharBuffer::create_empty() {
     return {{}, 0};
 }
-UnicodeCharBuffer UnicodeCharBuffer::create_1(uint32_t c1) {
+UnicodeCharBuffer UnicodeCharBuffer::create_1(UnicodeChar c1) {
     return {{c1}, 1};
 }
-UnicodeCharBuffer UnicodeCharBuffer::create_2(uint32_t c1, uint32_t c2) {
+UnicodeCharBuffer UnicodeCharBuffer::create_2(UnicodeChar c1, UnicodeChar c2) {
     return {{c1, c2}, 2};
 }
-UnicodeCharBuffer UnicodeCharBuffer::create_3(uint32_t c1, uint32_t c2, uint32_t c3) {
+UnicodeCharBuffer UnicodeCharBuffer::create_3(UnicodeChar c1, UnicodeChar c2, UnicodeChar c3) {
     return {{c1, c2, c3}, 3};
 }
-UnicodeCharBuffer UnicodeCharBuffer::create_4(uint32_t c1, uint32_t c2, uint32_t c3, uint32_t c4) {
+UnicodeCharBuffer UnicodeCharBuffer::create_4(UnicodeChar c1, UnicodeChar c2, UnicodeChar c3, UnicodeChar c4) {
     return {{c1, c2, c3, c4}, 4};
 }
-UnicodeCharBuffer UnicodeCharBuffer::create_5(uint32_t c1, uint32_t c2, uint32_t c3, uint32_t c4, uint32_t c5) {
+UnicodeCharBuffer UnicodeCharBuffer::create_5(UnicodeChar c1, UnicodeChar c2, UnicodeChar c3, UnicodeChar c4, UnicodeChar c5) {
     return {{c1, c2, c3, c4, c5}, 5};
 }
-UnicodeCharBuffer UnicodeCharBuffer::create_6(uint32_t c1, uint32_t c2, uint32_t c3, uint32_t c4, uint32_t c5, uint32_t c6) {
+UnicodeCharBuffer UnicodeCharBuffer::create_6(UnicodeChar c1, UnicodeChar c2, UnicodeChar c3, UnicodeChar c4, UnicodeChar c5, UnicodeChar c6) {
     return {{c1, c2, c3, c4, c5, c6}, 6};
 }
-UnicodeCharBuffer UnicodeCharBuffer::create_7(uint32_t c1, uint32_t c2, uint32_t c3, uint32_t c4, uint32_t c5, uint32_t c6, uint32_t c7) {
+UnicodeCharBuffer UnicodeCharBuffer::create_7(UnicodeChar c1, UnicodeChar c2, UnicodeChar c3, UnicodeChar c4, UnicodeChar c5, UnicodeChar c6, UnicodeChar c7) {
     return {{c1, c2, c3, c4, c5, c6, c7}, 7};
 }
-UnicodeCharBuffer UnicodeCharBuffer::create_8(uint32_t c1, uint32_t c2, uint32_t c3, uint32_t c4, uint32_t c5, uint32_t c6, uint32_t c7, uint32_t c8) {
+UnicodeCharBuffer UnicodeCharBuffer::create_8(UnicodeChar c1, UnicodeChar c2, UnicodeChar c3, UnicodeChar c4, UnicodeChar c5, UnicodeChar c6, UnicodeChar c7, UnicodeChar c8) {
     return {{c1, c2, c3, c4, c5, c6, c7, c8}, 8};
 }
 

--- a/src/backend/cpp/runtime/cppruntime.cpp
+++ b/src/backend/cpp/runtime/cppruntime.cpp
@@ -2,6 +2,8 @@
 
 namespace __CoreCpp {
 
+ThreadLocalInfo& info = ThreadLocalInfo::get();
+    
 PathStack PathStack::create() {
     return {0, 0};
 }
@@ -71,4 +73,41 @@ UnicodeCharBuffer UnicodeCharBuffer::create_8(UnicodeChar c1, UnicodeChar c2, Un
     return {{c1, c2, c3, c4, c5, c6, c7, c8}, 8};
 }
 
+std::string to_string(MainType v) noexcept {
+    if(std::holds_alternative<bool>(v)) {
+        bool res = std::get<bool>(v);
+        if(!res) {
+            return "false";
+        }
+        return "true";
+    }
+    else if(std::holds_alternative<Int>(v)) {
+        return std::to_string(std::get<Int>(v).get()) + "_i";
+    }
+    else if (std::holds_alternative<Nat>(v)) {
+        return std::to_string(std::get<Nat>(v).get()) + "_n";
+    }
+    else if (std::holds_alternative<Float>(v)) {
+        return std::to_string(std::get<Float>(v).get()) + "_f";
+    }
+    else if(std::holds_alternative<BigInt>(v)) {
+        __int128_t res = std::get<BigInt>(v).get();
+        return t_to_string<__int128_t>(res) + "_I";
+    }
+    else if(std::holds_alternative<BigNat>(v)) {
+        __int128_t res = std::get<BigNat>(v).get();
+        return t_to_string<__uint128_t>(res) + "_N";
+    }
+    else {
+        return "Unable to print main return type!\n";
+    }
+}
+
 } // namespace __CoreCpp
+
+// For debugging
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::Int& t) { return os << t.get() << "_i"; }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::BigInt& t) { return os << __CoreCpp::t_to_string<__int128_t>(t.get()) << "_I"; }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::Nat& t) { return os << t.get() << "_n"; }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::BigNat& t) { return os << __CoreCpp::t_to_string<__uint128_t>(t.get()) << "_N"; }
+std::ostream& operator<<(std::ostream &os, const __CoreCpp::Float& t) { return os << t.get() << "_f"; }

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -261,6 +261,7 @@ public:
 typedef uintptr_t None;
 typedef bool Bool;
 typedef uint8_t CChar;
+typedef uint32_t UnicodeChar;
 
 #define MAX_BSQ_INT ((int64_t(1) << 62) - 1)
 #define MIN_BSQ_INT (-(int64_t(1) << 62) + 1) 
@@ -631,33 +632,33 @@ struct PathStack {
 
 // We say for now no more than 8 chars, may want to make this dynamically pick 8 or 16 max
 struct CCharBuffer {
-    uint8_t chars[8];
+    CChar chars[8];
     int size;
 
     static CCharBuffer create_empty();
-    static CCharBuffer create_1(uint8_t c1);
-    static CCharBuffer create_2(uint8_t c1, uint8_t c2);
-    static CCharBuffer create_3(uint8_t c1, uint8_t c2, uint8_t c3);
-    static CCharBuffer create_4(uint8_t c1, uint8_t c2, uint8_t c3, uint8_t c4);
-    static CCharBuffer create_5(uint8_t c1, uint8_t c2, uint8_t c3, uint8_t c4, uint8_t c5);
-    static CCharBuffer create_6(uint8_t c1, uint8_t c2, uint8_t c3, uint8_t c4, uint8_t c5, uint8_t c6);
-    static CCharBuffer create_7(uint8_t c1, uint8_t c2, uint8_t c3, uint8_t c4, uint8_t c5, uint8_t c6, uint8_t c7);
-    static CCharBuffer create_8(uint8_t c1, uint8_t c2, uint8_t c3, uint8_t c4, uint8_t c5, uint8_t c6, uint8_t c7, uint8_t c8);
+    static CCharBuffer create_1(CChar c1);
+    static CCharBuffer create_2(CChar c1, CChar c2);
+    static CCharBuffer create_3(CChar c1, CChar c2, CChar c3);
+    static CCharBuffer create_4(CChar c1, CChar c2, CChar c3, CChar c4);
+    static CCharBuffer create_5(CChar c1, CChar c2, CChar c3, CChar c4, CChar c5);
+    static CCharBuffer create_6(CChar c1, CChar c2, CChar c3, CChar c4, CChar c5, CChar c6);
+    static CCharBuffer create_7(CChar c1, CChar c2, CChar c3, CChar c4, CChar c5, CChar c6, CChar c7);
+    static CCharBuffer create_8(CChar c1, CChar c2, CChar c3, CChar c4, CChar c5, CChar c6, CChar c7, CChar c8);
 };
 
 struct UnicodeCharBuffer {
-    uint32_t chars[8];
+    UnicodeChar chars[8];
     int size;
 
     static UnicodeCharBuffer create_empty();
-    static UnicodeCharBuffer create_1(uint32_t c1);
-    static UnicodeCharBuffer create_2(uint32_t c1, uint32_t c2);
-    static UnicodeCharBuffer create_3(uint32_t c1, uint32_t c2, uint32_t c3);
-    static UnicodeCharBuffer create_4(uint32_t c1, uint32_t c2, uint32_t c3, uint32_t c4);
-    static UnicodeCharBuffer create_5(uint32_t c1, uint32_t c2, uint32_t c3, uint32_t c4, uint32_t c5);
-    static UnicodeCharBuffer create_6(uint32_t c1, uint32_t c2, uint32_t c3, uint32_t c4, uint32_t c5, uint32_t c6);
-    static UnicodeCharBuffer create_7(uint32_t c1, uint32_t c2, uint32_t c3, uint32_t c4, uint32_t c5, uint32_t c6, uint32_t c7);
-    static UnicodeCharBuffer create_8(uint32_t c1, uint32_t c2, uint32_t c3, uint32_t c4, uint32_t c5, uint32_t c6, uint32_t c7, uint32_t c8);
+    static UnicodeCharBuffer create_1(UnicodeChar c1);
+    static UnicodeCharBuffer create_2(UnicodeChar c1, UnicodeChar c2);
+    static UnicodeCharBuffer create_3(UnicodeChar c1, UnicodeChar c2, UnicodeChar c3);
+    static UnicodeCharBuffer create_4(UnicodeChar c1, UnicodeChar c2, UnicodeChar c3, UnicodeChar c4);
+    static UnicodeCharBuffer create_5(UnicodeChar c1, UnicodeChar c2, UnicodeChar c3, UnicodeChar c4, UnicodeChar c5);
+    static UnicodeCharBuffer create_6(UnicodeChar c1, UnicodeChar c2, UnicodeChar c3, UnicodeChar c4, UnicodeChar c5, UnicodeChar c6);
+    static UnicodeCharBuffer create_7(UnicodeChar c1, UnicodeChar c2, UnicodeChar c3, UnicodeChar c4, UnicodeChar c5, UnicodeChar c6, UnicodeChar c7);
+    static UnicodeCharBuffer create_8(UnicodeChar c1, UnicodeChar c2, UnicodeChar c3, UnicodeChar c4, UnicodeChar c5, UnicodeChar c6, UnicodeChar c7, UnicodeChar c8);
 };
 
 //

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -260,6 +260,7 @@ public:
 
 typedef uintptr_t None;
 typedef bool Bool;
+typedef uint8_t CChar;
 
 #define MAX_BSQ_INT ((int64_t(1) << 62) - 1)
 #define MIN_BSQ_INT (-(int64_t(1) << 62) + 1) 

--- a/src/backend/cpp/runtime/makefile
+++ b/src/backend/cpp/runtime/makefile
@@ -40,10 +40,10 @@ CPPEMIT_OBJS=$(OUT_OBJ)cppruntime.o
 all: $(OUT_EXE)memex
 
 # Only builds the GC by executing a temporary file that does nothing
-gc: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(SUPPORT_OBJS) $(MEMORY_OBJS) $(CPPEMIT_OBJS)
+gc: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(CPPEMIT_HEADERS) $(SUPPORT_OBJS) $(MEMORY_OBJS) $(CPPEMIT_OBJS)
 	@mkdir -p $(OUT_EXE)
 	@echo "int main() { return 0; }" > $(OUT_EXE)gcmain.cpp
-	$(CC) $(CFLAGS) -o $(OUT_EXE)gctest $(SUPPORT_OBJS) $(MEMORY_OBJS) $(OUT_EXE)gcmain.cpp
+	$(CC) $(CFLAGS) -o $(OUT_EXE)gctest $(SUPPORT_OBJS) $(MEMORY_OBJS) $(CPPEMIT_OBJS) $(OUT_EXE)gcmain.cpp
 	@rm $(OUT_EXE)gcmain.cpp
 	@rm $(OUT_EXE)gctest
 

--- a/src/backend/cpp/runtime/makefile
+++ b/src/backend/cpp/runtime/makefile
@@ -34,19 +34,22 @@ MEMORY_HEADERS=$(RUNTIME_DIR)common.h $(MEMORY_DIR)allocator.h $(MEMORY_DIR)thre
 MEMORY_SOURCES=$(MEMORY_DIR)allocator.cpp $(MEMORY_DIR)threadinfo.cpp $(MEMORY_DIR)gc.cpp
 MEMORY_OBJS=$(OUT_OBJ)allocator.o $(OUT_OBJ)threadinfo.o $(OUT_OBJ)gc.o 
 
+CPPEMIT_HEADERS=$(CPPEMIT_DIR)cppruntime.hpp
+CPPEMIT_OBJS=$(OUT_OBJ)cppruntime.o
+
 all: $(OUT_EXE)memex
 
 # Only builds the GC by executing a temporary file that does nothing
-gc: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(SUPPORT_OBJS) $(MEMORY_OBJS)
+gc: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(SUPPORT_OBJS) $(MEMORY_OBJS) $(CPPEMIT_OBJS)
 	@mkdir -p $(OUT_EXE)
 	@echo "int main() { return 0; }" > $(OUT_EXE)gcmain.cpp
 	$(CC) $(CFLAGS) -o $(OUT_EXE)gctest $(SUPPORT_OBJS) $(MEMORY_OBJS) $(OUT_EXE)gcmain.cpp
 	@rm $(OUT_EXE)gcmain.cpp
 	@rm $(OUT_EXE)gctest
 
-$(OUT_EXE)memex: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(SUPPORT_OBJS) $(MEMORY_OBJS) $(CPPEMIT_DIR)emit.cpp
+$(OUT_EXE)memex: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(CPPEMIT_HEADERS) $(SUPPORT_OBJS) $(MEMORY_OBJS) $(CPPEMIT_OBJS) $(CPPEMIT_DIR)emit.cpp
 	@mkdir -p $(OUT_EXE)
-	$(CC) $(CFLAGS) -o $(OUT_EXE)memex $(SUPPORT_OBJS) $(MEMORY_OBJS) $(CPPEMIT_DIR)emit.cpp
+	$(CC) $(CFLAGS) -o $(OUT_EXE)memex $(SUPPORT_OBJS) $(MEMORY_OBJS) $(CPPEMIT_OBJS) $(CPPEMIT_DIR)emit.cpp
 
 $(OUT_OBJ)gc.o: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(MEMORY_DIR)gc.cpp
 	@mkdir -p $(OUT_OBJ)
@@ -67,6 +70,10 @@ $(OUT_OBJ)xalloc.o: $(SUPPORT_HEADERS) $(SUPPORT_DIR)xalloc.cpp
 $(OUT_OBJ)common.o: $(SUPPORT_HEADERS) $(RUNTIME_DIR)common.cpp
 	@mkdir -p $(OUT_OBJ)
 	$(CC) $(CFLAGS) -o $(OUT_OBJ)common.o -c $(RUNTIME_DIR)common.cpp
+
+$(OUT_OBJ)cppruntime.o: $(CPPEMIT_HEADERS) $(CPPEMIT_DIR)cppruntime.cpp 
+	@mkdir -p $(OUT_OBJ)
+	$(CC) $(CFLAGS) -o $(OUT_OBJ)cppruntime.o -c $(CPPEMIT_DIR)cppruntime.cpp
 
 clean:
 	rm -rf $(OUT_EXE)

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -990,7 +990,7 @@ function emitLiteralCCharExpression(exp: CPPAssembly::LiteralCCharExpression): S
 }
 
 function emitLiteralUnicodeCharExpression(exp: CPPAssembly::LiteralUnicodeCharExpression): String {
-    abort; %% TODO: Once ropes for CStrings work we will need unicode char emission support
+    return String::concat("U'", String::fromUnicodeChar(exp.value), "'");
 }
 
 function emitExpression(e: CPPAssembly::Expression, ctx: Context): String {
@@ -1297,6 +1297,15 @@ function emitBuiltinBodyImplementation(body: CPPAssembly::BuiltinBodyImplementat
         | "ccharbuffer_create_6" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_3(c1, c2, c3, c4, c5, c6);", ); }
         | "ccharbuffer_create_7" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_3(c1, c2, c3, c4, c5, c6, c7);", ); }
         | "ccharbuffer_create_8" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_3(c1, c2, c3, c4, c5, c6, c7, c8);", ); }
+        | "unicodecharbuffer_create_empty" => { return String::concat(indent, "    return __CoreCpp::UnicodeCharBuffer::create_empty();", ); }
+        | "unicodecharbuffer_create_1" => { return String::concat(indent, "    return __CoreCpp::UnicodeCharBuffer::create_3(c1);", ); }
+        | "unicodecharbuffer_create_2" => { return String::concat(indent, "    return __CoreCpp::UnicodeCharBuffer::create_3(c1, c2);", ); }
+        | "unicodecharbuffer_create_3" => { return String::concat(indent, "    return __CoreCpp::UnicodeCharBuffer::create_3(c1, c2, c3);", ); }
+        | "unicodecharbuffer_create_4" => { return String::concat(indent, "    return __CoreCpp::UnicodeCharBuffer::create_3(c1, c2, c3, c4);", ); }
+        | "unicodecharbuffer_create_5" => { return String::concat(indent, "    return __CoreCpp::UnicodeCharBuffer::create_3(c1, c2, c3, c4, c5);", ); }
+        | "unicodecharbuffer_create_6" => { return String::concat(indent, "    return __CoreCpp::UnicodeCharBuffer::create_3(c1, c2, c3, c4, c5, c6);", ); }
+        | "unicodecharbuffer_create_7" => { return String::concat(indent, "    return __CoreCpp::UnicodeCharBuffer::create_3(c1, c2, c3, c4, c5, c6, c7);", ); }
+        | "unicodecharbuffer_create_8" => { return String::concat(indent, "    return __CoreCpp::UnicodeCharBuffer::create_3(c1, c2, c3, c4, c5, c6, c7, c8);", ); }
         | _ => { abort; } %% TODO: Not implemented
     }
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1288,8 +1288,15 @@ function emitBuiltinBodyImplementation(body: CPPAssembly::BuiltinBodyImplementat
     switch(String::fromCString(body.builtin)) {
         "s_float_power" => { return String::concat(indent, "    ", "return __CoreCpp::Float(powf64(a.get(), b.get()));%n;"); }
         | "s_float_sqrt" => { return String::concat(indent, "    ", "return __CoreCpp::Float(sqrtf64(a.get()));%n;"); }
-        | "ccharbuffer_create_3" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_3(
-            static_cast<uint8_t>(c1), static_cast<uint8_t>(c2), static_cast<uint8_t>(c3));", ); }
+        | "ccharbuffer_create_empty" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_empty();", ); }
+        | "ccharbuffer_create_1" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_3(c1);", ); }
+        | "ccharbuffer_create_2" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_3(c1, c2);", ); }
+        | "ccharbuffer_create_3" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_3(c1, c2, c3);", ); }
+        | "ccharbuffer_create_4" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_3(c1, c2, c3, c4);", ); }
+        | "ccharbuffer_create_5" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_3(c1, c2, c3, c4, c5);", ); }
+        | "ccharbuffer_create_6" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_3(c1, c2, c3, c4, c5, c6);", ); }
+        | "ccharbuffer_create_7" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_3(c1, c2, c3, c4, c5, c6, c7);", ); }
+        | "ccharbuffer_create_8" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_3(c1, c2, c3, c4, c5, c6, c7, c8);", ); }
         | _ => { abort; } %% TODO: Not implemented
     }
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -315,7 +315,6 @@ function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression):
         | "__CoreCpp::BigNat" => { return String::concat(val, "_N"); }
         | "__CoreCpp::Float" => { return String::concat(val, "_f"); }
         | "__CoreCpp::Bool" => { return val; }
-        | "__CoreCpp::CChar" => { return val; }
         | _ => { abort; }
     }
 }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -315,6 +315,7 @@ function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression):
         | "__CoreCpp::BigNat" => { return String::concat(val, "_N"); }
         | "__CoreCpp::Float" => { return String::concat(val, "_f"); }
         | "__CoreCpp::Bool" => { return val; }
+        | "__CoreCpp::CChar" => { return val; }
         | _ => { abort; }
     }
 }
@@ -984,12 +985,22 @@ function emitLambdaInvokeExpression(exp: CPPAssembly::LambdaInvokeExpression, ct
     return String::concat(name, "( ", args, " )");
 }
 
+function emitLiteralCCharExpression(exp: CPPAssembly::LiteralCCharExpression): String {
+    return String::concat("'", String::fromCChar(exp.value), "'");
+}
+
+function emitLiteralUnicodeCharExpression(exp: CPPAssembly::LiteralUnicodeCharExpression): String {
+    abort; %% TODO: Once ropes for CStrings work we will need unicode char emission support
+}
+
 function emitExpression(e: CPPAssembly::Expression, ctx: Context): String {
     match(e)@ {
         CPPAssembly::LiteralNoneExpression => { return emitLiteralNoneExpression($e, ctx); }
         | CPPAssembly::LiteralSimpleExpression => { return emitLiteralSimpleExpression($e); }
         %%| CPPAssembly::LiteralCCharExpression => { abort; }
         %%| CPPAssembly::LiteralUnicodeCharExpression => { abort; }
+        | CPPAssembly::LiteralCCharExpression => { return emitLiteralCCharExpression($e); }
+        | CPPAssembly::LiteralUnicodeCharExpression => { return emitLiteralUnicodeCharExpression($e); }
         %%| CPPAssembly::LiteralCStringExpression => { abort; }
         %%| CPPAssembly::LiteralStringExpression => { abort; }
         %%| CPPAssembly::LiteralCRegexExpression => { abort; }
@@ -1277,6 +1288,8 @@ function emitBuiltinBodyImplementation(body: CPPAssembly::BuiltinBodyImplementat
     switch(String::fromCString(body.builtin)) {
         "s_float_power" => { return String::concat(indent, "    ", "return __CoreCpp::Float(powf64(a.get(), b.get()));%n;"); }
         | "s_float_sqrt" => { return String::concat(indent, "    ", "return __CoreCpp::Float(sqrtf64(a.get()));%n;"); }
+        | "ccharbuffer_create_3" => { return String::concat(indent, "    return __CoreCpp::CCharBuffer::create_3(
+            static_cast<uint8_t>(c1), static_cast<uint8_t>(c2), static_cast<uint8_t>(c3));", ); }
         | _ => { abort; } %% TODO: Not implemented
     }
 }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -21,6 +21,10 @@ namespace CPPTransformNameManager {
             | 'BigNat' => { return CPPAssembly::TypeKey::from('__CoreCpp::BigNat'); }
             | 'BigInt' => { return CPPAssembly::TypeKey::from('__CoreCpp::BigInt'); }
             | 'Float' => { return CPPAssembly::TypeKey::from('__CoreCpp::Float'); }
+            | 'CChar' => { return CPPAssembly::TypeKey::from('__CoreCpp::CChar'); }
+            | 'UnicodeChar' => { return CPPAssembly::TypeKey::from('__CoreCpp::UnicodeChar'); }
+            | 'CCharBuffer' => { return CPPAssembly::TypeKey::from('__CoreCpp::CCharBuffer'); }
+            | 'UnicodeCharBuffer' => { return CPPAssembly::TypeKey::from('__CoreCpp::UnicodeCharBuffer'); }
             | _ => { return CPPAssembly::TypeKey::from(tk.value); } 
         }
     }
@@ -35,6 +39,10 @@ namespace CPPTransformNameManager {
             | '__CoreCpp::BigNat' => { return BSQAssembly::TypeKey::from('BigNat'); }
             | '__CoreCpp::BigInt' => { return BSQAssembly::TypeKey::from('BigInt'); }
             | '__CoreCpp::Float' => { return BSQAssembly::TypeKey::from('Float'); }
+            | '__CoreCpp::CChar' => { return BSQAssembly::TypeKey::from('CChar'); }
+            | '__CoreCpp::UnicodeChar' => { return BSQAssembly::TypeKey::from('UnicodeChar'); }
+            | '__CoreCpp::CCharBuffer' => { return BSQAssembly::TypeKey::from('CCharBuffer'); }
+            | '__CoreCpp::UnicodeCharBuffer' => { return BSQAssembly::TypeKey::from('UnicodeCharBuffer'); }
             | _ => { return BSQAssembly::TypeKey::from(tk.value); }
         }
     }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -1048,6 +1048,9 @@ entity CPPTransformer {
                 return tic.tinfos.get(cpptkey), tic;
             }
             
+            %%
+            %% NOTE: If we decide to make our char buffers support 16 characters this will break
+            %%
             if(this.bsqasm.isPrimtitiveType(typekey)) {
                 var matchedType: CPPAssembly::TypeInfo;
                 switch(typekey) {
@@ -1061,7 +1064,7 @@ entity CPPTransformer {
                     | 'CChar'<BSQAssembly::TypeKey> =>  { matchedType = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
                     | 'CCharBuffer'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
                     | 'UnicodeChar'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
-                    | 'UnicodeCharBuffer'<BSQAssembly::TypeKey> => { abort; }
+                    | 'UnicodeCharBuffer'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{tic.tid, 32n, 4n, '0000', cpptkey, CPPAssembly::Tag#Value }; }
                     | _ => { abort; } %% Not supported by cpp emitter yet!
                 }
 

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -618,14 +618,34 @@ entity CPPTransformer {
         return CPPAssembly::AccessCapturedVariableExpression{ etype, vname };
     }
 
+    method transformLiteralCStringExpression(exp: BSQAssembly::LiteralCStringExpression): CPPAssembly::LiteralCStringExpression {
+        abort; %% TODO: Lacking ropes so this is an abort for now
+    }
+
+    method transformLiteralStringExpression(exp: BSQAssembly::LiteralStringExpression): CPPAssembly::LiteralStringExpression {
+        abort; %% TODO: Lacking ropes so this is an abort for now
+    }
+
+    method transformLiteralCCharExpression(exp: BSQAssembly::LiteralCCharExpression): CPPAssembly::LiteralCCharExpression {
+        let etype = this.convertTypeSignature(exp.etype); 
+        return CPPAssembly::LiteralCCharExpression{ etype, exp.value };
+    }
+
+    method transformLiteralUnicodeCharExpression(exp: BSQAssembly::LiteralUnicodeCharExpression): CPPAssembly::LiteralUnicodeCharExpression {
+        let etype = this.convertTypeSignature(exp.etype);
+        return CPPAssembly::LiteralUnicodeCharExpression{ etype, exp.value };
+    }
+
     recursive method transformExpressionToCpp(expr: BSQAssembly::Expression): CPPAssembly::Expression {
         match(expr)@ {
             BSQAssembly::LiteralNoneExpression => { return this.transformLiteralNoneExpression($expr); }
             | BSQAssembly::LiteralSimpleExpression => { return this.transformLiteralSimpleExpression($expr); }
-            | BSQAssembly::LiteralCCharExpression => { abort; }
-            | BSQAssembly::LiteralUnicodeCharExpression => { abort; }
-            | BSQAssembly::LiteralCStringExpression => { abort; }
-            | BSQAssembly::LiteralStringExpression => { abort; }
+            | BSQAssembly::LiteralCCharExpression => { return this.transformLiteralCCharExpression($expr); }
+            | BSQAssembly::LiteralUnicodeCharExpression => { return this.transformLiteralUnicodeCharExpression($expr); }
+            | BSQAssembly::LiteralCStringExpression => { return this.transformLiteralCStringExpression($expr); }
+            | BSQAssembly::LiteralStringExpression => { return this.transformLiteralStringExpression($expr); }
+            | BSQAssembly::LiteralCCharExpression => { return this.transformLiteralCCharExpression($expr); }
+            | BSQAssembly::LiteralUnicodeCharExpression => { return this.transformLiteralUnicodeCharExpression($expr); }
             | BSQAssembly::LiteralCRegexExpression => { abort; }
             | BSQAssembly::LiteralRegexExpression => { abort; }
             | BSQAssembly::LiteralTypeDeclValueExpression => { abort; }
@@ -1030,6 +1050,10 @@ entity CPPTransformer {
                     | 'BigNat'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
                     | 'BigInt'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ tic.tid, 16n, 2n,'00', cpptkey, CPPAssembly::Tag#Value }; }
                     | 'Float'<BSQAssembly::TypeKey> =>  { matchedType = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                    | 'CChar'<BSQAssembly::TypeKey> =>  { matchedType = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                    | 'CCharBuffer'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                    | 'UnicodeChar'<BSQAssembly::TypeKey> => { matchedType = CPPAssembly::TypeInfo{ tic.tid, 8n, 1n, '0', cpptkey, CPPAssembly::Tag#Value }; }
+                    | 'UnicodeCharBuffer'<BSQAssembly::TypeKey> => { abort; }
                     | _ => { abort; } %% Not supported by cpp emitter yet!
                 }
 

--- a/src/backend/jsemitter/jsemitter.ts
+++ b/src/backend/jsemitter/jsemitter.ts
@@ -2339,6 +2339,9 @@ class JSEmitter {
         else if(bname === "string_from_cstring") {
             bop = `s`;
         }
+        else if(bname === "string_from_cchar") {
+            bop = `s`
+        }
         else if(bname === "string_empty") {
             bop = `s === ""`;
         }

--- a/src/backend/jsemitter/jsemitter.ts
+++ b/src/backend/jsemitter/jsemitter.ts
@@ -2342,6 +2342,9 @@ class JSEmitter {
         else if(bname === "string_from_cchar") {
             bop = `s`
         }
+        else if(bname === "string_from_unicodechar") {
+            bop = `s`
+        }
         else if(bname === "string_empty") {
             bop = `s === ""`;
         }

--- a/src/bsqir/asm/body.bsq
+++ b/src/bsqir/asm/body.bsq
@@ -70,11 +70,11 @@ entity LiteralSimpleExpression provides Expression {
 }
 
 entity LiteralCCharExpression provides Expression {
-    field value: CString;
+    field value: CChar;
 }
 
 entity LiteralUnicodeCharExpression provides Expression {
-    field value: String;
+    field value: UnicodeChar;
 }
 
 entity LiteralCStringExpression provides Expression {

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -749,7 +749,9 @@ entity ConstantSimplification {
             LiteralNoneExpression => { return e; }
             | LiteralSimpleExpression => { return e; }
             | LiteralCStringExpression => { return e; }
-            | LiteralStringExpression => { return e; }  
+            | LiteralStringExpression => { return e; }
+            | LiteralCCharExpression => { return e; }
+            | LiteralUnicodeCharExpression => { return e; }
             | LiteralCRegexExpression => { return e; }
             | LiteralRegexExpression => { return e; }
             | LiteralTypeDeclValueExpression => { return e; }

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -572,6 +572,8 @@ entity ExplicitifyTransform {
             | LiteralSimpleExpression => { return e; }
             | LiteralCStringExpression => { return e; }
             | LiteralStringExpression => { return e; }
+            | LiteralCCharExpression => { return e; }
+            | LiteralUnicodeCharExpression => { return e; }
             | LiteralCRegexExpression => { return e; }
             | LiteralRegexExpression => { return e; }
             | LiteralTypeDeclValueExpression => { return e; }

--- a/src/cmd/analyzecpp.ts
+++ b/src/cmd/analyzecpp.ts
@@ -19,6 +19,7 @@ const cpp_emit_runtime_path = path.join(bosque_dir, "bin/cppruntime/");
 const cpp_emit_runtime_src_path = path.join(cpp_emit_runtime_path, "emit.cpp");
 const cpp_emit_runtime_header_path = path.join(cpp_emit_runtime_path, "emit.hpp");
 const cpp_runtime_header_path = path.join(cpp_emit_runtime_path, "cppruntime.hpp");
+const cpp_runtime_source_path = path.join(cpp_emit_runtime_path, "cppruntime.cpp");
 const makefile_path = path.join(cpp_emit_runtime_path, "makefile");
 const gc_path = path.join(bosque_dir, "bin/cppruntime/gc/");
 const output_path = path.join(bosque_dir, "bin/cppruntime/output/");
@@ -114,6 +115,7 @@ function generateCPPFiles(header: string, src: string, outdir: string) {
     Status.output("    Copying GC and runtime files...\n");
     try {
         copyFile(cpp_runtime_header_path, outdir);
+        copyFile(cpp_runtime_source_path, outdir);
         copyFile(makefile_path, outdir);
         copyGC(gc_path, path.join(outdir, "gc/"));
         copyGC(output_path, path.join(outdir, "output/"));

--- a/src/core/core.bsq
+++ b/src/core/core.bsq
@@ -136,6 +136,15 @@ __internal __typedeclable __keycomparable entity String {
         return StringOps::s_fromCString(s);
     }
 
+    %** Convert a CChar to a String **%
+    function fromCChar(s: CChar): String {
+        return StringOps::s_fromCChar(s);
+    }
+
+    %%
+    %% TODO: Will need a UnicodeChar -> String function too
+    %%
+
     %** Check if the string is empty **%
     method empty(): Bool {
         return StringOps::s_empty(this);

--- a/src/core/core.bsq
+++ b/src/core/core.bsq
@@ -145,9 +145,10 @@ __internal __typedeclable __keycomparable entity String {
         return StringOps::s_fromCChar(s);
     }
 
-    %%
-    %% TODO: Will need a UnicodeChar -> String function too
-    %%
+    %** Convert a UnicodeChar to a String **%
+    function fromUnicodeChar(s: UnicodeChar): String {
+        return StringOps::s_fromUnicodeChar(s);
+    }
 
     %** Check if the string is empty **%
     method empty(): Bool {

--- a/src/core/core.bsq
+++ b/src/core/core.bsq
@@ -127,6 +127,10 @@ __internal __typedeclable __keycomparable entity CChar {
 __internal __typedeclable __keycomparable entity UnicodeChar { 
 }
 
+%%
+%% May need to add CCharBuffer and UnicodeCharBuffer?
+%%
+
 %** Primitive string value. **%
 __internal __typedeclable __keycomparable entity String {
     #if STRIPPED_CORE

--- a/src/core/core.bsq
+++ b/src/core/core.bsq
@@ -127,10 +127,6 @@ __internal __typedeclable __keycomparable entity CChar {
 __internal __typedeclable __keycomparable entity UnicodeChar { 
 }
 
-%%
-%% May need to add CCharBuffer and UnicodeCharBuffer?
-%%
-
 %** Primitive string value. **%
 __internal __typedeclable __keycomparable entity String {
     #if STRIPPED_CORE

--- a/src/core/xcore_string_exec.bsq
+++ b/src/core/xcore_string_exec.bsq
@@ -18,6 +18,7 @@ namespace UnicodeCharBufferOps {
 
 namespace StringOps {
     function s_fromCString(s: CString): String = string_from_cstring;
+    function s_fromCChar(s: CChar): String = string_from_cchar;
 
     function s_empty(s: String): Bool = string_empty;
 

--- a/src/core/xcore_string_exec.bsq
+++ b/src/core/xcore_string_exec.bsq
@@ -19,6 +19,7 @@ namespace UnicodeCharBufferOps {
 namespace StringOps {
     function s_fromCString(s: CString): String = string_from_cstring;
     function s_fromCChar(s: CChar): String = string_from_cchar;
+    function s_fromUnicodeChar(s: UnicodeChar): String = string_from_unicodechar;
 
     function s_empty(s: String): Bool = string_empty;
 

--- a/src/core/xcore_string_smt.bsq
+++ b/src/core/xcore_string_smt.bsq
@@ -5,6 +5,7 @@ namespace Core;
 #if SMT_LIBS
 namespace StringOps {
     function s_fromCString(s: CString): String = string_from_cstring;
+    function s_fromCChar(s: CChar): String = string_from_cchar;
 
     function s_empty(s: String): Bool = string_empty;
 

--- a/src/core/xcore_string_smt.bsq
+++ b/src/core/xcore_string_smt.bsq
@@ -6,6 +6,7 @@ namespace Core;
 namespace StringOps {
     function s_fromCString(s: CString): String = string_from_cstring;
     function s_fromCChar(s: CChar): String = string_from_cchar;
+    function s_fromUnicodeChar(s: UnicodeChar): String = string_from_unicodechar;
 
     function s_empty(s: String): Bool = string_empty;
 

--- a/test/cppoutput/cppemit_nf.ts
+++ b/test/cppoutput/cppemit_nf.ts
@@ -18,6 +18,7 @@ const cpp_emit_runtime_path = path.join(bosque_dir, "bin/cppruntime/");
 const cpp_emit_runtime_src_path = path.join(cpp_emit_runtime_path, "emit.cpp");
 const cpp_emit_runtime_header_path = path.join(cpp_emit_runtime_path, "emit.hpp");
 const cpp_runtime_header_path = path.join(cpp_emit_runtime_path, "cppruntime.hpp");
+const cpp_runtime_source_path = path.join(cpp_emit_runtime_path, "cppruntime.cpp");
 const makefile_path = path.join(cpp_emit_runtime_path, "makefile");
 const gc_path = path.join(bosque_dir, "bin/cppruntime/gc/");
 const output_path = path.join(bosque_dir, "bin/cppruntime/output/");
@@ -126,6 +127,7 @@ function generateCPPFiles(header: string, src: string, outdir: string): boolean 
 
     try {
         copyFile(cpp_runtime_header_path, outdir);
+        copyFile(cpp_runtime_source_path, outdir);
         copyFile(makefile_path, outdir);
         copyGC(gc_path, path.join(outdir, "gc/"));
         copyGC(output_path, path.join(outdir, "output/"));

--- a/test/gc/gc_nf.ts
+++ b/test/gc/gc_nf.ts
@@ -14,6 +14,7 @@ const cpp_emit_runtime_path = path.join(bosque_dir, "bin/cppruntime/");
 const cpp_emit_runtime_src_path = path.join(cpp_emit_runtime_path, "emit.cpp");
 const cpp_emit_runtime_header_path = path.join(cpp_emit_runtime_path, "emit.hpp");
 const cpp_runtime_header_path = path.join(cpp_emit_runtime_path, "cppruntime.hpp");
+const cpp_runtime_source_path = path.join(cpp_emit_runtime_path, "cppruntime.cpp");
 const makefile_path = path.join(cpp_emit_runtime_path, "makefile");
 const gc_path = path.join(bosque_dir, "bin/cppruntime/gc/");
 const output_path = path.join(bosque_dir, "bin/cppruntime/output/");
@@ -58,6 +59,7 @@ function generateCPPFiles(header: string, src: string, cppmain: string, cpp_test
 
     try {
         copyFile(cpp_runtime_header_path, outdir);
+        copyFile(cpp_runtime_source_path, outdir);
         copyFile(makefile_path, outdir);
         copyGC(gc_path, path.join(outdir, "gc/"));
         copyGC(output_path, path.join(outdir, "output/"));


### PR DESCRIPTION
This sets up whats necessary for emitting our unicode and ascii char buffers to help us get setup for adding a rope backend to our strings.

I also modified our emission to also spit out the `cppruntime.cpp` file and added it to the cpp makefile since its a bit of a more pleasant location to keep all the char buffer ops.