### PR TITLE
Multiple Initialization and Return Multiple

### DIFF
--- a/src/backend/cpp/cpprepr/body.bsq
+++ b/src/backend/cpp/cpprepr/body.bsq
@@ -137,6 +137,16 @@ entity VariableInitializationStatement provides Statement {
     field exp: Expression;
 }
 
+entity VariableMultiInitializationExplicitStatement provides Statement {
+    field decls: List<(|Identifier, TypeSignature|)>;
+    field exps: List<Expression>;
+}
+
+entity VariableMultiInitializationImplicitStatement provides Statement {
+    field decls: List<(|Identifier, TypeSignature|)>;
+    field exp: Expression;
+}
+
 entity VariableAssignmentStatement provides Statement {
     field name: Identifier;
     field vtype: TypeSignature;
@@ -165,6 +175,12 @@ entity BinderBlockStatement provides Statement {
 entity ReturnSingleStatement provides Statement {
     field rtype: TypeSignature;
     field value: Expression;
+}
+
+entity ReturnMultiStatement provides Statement {
+    field elsig: EListTypeSignature;
+    field rtypes: List<TypeSignature>;
+    field exps: List<Expression>;
 }
 
 entity CallNamespaceFunctionExpression provides Expression {

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -157,10 +157,10 @@ public:
 
     TupleEntry() noexcept = default;
     TupleEntry(const TupleEntry& rhs) noexcept {
-        memcpy<K>(this->data, rhs->data);
+        memcpy<K>(this->data, rhs.data);
     }
     TupleEntry& operator=(const TupleEntry& rhs) noexcept {
-        memcpy<K>(this->data, rhs->data);
+        memcpy<K>(this->data, rhs.data);
         
         return *this;
     }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1371,13 +1371,18 @@ function emitVariableMultiInitilizationImplicitStatement(vmii: CPPAssembly::Vari
             return edecl, assignment, acc.2 + 1n;
         });
 
-    return String::concat(decls.0, decls.1, full_indent "}%n;");
+    return String::concat(decls.0, decls.1, full_indent, "}%n;");
 }
 
 function emitReturnMultiStatement(rms: CPPAssembly::ReturnMultiStatement, ctx: Context, indent: String): String {
-    return "";
-}
+    let full_indent = String::concat(indent, "    ");
+    
+    let elsig = emitTypeSignature(rms.elsig, true, ctx);
+    let exps = rms.exps.map<String>(fn(e) => emitExpression(e, ctx));
+    let eexps = String::joinAll(", ", exps);
 
+    return String::concat(full_indent, "return ", elsig, "(", eexps, ");");
+}
 
 function emitStatement(stmt: CPPAssembly::Statement, ctx: Context, indent: String): String {
     match(stmt)@ {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -155,7 +155,13 @@ function emitResolvedTemplates(tk: Option<CPPAssembly::TypeKey>, ik: Option<CPPA
         Some<CPPAssembly::TypeKey> => { 
             let ntk = tk@some;
             if(ctx.asm.primitives.has(ntk)) {
-                return String::fromCString(ntk.value);
+                %% CString and String are not defined in __CoreCpp
+                let t = String::fromCString(ntk.value);
+                if(t === "CString" || t === "String") {
+                    return String::concat("Core::", t);
+                }
+
+                return t;
             }
 
             declaredInNS = emitNamespaceKey(ctx.asm.lookupNominalTypeDeclaration(ntk).declaredInNS); 
@@ -1037,7 +1043,9 @@ function emitLiteralUnicodeCharExpression(exp: CPPAssembly::LiteralUnicodeCharEx
 }
 
 function emitCStringAsLiteral(s: CString): String {
-    return String::fromCString(CString::concat('"', s,'"'));
+    let formatted = s.replaceAllStringOccurrences('%n;', '\n');
+    
+    return String::fromCString(CString::concat('"', formatted,'"'));
 }
 
 function emitLiteralCStringExpression(exp: CPPAssembly::LiteralCStringExpression): String {
@@ -1361,7 +1369,7 @@ function emitVariableMultiInitilizationImplicitStatement(vmii: CPPAssembly::Vari
     let decls = vmii.decls
         .reduce<(|String, String, Nat|)>((|"", String::concat(full_indent, "{%n;", rhsinit), 0n|), fn(acc, decl) => {
             let name = emitIdentifier(decl.0);
-            let stype = emitTypeSignature(decl.1, true, ctx);
+            let stype = String::concat("[[maybe_unused]] ", emitTypeSignature(decl.1, true, ctx));
 
             let edecl = String::concat(acc.0, full_indent, stype, " ", name, ";%n;");
 
@@ -2050,12 +2058,14 @@ function emitAssembly(asm: CPPAssembly::Assembly): String {
 
     %% Checking for equality on our ropes needs to be overloaded in global namespace
     var overloads: String;
-    if(ctx.asm.typeinfos.has(CPPAssembly::TypeKey::from('CRope'))) {
+    if(ctx.asm.nsfuncs.has(CPPAssembly::InvokeKey::from('Core::CRopeOps::s_crope_equal'))) {
         overloads = "__CoreCpp::Bool operator==(const Core::CString& lhs, const Core::CString& rhs) { return Core::CRopeOps::s_crope_equal(lhs, rhs); }";
     }
+    %*
     elif(ctx.asm.typeinfos.has(CPPAssembly::TypeKey::from('UnicodeRope'))) {
         overloads = "__CoreCpp::Bool operator==(const Core::String& lhs, const Core::String& rhs) { return Core::UnicodeRopeOps::s_unicoderope_equal(lhs, rhs); }";
     }
+    *%
     else {
         overloads = "";
     }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -588,13 +588,20 @@ function emitPostfixAccessFromName(op: CPPAssembly::PostfixAccessFromName, ctx: 
     return String::concat(accessor, ident);
 }
 
-%% For now we assume this is only used for accessing elist fields
-function emitPostfixAccessFromIndex(op: CPPAssembly::PostfixAccessFromIndex, acc: String, ctx: Context): String {
-    let accesstype = op.baseType@<CPPAssembly::EListTypeSignature>.entries.get(Nat::fromCString(op.idx));
-    let accessed = emitTypeSignature(accesstype, true, ctx);
-    let idx = String::fromCString(op.idx);
+%% Assumes access type is elist (I believe this is the only type accessable via postfix index)
+function generateAccessFromIndex(idx: Nat, accessing: CPPAssembly::TypeSignature, ctx: Context): String {
+    let accessed = emitTypeSignature(accessing, true, ctx);
+    let accessidx = natToString(idx);
 
-    return String::concat(acc, ".access<", accessed, ", ", idx, ">()");
+    return String::concat(".access<", accessed, ", ", accessidx, ">()");
+}
+
+function emitPostfixAccessFromIndex(op: CPPAssembly::PostfixAccessFromIndex, acc: String, ctx: Context): String {
+    let idx = Nat::fromCString(op.idx);
+    let accesstype = op.baseType@<CPPAssembly::EListTypeSignature>.entries.get(idx);
+    let access = generateAccessFromIndex(idx, accesstype, ctx);
+
+    return String::concat(acc, access);
 }
 
 function emitPostfixInvokeStatic(op: CPPAssembly::PostfixInvokeStatic, rootexp: String, ctx: Context): String {
@@ -1329,21 +1336,64 @@ function emitSwitchStatement(stmt: CPPAssembly::SwitchStatement, ctx: Context, i
     return String::concat(matches, failure);
 }
 
+function emitVariableMultiInitilizationExplicitStatement(vmie: CPPAssembly::VariableMultiInitializationExplicitStatement, ctx: Context, indent: String): String {
+    let full_indent = String::concat(indent, "    ");
+    let stmts = vmie.decls.mapIdx<String>(fn(decl, ii) => {
+        let name = emitIdentifier(decl.0);
+        let tsig = emitTypeSignature(decl.1, true, ctx);
+        let exp = emitExpression(vmie.exps.get(ii), ctx);
+
+        return String::concat(indent, tsig, " ", name, " = ", exp);
+    });
+
+    return String::joinAll(";%n;", stmts);
+}
+
+%% This assumes implicit multiple initialization is done using elist
+function emitVariableMultiInitilizationImplicitStatement(vmii: CPPAssembly::VariableMultiInitializationImplicitStatement, ctx: Context, indent: String): String {
+    let full_indent = String::concat(indent, "    ");
+    let fullfull_indent = String::concat(full_indent,  "    ");
+    let exp = emitExpression(vmii.exp, ctx);
+    let etype = emitTypeSignature(vmii.exp.etype, true, ctx);
+    let rhsinit = String::concat(fullfull_indent, etype, " elist = ", exp, ";%n;");
+
+    %% (| decls, assignment, elist index |)
+    let decls = vmii.decls
+        .reduce<(|String, String, Nat|)>((|"", String::concat(full_indent, "{%n;", rhsinit), 0n|), fn(acc, decl) => {
+            let name = emitIdentifier(decl.0);
+            let stype = emitTypeSignature(decl.1, true, ctx);
+
+            let edecl = String::concat(acc.0, full_indent, stype, " ", name, ";%n;");
+
+            let access = generateAccessFromIndex(acc.2, decl.1, ctx);
+            let assignment = String::concat(acc.1, fullfull_indent, name, " = elist", access, ";%n;");
+
+            return edecl, assignment, acc.2 + 1n;
+        });
+
+    return String::concat(decls.0, decls.1, full_indent "}%n;");
+}
+
+function emitReturnMultiStatement(rms: CPPAssembly::ReturnMultiStatement, ctx: Context, indent: String): String {
+    return "";
+}
+
+
 function emitStatement(stmt: CPPAssembly::Statement, ctx: Context, indent: String): String {
     match(stmt)@ {
         CPPAssembly::EmptyStatement => { return ""; }
         | CPPAssembly::VariableDeclarationStatement => { return emitVariableDeclarationStatement($stmt, ctx, indent); }
         %%| CPPAssembly::VariableMultiDeclarationStatement => { abort; }
         | CPPAssembly::VariableInitializationStatement => { return emitVariableInitializationStatement($stmt, ctx, indent); }
-        %%| CPPAssembly::VariableMultiInitializationExplicitStatement => { abort; }
-        %%| CPPAssembly::VariableMultiInitializationImplicitStatement => { abort; }
+        | CPPAssembly::VariableMultiInitializationExplicitStatement => { return emitVariableMultiInitilizationExplicitStatement($stmt, ctx, indent); }
+        | CPPAssembly::VariableMultiInitializationImplicitStatement => { return emitVariableMultiInitilizationImplicitStatement($stmt, ctx, indent); }
         | CPPAssembly::VariableAssignmentStatement => { return emitVariableAssignmentStatement($stmt, ctx, indent); }
         %%| CPPAssembly::VariableMultiInitializationExplicitStatement => { abort; }
         %%| CPPAssembly::VariableMultiAssignmentImplicitStatement => { abort; }
         %%| CPPAssembly::VariableRetypeStatement => { abort; }
         %%| CPPAssembly::ReturnVoidStatement => { abort; }
         | CPPAssembly::ReturnSingleStatement => { return emitReturnSingleStatement($stmt, ctx, indent); }
-        %%| CPPAssembly::ReturnMultiStatement => { abort; }
+        | CPPAssembly::ReturnMultiStatement => { return emitReturnMultiStatement($stmt, ctx, indent); }
         | CPPAssembly::IfStatement => { return emitIfStatement($stmt, ctx, indent); }
         | CPPAssembly::IfElseStatement => { return emitIfElseStatement($stmt, ctx, indent); }
         | CPPAssembly::IfElifElseStatement => { return emitIfElifElseStatement($stmt, ctx, indent); }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -817,21 +817,53 @@ entity CPPTransformer {
         return CPPAssembly::VariableDeclarationStatement{ name, vtype };
     }
 
+    method transformVariableMultiInitilizationExplicitStatement(vmie: BSQAssembly::VariableMultiInitializationExplicitStatement): CPPAssembly::VariableMultiInitializationExplicitStatement {
+        let decls = vmie.decls.map<(|CPPAssembly::Identifier, CPPAssembly::TypeSignature|)>(fn(decl) => {
+            let cppidentifier = CPPTransformNameManager::convertIdentifier(decl.0);
+            let cpptsig = this.convertTypeSignature(decl.1);
+
+            return cppidentifier, cpptsig;
+        });
+        let exps = vmie.exps.map<CPPAssembly::Expression>(fn(e) => this.transformExpressionToCpp(e));
+
+        return CPPAssembly::VariableMultiInitializationExplicitStatement{ decls, exps };
+    }
+
+    method transformVariableMultiInitilizationImplicitStatement(vmii: BSQAssembly::VariableMultiInitializationImplicitStatement): CPPAssembly::VariableMultiInitializationImplicitStatement {
+        let decls = vmii.decls.map<(|CPPAssembly::Identifier, CPPAssembly::TypeSignature|)>(fn(decl) => {
+            let cppidentifier = CPPTransformNameManager::convertIdentifier(decl.0);
+            let cpptsig = this.convertTypeSignature(decl.1);
+
+            return cppidentifier, cpptsig;
+        });
+        let exp = this.transformExpressionToCpp(vmii.exp);
+
+        return CPPAssembly::VariableMultiInitializationImplicitStatement{ decls, exp };
+    }
+
+    method transformReturnMultiStatement(rms: BSQAssembly::ReturnMultiStatement): CPPAssembly::ReturnMultiStatement {
+        let elsig = this.convertTypeSignature(rms.elsig)@<CPPAssembly::EListTypeSignature>;
+        let rtypes = rms.rtypes.map<CPPAssembly::TypeSignature>(fn(ts) => this.convertTypeSignature(ts));
+        let exps = rms.exps.map<CPPAssembly::Expression>(fn(e) => this.transformExpressionToCpp(e));
+
+        return CPPAssembly::ReturnMultiStatement{ elsig, rtypes, exps };
+    }
+
     method transformStatementToCpp(stmt: BSQAssembly::Statement): CPPAssembly::Statement {
         match(stmt)@ {
             BSQAssembly::EmptyStatement => { return CPPAssembly::EmptyStatement{ }; }
             | BSQAssembly::VariableDeclarationStatement => { return this.transformVariableDeclarationStatement($stmt); }
             | BSQAssembly::VariableMultiDeclarationStatement => { abort; }
             | BSQAssembly::VariableInitializationStatement => { return this.transformVariableInitializationStatementToCpp($stmt); }
-            | BSQAssembly::VariableMultiInitializationExplicitStatement => { abort; }
-            | BSQAssembly::VariableMultiInitializationImplicitStatement => { abort; }
+            | BSQAssembly::VariableMultiInitializationExplicitStatement => { return this.transformVariableMultiInitilizationExplicitStatement($stmt); }
+            | BSQAssembly::VariableMultiInitializationImplicitStatement => { return this.transformVariableMultiInitilizationImplicitStatement($stmt); }
             | BSQAssembly::VariableAssignmentStatement => { return this.transformVariableAssignmentStatement($stmt); }
-            | BSQAssembly::VariableMultiInitializationExplicitStatement => { abort; }
+            | BSQAssembly::VariableMultiAssignmentExplicitStatement => { abort; }
             | BSQAssembly::VariableMultiAssignmentImplicitStatement => { abort; }
             | BSQAssembly::VariableRetypeStatement => { abort; }
             | BSQAssembly::ReturnVoidStatement => { abort; }
             | BSQAssembly::ReturnSingleStatement => { return this.transformReturnSingleStatementToCpp[recursive]($stmt); }
-            | BSQAssembly::ReturnMultiStatement => { abort; }
+            | BSQAssembly::ReturnMultiStatement => { return this.transformReturnMultiStatement($stmt); }
             | BSQAssembly::IfStatement => { return this.transformIfStatement[recursive]($stmt); }
             | BSQAssembly::IfElseStatement => { return this.transformIfElseStatement[recursive]($stmt); }
             | BSQAssembly::IfElifElseStatement => { return this.transformIfElifElseStatement[recursive]($stmt); }

--- a/src/core/xcore_list_exec.bsq
+++ b/src/core/xcore_list_exec.bsq
@@ -859,7 +859,7 @@ namespace ListOps {
                     then Tree<T>::createNode(Color#Black, $nt.l, $nt.r)
                     else nt;
 
-                return nt;
+                return ntt;
             }
             | _ => { 
                 return nt; 


### PR DESCRIPTION
This adds support for `VariableMultiInitilizationExplicitStatement`, `VariableMultiInitilizationImplicitStatement`, and `ReturnMultiStatement` to the cpp emitter.

With these changes I was able to sucessfully compile `db.bsq` test (although I have not simulated a proper work load on it yet).

Multiple initilization ended up looking something like so, we declare all variables used then in a deeper scope assign to correct elist entry in rhs.
```
    let y, z = (|1i, 2n|);
```
⬇️
```
        [[maybe_unused]] __CoreCpp::Int y;
        [[maybe_unused]] __CoreCpp::Nat z;
        {
            __CoreCpp::Tuple2<1, 1> elist = __CoreCpp::Tuple2<1, 1>(1_i, 2_n);
            y = elist.access<__CoreCpp::Int, 0>();
            z = elist.access<__CoreCpp::Nat, 1>();
        }
```