### PR TITLE
RB Deletion Fix

### DIFF
--- a/src/core/xcore_list_exec.bsq
+++ b/src/core/xcore_list_exec.bsq
@@ -641,16 +641,12 @@ namespace ListOps {
     }
 
     function bubble<T>(c: Color, tleft: Tree<T>, tright: Tree<T>): Tree<T> {
-        if(tleft?<BBLeaf<T>> && tright?<BBLeaf<T>>) {
-            return Tree<T>::emptyTree;
-        }
-
         %% Propagate up live subtree
         if(tleft)<BBLeaf<T>> {
             return tright;
         }
-        if(tleft)<BBLeaf<T>> {
-            return tright;
+        if(tright)<BBLeaf<T>> {
+            return tleft;
         }
 
         return balance<T>(c, tleft, tright);

--- a/src/core/xcore_list_exec.bsq
+++ b/src/core/xcore_list_exec.bsq
@@ -641,22 +641,18 @@ namespace ListOps {
     }
 
     function bubble<T>(c: Color, tleft: Tree<T>, tright: Tree<T>): Tree<T> {
-        %% Handle case where we try to bubble an empty tree up
-        if(/\(tleft?<BBLeaf<T>>, tright?<BBLeaf<T>>)) {
+        if(tleft?<BBLeaf<T>> && tright?<BBLeaf<T>>) {
             return Tree<T>::emptyTree;
         }
 
-        if(/\(tleft?<Node<T>>, tright?<Node<T>>)) {
-            let tl = tleft@<Node<T>>;
-            let tr = tright@<Node<T>>;
-
-            if(tl.c === Color#BB || tr.c === Color#BB) {
-                let nl = create_with_empty<T>(redden(tl.c), tl.l, tl.r);
-                let nr = create_with_empty<T>(redden(tr.c), tr.l, tr.r);
-                return balance<T>(blacken(tl.c), nl, nr);
-            }
+        %% Propagate up live subtree
+        if(tleft)<BBLeaf<T>> {
+            return tright;
         }
-        
+        if(tleft)<BBLeaf<T>> {
+            return tright;
+        }
+
         return balance<T>(c, tleft, tright);
     }
 
@@ -800,7 +796,10 @@ namespace ListOps {
 
     recursive function insert_helper<T>(t: Tree<T>, idx: Nat, v: T): Tree<T> {
         match(t)@ {
-            Leaf<T> => { 
+            BBLeaf<T> => {
+                return Tree<T>::createLeaf(v);
+            }
+            | Leaf<T> => { 
                 if(idx == 0n) {
                     return Tree<T>::createNode(Color#Red, Tree<T>::createLeaf(v), $t);
                 }
@@ -837,36 +836,21 @@ namespace ListOps {
         }
     }
 
-    %% Forcefully bubble up leaves to red nodes, otherwise create new node
-    function create_with_empty<T>(c: Color, l: Tree<T>, r: Tree<T>): Tree<T> {
-        if(/\(l?<BBLeaf<T>>, r?<BBLeaf<T>>)) {
-            return Tree<T>::emptyTree;
-        }
-        if(l?<BBLeaf<T>>) {
-            if(c === Color#Red) {
-                return r;
-            }
-        }
-        if(r?<BBLeaf<T>>) {
-            if(c === Color#Red) {
-                return l;
-            }
-        }
-        assert /\(l?!<BBLeaf<T>>, r?!<BBLeaf<T>>);
-        return Tree<T>::createNode(c, l, r);
-    }
-
     recursive function delete_helper<T>(t: Tree<T>, idx: Nat): Tree<T> {
         match(t)@ {
-            BBLeaf<T> => { return Tree<T>::emptyTree; }
-            | Leaf<T> => { return Tree<T>::emptyTree; }
+            Leaf<T> => { 
+                return Tree<T>::emptyTree; 
+            }
             | Node<T> => {
-                %% We need to locate our leaf of interest
                 let count = size<T>($t.l);
                 if(idx < count) {
-                     return bubble<T>($t.c, delete_helper[recursive]<T>($t.l, idx), $t.r);
+                    let nl = delete_helper[recursive]<T>($t.l, idx);
+                    return bubble<T>($t.c, nl, $t.r);
                 }
-                return bubble<T>($t.c, $t.l, delete_helper[recursive]<T>($t.r, idx - count));
+                else {
+                    let nr = delete_helper[recursive]<T>($t.r, idx - count);
+                    return bubble<T>($t.c, $t.l, nr);
+                }
             }
         }
     }
@@ -875,28 +859,15 @@ namespace ListOps {
         let nt = delete_helper<T>(t, idx); 
         match(nt)@ {
             Node<T> => {
-                %% If empty sub tree move root down to non empty slot
-                if($nt.l?<BBLeaf<T>>) {
-                    let r = $nt.r;
-                    if(r)@@!<Node<T>> {
-                        return r;
-                    }
-                    let nrt = balance<T>(r.c, r.l, r.r);
-                    return nrt;
-                }
-                
-                if($nt.r?<BBLeaf<T>>) {
-                    let l = $nt.l;
-                    if(l)@@!<Node<T>> {
-                        return l;
-                    }
-                    let nlt = balance<T>(l.c, l.l, l.r);
-                    return nlt;
-                }
-                
+                let ntt = if($nt.c === Color#Red)
+                    then Tree<T>::createNode(Color#Black, $nt.l, $nt.r)
+                    else nt;
+
                 return nt;
             }
-            | _ => { return nt; }
+            | _ => { 
+                return nt; 
+            }
         }
     }
 

--- a/src/core/xcore_map_exec.bsq
+++ b/src/core/xcore_map_exec.bsq
@@ -414,20 +414,18 @@ namespace MapOps {
     }
 
     function bubble<K: keytype, V>(c: Color, tleft: Tree<K, V>, tright: Tree<K, V>): Tree<K, V> {
-        %% Handle case where we try to bubble an empty tree up
-        if(/\(tleft?<BBLeaf<K, V>>, tright?<BBLeaf<K, V>>)) {
+        if(tleft?<BBLeaf<K, V>> && tright?<BBLeaf<K, V>>) {
             return Tree<K, V>::emptyTree;
         }
-        if(/\(tleft?<Node<K, V>>, tright?<Node<K, V>>)) {
-            let tl = tleft@<Node<K, V>>;
-            let tr = tright@<Node<K, V>>;
 
-            if(tl.c === Color#BB || tr.c === Color#BB) {
-                let nl = create_with_empty<K, V>(redden(tl.c), tl.l, tl.r);
-                let nr = create_with_empty<K, V>(redden(tr.c), tr.l, tr.r);
-                return balance<K, V>(blacken(tl.c), nl, nr);
-            }
+        %% Propogate up live subtree
+        if(tleft)<BBLeaf<K, V>> {
+            return tright;
         }
+        if(tright)<BBLeaf<K, V>> {
+            return tleft;
+        }
+
         return balance<K, V>(c, tleft, tright);
     }
 
@@ -554,7 +552,10 @@ namespace MapOps {
 
     recursive function insert_helper<K: keytype, V>(t: Tree<K, V>, k: K, v: V): Tree<K, V> {
         match(t)@ {
-            Leaf<K, V> => {
+            BBLeaf<K, V> => {
+                return Tree<K, V>::createLeaf(MapEntry<K, V>{k, v});               
+            }
+            | Leaf<K, V> => {
                 assert !KeyComparator::equal<K>(k, $t.v.key);
 
                 if(KeyComparator::less<K>(k, $t.v.key)) {
@@ -617,76 +618,35 @@ namespace MapOps {
         }
     }
 
-    function create_with_empty<K: keytype, V>(c: Color, l: Tree<K, V>, r: Tree<K, V>): Tree<K, V> {
-        if(/\(l?<BBLeaf<K, V>>, r?<BBLeaf<K, V>>)) {
-            return Tree<K, V>::emptyTree;
-        }
-        if(l?<BBLeaf<K, V>>) {
-            if(c === Color#Red) {
-                return r;
-            }
-        }
-        if(r?<BBLeaf<K, V>>) {
-            if(c === Color#Red) {
-                return l;
-            }
-        }
-        assert /\(l?!<BBLeaf<K, V>>, r?!<BBLeaf<K, V>>);
-        return Tree<K, V>::createNode(c, l, r);
-    }
-
-    %% Search through tree until we find leaf of interest, then replace with empty tree
+    %% Replace target node with empty tree
     recursive function delete_helper<K: keytype, V>(t: Tree<K, V>, k: K): Tree<K, V> {
         match(t)@ {
-            BBLeaf<K, V> => { return Tree<K, V>::emptyTree; }
-            | Leaf<K, V> => {             
+            Leaf<K, V> => {             
                 return Tree<K, V>::emptyTree;
             }
             | Node<K, V> => {
-                %% Ensure we dont try to bubble with an empty tree
-                if($t.l)@<BBLeaf<K, V>> {
-                    return bubble<K, V>($t.c, $t.l, delete_helper[recursive]<K, V>($t.r, k));
-                }
-                if($t.r)@<BBLeaf<K, V>> {
-                    return bubble<K, V>($t.c, delete_helper[recursive]<K, V>($t.l, k), $t.r);
-                }
-
-                %% Determine if we need to recurse left or right
                 let rmin = mink<K, V>($t.r);
-                let lmin = mink<K, V>($t.l);
                 if(KeyComparator::less<K>(k, rmin)) {
-                    return bubble<K, V>($t.c, delete_helper[recursive]<K, V>($t.l, k), $t.r);
+                    let nl = delete_helper[recursive]<K, V>($t.l, k);
+                    return bubble<K, V>($t.c, nl, $t.r);
                 }
-                return bubble<K, V>($t.c, $t.l, delete_helper[recursive]<K, V>($t.r, k));
+                else {
+                    let nr = delete_helper[recursive]<K, V>($t.r, k);
+                    return bubble<K, V>($t.c, $t.l, nr);
+                }
             }
         }
     }
 
-    %% Deletes node of given key, k, from our tree
     function delete<K: keytype, V>(t: Tree<K, V>, k: K): Tree<K, V> {
         let nt = delete_helper[recursive]<K, V>(t, k);
         match(nt)@ {
             Node<K, V> => {
-                %% If empty sub tree move root down
-                if($nt.l?<BBLeaf<K, V>>) {
-                    let r = $nt.r;
-                    if(r)@@!<Node<K, V>> {
-                        return r;
-                    }
-                    let nrt = balance<K, V>(r.c, r.l, r.r);
-                    return nrt;
-                }
+                let ntt = if($nt.c === Color#Red) 
+                    then Tree<K, V>::createNode(Color#Black, $nt.l, $nt.r) 
+                    else nt;
 
-                if($nt.r?<BBLeaf<K, V>>) {
-                    let l = $nt.l;
-                    if(l)@@!<Node<K, V>> {
-                        return l;
-                    }
-                    let nlt = balance<K, V>(l.c, l.l, l.r);
-                    return nlt;
-                }
-
-                return nt;
+                return ntt;
             }
             | _ => { return nt; }
         }

--- a/src/core/xcore_map_exec.bsq
+++ b/src/core/xcore_map_exec.bsq
@@ -414,10 +414,6 @@ namespace MapOps {
     }
 
     function bubble<K: keytype, V>(c: Color, tleft: Tree<K, V>, tright: Tree<K, V>): Tree<K, V> {
-        if(tleft?<BBLeaf<K, V>> && tright?<BBLeaf<K, V>>) {
-            return Tree<K, V>::emptyTree;
-        }
-
         %% Propagate up live subtree
         if(tleft)<BBLeaf<K, V>> {
             return tright;

--- a/src/core/xcore_map_exec.bsq
+++ b/src/core/xcore_map_exec.bsq
@@ -646,10 +646,6 @@ namespace MapOps {
                     then Tree<K, V>::createNode(Color#Black, $nt.l, $nt.r) 
                     else nt;
 
-                if(!checkRBChildColorInvariant<K, V>(ntt)) {
-                    abort;
-                }
-
                 return ntt;
             }
             | _ => { 

--- a/src/core/xcore_map_exec.bsq
+++ b/src/core/xcore_map_exec.bsq
@@ -418,7 +418,7 @@ namespace MapOps {
             return Tree<K, V>::emptyTree;
         }
 
-        %% Propogate up live subtree
+        %% Propagate up live subtree
         if(tleft)<BBLeaf<K, V>> {
             return tright;
         }
@@ -646,9 +646,15 @@ namespace MapOps {
                     then Tree<K, V>::createNode(Color#Black, $nt.l, $nt.r) 
                     else nt;
 
+                if(!checkRBChildColorInvariant<K, V>(ntt)) {
+                    abort;
+                }
+
                 return ntt;
             }
-            | _ => { return nt; }
+            | _ => { 
+                return nt; 
+            }
         }
     }
 


### PR DESCRIPTION
This fixes deletion from our RB trees (was detected in map deletion while running the cpp transformer) causing failures. From what I found our deletion was not doing proper rebalancing which caused a later call to `mink` to fail caused by a `BBLeaf` being passed in. I also added a extra case to `insert_helper` ensuring if a `BBLeaf` finds its way into this function we don't explode. And generally cleaned up some of the redundant deletion logic I wrote initially.