### PR TITLE
Runtime and GC Bug Fixes

### DIFF
--- a/src/backend/cpp/gc/src/runtime/common.h
+++ b/src/backend/cpp/gc/src/runtime/common.h
@@ -140,8 +140,8 @@ struct MetaData
     bool ismarked;
     bool isroot;
     //TODO -- also a parent thread root bit (that we don't clear but we treat as a root for the purposes of marking etc.)
-    uint32_t forward_index;
-    uint32_t ref_count;
+    int forward_index;
+    int ref_count;
 }; 
 #else
 typedef struct MetaData 

--- a/src/backend/cpp/gc/src/runtime/common.h
+++ b/src/backend/cpp/gc/src/runtime/common.h
@@ -152,8 +152,10 @@ typedef struct MetaData
 static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #endif
 
-// After we evacuate an object we need to update the original metadata
-#define RESET_METADATA_FOR_OBJECT(M, FP) *M = { .type=nullptr, .isalloc=false, .isyoung=false, .ismarked=false, .isroot=false, .forward_index=(FP), .ref_count=0 }
+#define NON_FORWARDED -1
+
+// Resets an objects metadata and updates with index into forward table
+#define RESET_METADATA_FOR_OBJECT(M, FP) ((*(M)) = { .type=nullptr, .isalloc=false, .isyoung=false, .ismarked=false, .isroot=false, .forward_index=FP, .ref_count=0 })
 
 #define GC_GET_META_DATA_ADDR(O) ((MetaData*)((uint8_t*)O - sizeof(MetaData)))
 

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
@@ -42,6 +42,8 @@ void PageInfo::rebuild() noexcept
     for(int64_t i = this->entrycount - 1; i >= 0; i--) {
         MetaData* meta = this->getMetaEntryAtIndex(i);
         
+        assert(meta->ref_count >= 0);
+
         if(GC_SHOULD_FREE_LIST_ADD(meta)) {
             FreeListEntry* entry = this->getFreelistEntryAtIndex(i);
             entry->next = this->freelist;
@@ -73,7 +75,7 @@ PageInfo* GlobalPageGCManager::allocateFreshPage(uint16_t entrysize, uint16_t re
 #else
         ALLOC_LOCK_ACQUIRE();
 
-        void* page = (XAllocPage*)mmap(GlobalThreadAllocInfo::s_current_page_address, BSQ_BLOCK_ALLOCATION_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, 0, 0);
+        void* page = mmap(GlobalThreadAllocInfo::s_current_page_address, BSQ_BLOCK_ALLOCATION_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, 0, 0);
         GlobalThreadAllocInfo::s_current_page_address = (void*)((uint8_t*)GlobalThreadAllocInfo::s_current_page_address + BSQ_BLOCK_ALLOCATION_SIZE);
 
         ALLOC_LOCK_RELEASE();    

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
@@ -178,7 +178,7 @@ void GCAllocator::allocatorRefreshAllocationPage() noexcept
         // If we exceed our filled pages thresh collect
         if(gtl_info.newly_filled_pages_count == BSQ_COLLECTION_THRESHOLD) {
             if(!gtl_info.disable_automatic_collections) {
-                collect();
+                this->collectfp();
             }
         }
         else {

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
@@ -42,7 +42,7 @@ void PageInfo::rebuild() noexcept
     for(int64_t i = this->entrycount - 1; i >= 0; i--) {
         MetaData* meta = this->getMetaEntryAtIndex(i);
         
-        assert(meta->ref_count >= 0);
+        GC_INVARIANT_CHECK(meta->ref_count >= 0);
 
         if(GC_SHOULD_FREE_LIST_ADD(meta)) {
             FreeListEntry* entry = this->getFreelistEntryAtIndex(i);

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.h
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.h
@@ -144,7 +144,7 @@ private:
 public:
     static GlobalPageGCManager g_gc_page_manager;
 
-    GlobalPageGCManager() noexcept : empty_pages(nullptr) { }
+    GlobalPageGCManager() noexcept : empty_pages(nullptr), pagetable() { }
 
     PageInfo* allocateFreshPage(uint16_t entrysize, uint16_t realsize) noexcept;
 
@@ -176,8 +176,8 @@ public:
 #define SET_ALLOC_LAYOUT_HANDLE_CANARY(BASEALLOC, T) PageInfo::initializeWithDebugInfo(BASEALLOC, T)
 #endif
 
-#define SETUP_ALLOC_INITIALIZE_FRESH_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=true, .ismarked=false, .isroot=false, .forward_index=MAX_FWD_INDEX, .ref_count=0 }
-#define SETUP_ALLOC_INITIALIZE_CONVERT_OLD_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=false, .ismarked=false, .isroot=false, .forward_index=MAX_FWD_INDEX, .ref_count=0 }
+#define SETUP_ALLOC_INITIALIZE_FRESH_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=true, .ismarked=false, .isroot=false, .forward_index=-1, .ref_count=0 }
+#define SETUP_ALLOC_INITIALIZE_CONVERT_OLD_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=false, .ismarked=false, .isroot=false, .forward_index=-1, .ref_count=0 }
 
 template<typename T>
 T* MEM_ALLOC_CHECK(T* alloc)
@@ -224,7 +224,7 @@ private:
     PageInfo* getFreshPageForEvacuation() noexcept;
 
 public:
-    GCAllocator(uint16_t allocsize, uint16_t realsize, void (*collect)()) noexcept : freelist(nullptr), evacfreelist(nullptr), alloc_page(nullptr), evac_page(nullptr), allocsize(allocsize), realsize(realsize), pendinggc_pages(nullptr), filled_pages(nullptr), collectfp(collect) {
+    GCAllocator(uint16_t objsize, uint16_t fullsize, void (*collect)()) noexcept : freelist(nullptr), evacfreelist(nullptr), alloc_page(nullptr), evac_page(nullptr), allocsize(objsize), realsize(fullsize), pendinggc_pages(nullptr), filled_pages(nullptr), collectfp(collect) {
         resetBuckets();
     }
 

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.h
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.h
@@ -176,8 +176,8 @@ public:
 #define SET_ALLOC_LAYOUT_HANDLE_CANARY(BASEALLOC, T) PageInfo::initializeWithDebugInfo(BASEALLOC, T)
 #endif
 
-#define SETUP_ALLOC_INITIALIZE_FRESH_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=true, .ismarked=false, .isroot=false, .forward_index=-1, .ref_count=0 }
-#define SETUP_ALLOC_INITIALIZE_CONVERT_OLD_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=false, .ismarked=false, .isroot=false, .forward_index=-1, .ref_count=0 }
+#define SETUP_ALLOC_INITIALIZE_FRESH_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=true, .ismarked=false, .isroot=false, .forward_index=NON_FORWARDED, .ref_count=0 }
+#define SETUP_ALLOC_INITIALIZE_CONVERT_OLD_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=false, .ismarked=false, .isroot=false, .forward_index=NON_FORWARDED, .ref_count=0 }
 
 template<typename T>
 T* MEM_ALLOC_CHECK(T* alloc)

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -13,11 +13,11 @@
 #define INC_REF_COUNT(O) (++GC_REF_COUNT(O))
 #define DEC_REF_COUNT(O) (--GC_REF_COUNT(O))
 
-void walkPointerMaskForDecrements(BSQMemoryTheadLocalInfo& tinfo, __CoreGC::TypeInfoBase* typeinfo, void** slots) noexcept;
-void updatePointers(void** slots, const BSQMemoryTheadLocalInfo& tinfo) noexcept;
-void walkPointerMaskForMarking(BSQMemoryTheadLocalInfo& tinfo, __CoreGC::TypeInfoBase* typeinfo, void** slots) noexcept; 
+static void walkPointerMaskForDecrements(BSQMemoryTheadLocalInfo& tinfo, __CoreGC::TypeInfoBase* typeinfo, void** slots) noexcept;
+static void updatePointers(void** slots, BSQMemoryTheadLocalInfo& tinfo) noexcept;
+static void walkPointerMaskForMarking(BSQMemoryTheadLocalInfo& tinfo, __CoreGC::TypeInfoBase* typeinfo, void** slots) noexcept; 
 
-void reprocessPageInfo(PageInfo* page, BSQMemoryTheadLocalInfo& tinfo) noexcept
+static void reprocessPageInfo(PageInfo* page, BSQMemoryTheadLocalInfo& tinfo) noexcept
 {
     // This should not be called on pages that are (1) active allocators or evacuators or (2) pending collection pages
     GCAllocator* gcalloc = tinfo.getAllocatorForPageSize(page);
@@ -28,7 +28,13 @@ void reprocessPageInfo(PageInfo* page, BSQMemoryTheadLocalInfo& tinfo) noexcept
     }
 }
 
-void computeDeadRootsForDecrement(BSQMemoryTheadLocalInfo& tinfo) noexcept
+static inline void pushPendingDecs(BSQMemoryTheadLocalInfo& tinfo, void* obj)
+{
+    PageInfo::extractPageFromPointer(obj)->pending_decs_count++;
+    tinfo.pending_decs.push_back(obj);
+}
+
+static void computeDeadRootsForDecrement(BSQMemoryTheadLocalInfo& tinfo) noexcept
 {
     // First we need to sort the roots we find
     qsort(tinfo.roots, 0, tinfo.roots_count - 1, tinfo.roots_count);
@@ -41,7 +47,7 @@ void computeDeadRootsForDecrement(BSQMemoryTheadLocalInfo& tinfo) noexcept
         
         if(roots_idx >= tinfo.roots_count) {
             // Was dropped from roots
-            tinfo.pending_decs.push_back(cur_oldroot);
+            pushPendingDecs(tinfo, cur_oldroot);
             oldroots_idx++;
             continue;
         }
@@ -53,7 +59,7 @@ void computeDeadRootsForDecrement(BSQMemoryTheadLocalInfo& tinfo) noexcept
         } 
         else if(cur_oldroot < cur_root) {
             // Was dropped from roots
-            tinfo.pending_decs.push_back(cur_oldroot);
+            pushPendingDecs(tinfo, cur_oldroot);
             oldroots_idx++;
         } 
         else {
@@ -66,29 +72,12 @@ void computeDeadRootsForDecrement(BSQMemoryTheadLocalInfo& tinfo) noexcept
     tinfo.old_roots_count = 0;
 }
 
-inline void pushPendingDecs(BSQMemoryTheadLocalInfo& tinfo, void** obj)
-{
-    PageInfo::extractPageFromPointer(*obj)->pending_decs_count++;
-    tinfo.pending_decs.push_back(*obj);
-}
-
-inline void handleRefDecrement(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept 
-{
-    void* obj = *slots;
-    int refcount = DEC_REF_COUNT(obj);
-    if(refcount != 0 || GC_IS_ROOT(obj)) {
-        return ;
-    }
-
-    pushPendingDecs(tinfo, slots);
-}
-
-inline void handleTaggedObjectDecrement(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept 
+static inline void handleTaggedObjectDecrement(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept 
 {
     __CoreGC::TypeInfoBase* tagged_typeinfo = (__CoreGC::TypeInfoBase*)*slots;
     switch(tagged_typeinfo->tag) {
         case __CoreGC::Tag::Ref: {
-            handleRefDecrement(tinfo, slots + 1); 
+            pushPendingDecs(tinfo, *(slots + 1)); 
             break;
         }
         case __CoreGC::Tag::Tagged: {
@@ -101,7 +90,7 @@ inline void handleTaggedObjectDecrement(BSQMemoryTheadLocalInfo& tinfo, void** s
     }
 }
 
-void walkPointerMaskForDecrements(BSQMemoryTheadLocalInfo& tinfo, __CoreGC::TypeInfoBase* typeinfo, void** slots) noexcept
+static void walkPointerMaskForDecrements(BSQMemoryTheadLocalInfo& tinfo, __CoreGC::TypeInfoBase* typeinfo, void** slots) noexcept
 {
     const char* ptr_mask = typeinfo->ptr_mask;
     if(ptr_mask == PTR_MASK_LEAF) {
@@ -111,7 +100,7 @@ void walkPointerMaskForDecrements(BSQMemoryTheadLocalInfo& tinfo, __CoreGC::Type
     while(*ptr_mask != '\0') {
         switch(*ptr_mask) {
             case PTR_MASK_PTR: { 
-                handleRefDecrement(tinfo, slots); 
+                pushPendingDecs(tinfo, *slots); 
                 break;
             }
             case PTR_MASK_TAGGED: { 
@@ -128,7 +117,7 @@ void walkPointerMaskForDecrements(BSQMemoryTheadLocalInfo& tinfo, __CoreGC::Type
     }
 }
 
-void processDecrements(BSQMemoryTheadLocalInfo& tinfo) noexcept
+static void processDecrements(BSQMemoryTheadLocalInfo& tinfo) noexcept
 {
     GC_REFCT_LOCK_ACQUIRE();
     MEM_STATS_START();
@@ -151,6 +140,10 @@ void processDecrements(BSQMemoryTheadLocalInfo& tinfo) noexcept
 
         GC_IS_ALLOCATED(obj) = false;
 
+        if(!GC_IS_ROOT(obj)) {
+            DEC_REF_COUNT(obj);
+        }
+
         if(objects_page->seen == false) {
             objects_page->seen = true;
             tinfo.decremented_pages[tinfo.decremented_pages_index++] = objects_page;
@@ -159,12 +152,6 @@ void processDecrements(BSQMemoryTheadLocalInfo& tinfo) noexcept
         deccount++;
     }
 
-    //
-    // Honestly I am wondering if we really should be moving these pagtes around
-    // Im starting to think our bug has something to do with an object
-    // getting evacuated but its parent object not being made known
-    // so it ends up pointing to garbage.
-    //
     for(uint32_t i = 0; i < tinfo.decremented_pages_index; i++) {        
         reprocessPageInfo(tinfo.decremented_pages[i], tinfo);
     }
@@ -178,23 +165,36 @@ void processDecrements(BSQMemoryTheadLocalInfo& tinfo) noexcept
     //
 }
 
-
-inline void updateRef(void** obj, const BSQMemoryTheadLocalInfo& tinfo)
+static inline void updateRef(void** obj, BSQMemoryTheadLocalInfo& tinfo)
 {
-    int fwd_index = GC_FWD_INDEX(*obj);
-    if(fwd_index >= 0) {
-        *obj = tinfo.forward_table[fwd_index]; 
-    }
+    void* ptr = *obj;
+    int fwd_index = GC_FWD_INDEX(ptr);
+
+    if(fwd_index == NON_FORWARDED) {
+        GC_INVARIANT_CHECK(GC_IS_ROOT(ptr) == false);
+
+        GCAllocator* gcalloc = tinfo.getAllocatorForPageSize(PageInfo::extractPageFromPointer(ptr));
+        GC_INVARIANT_CHECK(gcalloc != nullptr);
     
-    // Prevent possible ref count increase of a non-forwarded object
-    if(*obj == nullptr) {
-        return ;
+        __CoreGC::TypeInfoBase* type_info = GC_TYPE(ptr);
+        void* nptr = gcalloc->allocateEvacuation(type_info);
+        xmem_copy(ptr, nptr, type_info->slot_size);
+        updatePointers((void**)nptr, tinfo);
+
+        // Insert into forward table and update object ensuring future objects update
+        RESET_METADATA_FOR_OBJECT(GC_GET_META_DATA_ADDR(ptr), tinfo.forward_table_index);
+        tinfo.forward_table[tinfo.forward_table_index++] = nptr;    
+        
+        *obj = nptr; 
+    }
+    else {
+        *obj = tinfo.forward_table[fwd_index]; 
     }
 
     INC_REF_COUNT(*obj);
 }
 
-inline void handleTaggedObjectUpdate(void** slots, const BSQMemoryTheadLocalInfo& tinfo) noexcept 
+static inline void handleTaggedObjectUpdate(void** slots, BSQMemoryTheadLocalInfo& tinfo) noexcept 
 {
     __CoreGC::TypeInfoBase* tagged_typeinfo = (__CoreGC::TypeInfoBase*)*slots;
     switch(tagged_typeinfo->tag) {
@@ -213,7 +213,7 @@ inline void handleTaggedObjectUpdate(void** slots, const BSQMemoryTheadLocalInfo
 }
 
 // Update pointers using forward table
-void updatePointers(void** slots, const BSQMemoryTheadLocalInfo& tinfo) noexcept
+static void updatePointers(void** slots, BSQMemoryTheadLocalInfo& tinfo) noexcept
 {
     __CoreGC::TypeInfoBase* type_info = GC_TYPE(slots);
     const char* ptr_mask = type_info->ptr_mask;
@@ -242,39 +242,25 @@ void updatePointers(void** slots, const BSQMemoryTheadLocalInfo& tinfo) noexcept
 }
 
 // Move non root young objects to evacuation page (as needed) then forward pointers and inc ref counts
-void processMarkedYoungObjects(BSQMemoryTheadLocalInfo& tinfo) noexcept 
+static void processMarkedYoungObjects(BSQMemoryTheadLocalInfo& tinfo) noexcept 
 {
     GC_REFCT_LOCK_ACQUIRE();
     MEM_STATS_START();
 
     while(!tinfo.pending_young.isEmpty()) {
         void* obj = tinfo.pending_young.pop_front();
-        __CoreGC::TypeInfoBase* type_info = GC_TYPE(obj);
         GC_INVARIANT_CHECK(GC_IS_YOUNG(obj) && GC_IS_MARKED(obj));
 
-        if(GC_IS_ROOT(obj)) {
-            updatePointers((void**)obj, tinfo);
-            GC_CLEAR_YOUNG_MARK(GC_GET_META_DATA_ADDR(obj));
-            continue;
-        }
-        
-        // If we are not a root we want to evacuate
-        GCAllocator* gcalloc = tinfo.getAllocatorForPageSize(PageInfo::extractPageFromPointer(obj));
-        GC_INVARIANT_CHECK(gcalloc != nullptr);
-    
-        void* newobj = gcalloc->allocateEvacuation(type_info);
-        xmem_copy(obj, newobj, type_info->slot_size);
-        updatePointers((void**)newobj, tinfo);
-
-        RESET_METADATA_FOR_OBJECT(GC_GET_META_DATA_ADDR(obj), tinfo.forward_table_index);
-        tinfo.forward_table[tinfo.forward_table_index++] = newobj;
+        MetaData* m = GC_GET_META_DATA_ADDR(obj);
+        updatePointers((void**)obj, tinfo);
+        GC_CLEAR_YOUNG_MARK(m);
     }
 
     MEM_STATS_END(evacuation_times);
     GC_REFCT_LOCK_RELEASE();
 }
 
-void checkPotentialPtr(void* addr, BSQMemoryTheadLocalInfo& tinfo) noexcept
+static void checkPotentialPtr(void* addr, BSQMemoryTheadLocalInfo& tinfo) noexcept
 {
     if(addr == nullptr) {
         return ;
@@ -303,9 +289,11 @@ void checkPotentialPtr(void* addr, BSQMemoryTheadLocalInfo& tinfo) noexcept
     if(GC_SHOULD_PROCESS_AS_YOUNG(meta)) {
         tinfo.pending_roots.push_back(obj);
     }
+
+    std::cout << "root: " << obj << std::endl;
  }
 
-void walkStack(BSQMemoryTheadLocalInfo& tinfo) noexcept 
+static void walkStack(BSQMemoryTheadLocalInfo& tinfo) noexcept 
 {
     // Process global data (TODO -- later have flag to disable this after it is fixed as immortal)
     if(GlobalDataStorage::g_global_data.native_global_storage != nullptr) {
@@ -346,7 +334,7 @@ void walkStack(BSQMemoryTheadLocalInfo& tinfo) noexcept
     tinfo.unloadNativeRootSet();
 }
 
-void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
+static void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
 {
     MetaData* meta = GC_GET_META_DATA_ADDR(*slots);
     if(meta == nullptr) {
@@ -361,7 +349,7 @@ void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
     tinfo.visit_stack.push_back({*slots, MARK_STACK_NODE_COLOR_GREY});
 }
 
-void handleMarkingTaggedObject(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept 
+static void handleMarkingTaggedObject(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept 
 {
     __CoreGC::TypeInfoBase* tagged_typeinfo = (__CoreGC::TypeInfoBase*)*slots;
     switch(tagged_typeinfo->tag) {
@@ -379,7 +367,7 @@ void handleMarkingTaggedObject(BSQMemoryTheadLocalInfo& tinfo, void** slots) noe
     }
 }
 
-void walkPointerMaskForMarking(BSQMemoryTheadLocalInfo& tinfo, __CoreGC::TypeInfoBase* typeinfo, void** slots) noexcept 
+static void walkPointerMaskForMarking(BSQMemoryTheadLocalInfo& tinfo, __CoreGC::TypeInfoBase* typeinfo, void** slots) noexcept 
 {
     const char* ptr_mask = typeinfo->ptr_mask;
     if(ptr_mask == PTR_MASK_LEAF) {
@@ -406,7 +394,7 @@ void walkPointerMaskForMarking(BSQMemoryTheadLocalInfo& tinfo, __CoreGC::TypeInf
     }
 }
 
-void walkSingleRoot(void* root, BSQMemoryTheadLocalInfo& tinfo) noexcept
+static void walkSingleRoot(void* root, BSQMemoryTheadLocalInfo& tinfo) noexcept
 {
     while(!tinfo.visit_stack.isEmpty()) {
         MarkStackEntry entry = tinfo.visit_stack.pop_back();
@@ -423,7 +411,7 @@ void walkSingleRoot(void* root, BSQMemoryTheadLocalInfo& tinfo) noexcept
      }
 }
 
-void markingWalk(BSQMemoryTheadLocalInfo& tinfo) noexcept
+static void markingWalk(BSQMemoryTheadLocalInfo& tinfo) noexcept
 {
     MEM_STATS_START();
     
@@ -453,6 +441,8 @@ void markingWalk(BSQMemoryTheadLocalInfo& tinfo) noexcept
 void collect() noexcept
 {   
     MEM_STATS_START();
+
+    std::cout << " collect! " << std::endl;
 
     static bool should_reset_pending_decs = true;
     gtl_info.pending_young.initialize();

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -191,7 +191,7 @@ static inline void updateRef(void** obj, BSQMemoryTheadLocalInfo& tinfo)
 
     if(fwd_index == NON_FORWARDED) {
         // We do not want to forward roots
-        if(!GC_IS_ROOT(ptr)) {
+        if(GC_IS_ROOT(ptr)) {
             return ;
         }
  

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -187,6 +187,11 @@ static inline void updateRef(void** obj, BSQMemoryTheadLocalInfo& tinfo)
     void* ptr = *obj;
     int fwd_index = GC_FWD_INDEX(ptr);
 
+    //
+    // I BELIEVE forwarding at this point in updating pointers ensures
+    // all children pointers new address are correctly reflected in their
+    // parents data
+    //
     if(fwd_index == NON_FORWARDED) {
         // This might me invariant
         if(!GC_IS_ROOT(ptr)) {
@@ -220,7 +225,6 @@ static inline void handleTaggedObjectUpdate(void** slots, BSQMemoryTheadLocalInf
     }
 }
 
-// Update pointers using forward table
 static void updatePointers(void** slots, BSQMemoryTheadLocalInfo& tinfo) noexcept
 {
     __CoreGC::TypeInfoBase* type_info = GC_TYPE(slots);

--- a/src/backend/cpp/gc/src/runtime/memory/threadinfo.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/threadinfo.cpp
@@ -19,6 +19,8 @@ thread_local BSQMemoryTheadLocalInfo gtl_info;
 
 void BSQMemoryTheadLocalInfo::initialize(size_t tl_id, void** caller_rbp) noexcept
 {
+    assert(caller_rbp != nullptr);
+    
     this->tl_id = tl_id;
     this->native_stack_base = caller_rbp;
 
@@ -44,6 +46,16 @@ void BSQMemoryTheadLocalInfo::loadNativeRootSet() noexcept
 
     //this code should load from the asm stack pointers and copy the native stack into the roots memory
     #ifdef __x86_64__
+
+    // This might be what we want?
+    /*
+           void** current_frame = nullptr;
+        asm("\t mov %%rbp,%0" : "=r"(current_frame));        
+
+        assert(current_frame != nullptr); 
+    
+    */
+
         register void** rbp asm("rbp");
         void** current_frame = rbp;
         

--- a/src/backend/cpp/gc/src/runtime/memory/threadinfo.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/threadinfo.cpp
@@ -42,22 +42,6 @@ void BSQMemoryTheadLocalInfo::initialize(size_t ntl_id, void** caller_rbp) noexc
 
 void BSQMemoryTheadLocalInfo::loadNativeRootSet() noexcept
 {
-    // This might be what we want?
-    // Will need to do in all places that use registers. Might be a good idea as it is defined
-    // We shold probably also store the contents of the movq in a uint64 then cast to void
-    // in both clang and gcc
-    // 
-    // could try out  ` void * __builtin_frame_address(0) ` also (gcc builtin though)
-    //
-    /*
-           void** current_frame = nullptr;
-        asm("\t movq %%rbp,%0" : "=r"(current_frame));
-
-        assert(current_frame != nullptr);
-
-    */
-
-
     this->native_stack_contents.initialize();
 
     //this code should load from the asm stack pointers and copy the native stack into the roots memory

--- a/src/backend/cpp/gc/src/runtime/memory/threadinfo.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/threadinfo.cpp
@@ -17,11 +17,11 @@ thread_local BSQMemoryTheadLocalInfo gtl_info;
     native_register_contents.R = NULL;                                        \
     if(PTR_IN_RANGE(R) && PTR_NOT_IN_STACK(BASE, CURR, R)) { native_register_contents.R = R; }
 
-void BSQMemoryTheadLocalInfo::initialize(size_t tl_id, void** caller_rbp) noexcept
+void BSQMemoryTheadLocalInfo::initialize(size_t ntl_id, void** caller_rbp) noexcept
 {
     assert(caller_rbp != nullptr);
     
-    this->tl_id = tl_id;
+    this->tl_id = ntl_id;
     this->native_stack_base = caller_rbp;
 
     this->roots = roots_array;
@@ -48,31 +48,39 @@ void BSQMemoryTheadLocalInfo::loadNativeRootSet() noexcept
     #ifdef __x86_64__
 
     // This might be what we want?
+    // Will need to do in all places that use registers. Might be a good idea as it is defined
+    // We shold probably also store the contents of the movq in a uint64 then cast to void
+    // in both clang and gcc
+    // 
+    // could try out  ` void * __builtin_frame_address(0) ` also (gcc builtin though)
+    //
     /*
            void** current_frame = nullptr;
-        asm("\t mov %%rbp,%0" : "=r"(current_frame));        
+        asm("\t movq %%rbp,%0" : "=r"(current_frame));
 
-        assert(current_frame != nullptr); 
-    
+        assert(current_frame != nullptr);
+
     */
 
-        register void** rbp asm("rbp");
-        void** current_frame = rbp;
-        
-        /* Walk the stack */
-        while (current_frame <= native_stack_base) {
-            assert(IS_ALIGNED(current_frame));
-            
-            /* Walk entire frame looking for valid pointers */
-            void** it = current_frame;
-            void* potential_ptr = *it;
-            if (PTR_IN_RANGE(potential_ptr) && PTR_NOT_IN_STACK(native_stack_base, current_frame, potential_ptr)) {
-                this->native_stack_contents.push_back(potential_ptr);
-            }
-            it--;
-            
-            current_frame++;
-        } 
+    register void **rbp asm("rbp");
+    void **current_frame = rbp;
+
+    /* Walk the stack */
+    while (current_frame <= native_stack_base)
+    {
+        assert(IS_ALIGNED(current_frame));
+
+        /* Walk entire frame looking for valid pointers */
+        void **it = current_frame;
+        void *potential_ptr = *it;
+        if (PTR_IN_RANGE(potential_ptr) && PTR_NOT_IN_STACK(native_stack_base, current_frame, potential_ptr))
+        {
+            this->native_stack_contents.push_back(potential_ptr);
+        }
+        it--;
+
+        current_frame++;
+    } 
 
         /* Check contents of registers */
         PROCESS_REGISTER(native_stack_base, current_frame, rax)

--- a/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
+++ b/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
@@ -133,7 +133,7 @@ struct BSQMemoryTheadLocalInfo
         }
     }
 
-    void initialize(size_t tl_id, void** caller_rbp) noexcept;
+    void initialize(size_t ntl_id, void** caller_rbp) noexcept;
 
     void loadNativeRootSet() noexcept;
     void unloadNativeRootSet() noexcept;

--- a/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
+++ b/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
@@ -77,7 +77,7 @@ struct BSQMemoryTheadLocalInfo
     size_t old_roots_count;
     void** old_roots;
 
-    size_t forward_table_index = 0;
+    int forward_table_index = 0;
     void** forward_table;
 
     uint32_t newly_filled_pages_count = 0;
@@ -106,7 +106,7 @@ struct BSQMemoryTheadLocalInfo
     bool disable_stack_refs_for_tests = false;
 #endif
 
-    BSQMemoryTheadLocalInfo() noexcept : tl_id(0), g_gcallocs(nullptr), native_stack_base(nullptr), native_stack_contents(), roots_count(0), roots(nullptr), old_roots_count(0), old_roots(nullptr), forward_table_index(0), forward_table(nullptr), pending_roots(), visit_stack(), pending_young(), pending_decs(), max_decrement_count(BSQ_INITIAL_MAX_DECREMENT_COUNT) { }
+    BSQMemoryTheadLocalInfo() noexcept : tl_id(0), g_gcallocs(nullptr), native_stack_base(nullptr), native_stack_contents(), native_register_contents(), roots_count(0), roots(nullptr), old_roots_count(0), old_roots(nullptr), forward_table_index(0), forward_table(nullptr), pending_roots(), visit_stack(), pending_young(), pending_decs(), max_decrement_count(BSQ_INITIAL_MAX_DECREMENT_COUNT), mstats() { }
 
     inline GCAllocator* getAllocatorForPageSize(PageInfo* page) noexcept {
         uint8_t idx = this->g_gcallocs_lookuptable[page->allocsize >> 3];

--- a/src/backend/cpp/gc/src/runtime/support/pagetable.h
+++ b/src/backend/cpp/gc/src/runtime/support/pagetable.h
@@ -2,31 +2,24 @@
 
 #include "xalloc.h"
 
+#define PAGETABLE_LEVELS 4
+#define BITS_PER_LEVEL   9 
+
+#define LEVEL1_SHIFT 39 
+#define LEVEL2_SHIFT 30 
+#define LEVEL3_SHIFT 21 
+#define LEVEL4_SHIFT 12 
+
+#define LEVEL_MASK 0x1FFUL 
+#define PAGE_MASK  0xFFFUL
+
+#define PAGE_PRESENT 1
+
 //A class that keeps track of which pages are in use in the GC
 class PageTableInUseInfo
 {
 private:
     void** pagetable_root;
-
-    //
-    //Original implementation designed for 12 bits per level fails
-    //due to the fact that our pages being 4096 bytes, meaning since
-    //each block stores a void* we can have up to 4096/8 = 512 entries
-    //so in order to utilize space most effectively we can have
-    //log2(512) = 9 bits per level
-    //
-    
-    constexpr static uintptr_t PAGETABLE_LEVELS = 4;
-    constexpr static uintptr_t BITS_PER_LEVEL = 9; 
-    
-    constexpr static uintptr_t LEVEL1_SHIFT = 39; 
-    constexpr static uintptr_t LEVEL2_SHIFT = 30; 
-    constexpr static uintptr_t LEVEL3_SHIFT = 21; 
-    constexpr static uintptr_t LEVEL4_SHIFT = 12; 
-    constexpr static uintptr_t LEVEL_MASK = 0x1FF; 
-    constexpr static uintptr_t PAGE_MASK = 0xFFF;
-    constexpr static uintptr_t PAGE_PRESENT = 1;
-
 public:
     PageTableInUseInfo() noexcept : pagetable_root(nullptr) {}
 

--- a/src/backend/cpp/gc/test/tree_basic/tree_basic.bsq
+++ b/src/backend/cpp/gc/test/tree_basic/tree_basic.bsq
@@ -15,7 +15,11 @@ function makeTree(depth: Nat, val: Nat): BasicTree {
     };
 }
 
+function accessNode(t: BasicTree): Node {
+    return t@<Node>;
+}
+
 public function main(): Bool {
-    let t = makeTree(3n, 3n);
+    let t = accessNode(makeTree(3n, 3n));
     return true;
 }

--- a/src/backend/cpp/gc/test/tree_basic/tree_basic.cpp
+++ b/src/backend/cpp/gc/test/tree_basic/tree_basic.cpp
@@ -1,4 +1,4 @@
-#define verifyTest() do{ collect(); 𝐚𝐬𝐬𝐞𝐫𝐭(gtl_info.mstats.total_live_bytes == 0); }while(0)
+#define verifyTest() do{ collect(); std::cout << "basicL "<< gtl_info.mstats.total_live_bytes << std::endl; 𝐚𝐬𝐬𝐞𝐫𝐭(gtl_info.mstats.total_live_bytes == 0); }while(0)
 
 __CoreCpp::Int basicTreeTest_1()
 {

--- a/src/backend/cpp/gc/test/tree_basic/tree_basic.cpp
+++ b/src/backend/cpp/gc/test/tree_basic/tree_basic.cpp
@@ -1,97 +1,232 @@
-#define verifyTest() do{ collect(); std::cout << "basicL "<< gtl_info.mstats.total_live_bytes << std::endl; 𝐚𝐬𝐬𝐞𝐫𝐭(gtl_info.mstats.total_live_bytes == 0); }while(0)
+#define verifyTest() do{ collect(); 𝐚𝐬𝐬𝐞𝐫𝐭(gtl_info.mstats.total_live_bytes == 0); }while(0)
 
 __CoreCpp::Int basicTreeTest_1()
 {
-    [[maybe_unused]] Main::BasicTree t = Main::makeTree(1_n, 0_n);
-    [[maybe_unused]] Main::BasicTree tt = Main::makeTree(1_n, 0_n);
+    garray[0] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(1_n, 0_n));
 
     collect();
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
     𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+
+    verifyTest();
 
     return 1_i;
 }
 
 __CoreCpp::Int basicTreeTest_3()
 {
-    [[maybe_unused]] Main::BasicTree t = Main::makeTree(3_n, 0_n);
-    [[maybe_unused]] Main::BasicTree tt = Main::makeTree(3_n, 0_n);
+    garray[0] = Main::accessNode(Main::makeTree(3_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(3_n, 0_n));
 
     collect();
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
     𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+
+    verifyTest();
 
     return 1_i;
 }
 
 __CoreCpp::Int basicTreeTest_6()
 {
-    [[maybe_unused]] Main::BasicTree t = Main::makeTree(6_n, 0_n);
-    [[maybe_unused]] Main::BasicTree tt = Main::makeTree(6_n, 0_n);
+    garray[0] = Main::accessNode(Main::makeTree(6_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(6_n, 0_n));
 
     collect();
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
     𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+
+    verifyTest();
 
     return 1_i;
 }
 
 __CoreCpp::Int basicTreeTestMulti_1()
 {
-    [[maybe_unused]] Main::BasicTree t1 = Main::makeTree(1_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t2 = Main::makeTree(1_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t3 = Main::makeTree(1_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t4 = Main::makeTree(1_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t5 = Main::makeTree(1_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t6 = Main::makeTree(1_n, 0_n);
+    garray[0] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[2] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[3] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[4] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[5] = Main::accessNode(Main::makeTree(1_n, 0_n));
 
     collect();
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
     𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+    garray[2] = nullptr;
+    garray[3] = nullptr;
+    garray[4] = nullptr;
+    garray[5] = nullptr;
+
+    verifyTest();
 
     return 1_i;
 }
 
 __CoreCpp::Int basicTreeTestMulti_3()
 {
-    [[maybe_unused]] Main::BasicTree t1 = Main::makeTree(3_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t2 = Main::makeTree(3_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t3 = Main::makeTree(3_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t4 = Main::makeTree(3_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t5 = Main::makeTree(3_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t6 = Main::makeTree(3_n, 0_n);
+    garray[0] = Main::accessNode(Main::makeTree(3_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(3_n, 0_n));
+    garray[2] = Main::accessNode(Main::makeTree(3_n, 0_n));
+    garray[3] = Main::accessNode(Main::makeTree(3_n, 0_n));
+    garray[4] = Main::accessNode(Main::makeTree(3_n, 0_n));
+    garray[5] = Main::accessNode(Main::makeTree(3_n, 0_n));
 
     collect();
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
     𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+    garray[2] = nullptr;
+    garray[3] = nullptr;
+    garray[4] = nullptr;
+    garray[5] = nullptr;
+
+    verifyTest();
 
     return 1_i;
 }
 
 __CoreCpp::Int basicTreeTestMulti_6()
 {
-    [[maybe_unused]] Main::BasicTree t1 = Main::makeTree(6_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t2 = Main::makeTree(6_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t3 = Main::makeTree(6_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t4 = Main::makeTree(6_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t5 = Main::makeTree(6_n, 0_n);
-    [[maybe_unused]] Main::BasicTree t6 = Main::makeTree(6_n, 0_n);
+    garray[0] = Main::accessNode(Main::makeTree(6_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(6_n, 0_n));
+    garray[2] = Main::accessNode(Main::makeTree(6_n, 0_n));
+    garray[3] = Main::accessNode(Main::makeTree(6_n, 0_n));
+    garray[4] = Main::accessNode(Main::makeTree(6_n, 0_n));
+    garray[5] = Main::accessNode(Main::makeTree(6_n, 0_n));
 
     collect();
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
     𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+    garray[2] = nullptr;
+    garray[3] = nullptr;
+    garray[4] = nullptr;
+    garray[5] = nullptr;
+
+    verifyTest();
+
+    return 1_i;
+}
+
+// Wide tree tests with Main:: namespace
+__CoreCpp::Int wideTreeTest_1()
+{
+    garray[0] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(1_n, 0_n));
+
+    collect();
+    uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
+    collect();
+
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+
+    verifyTest();
+
+    return 1_i;
+}
+
+__CoreCpp::Int wideTreeTest_2()
+{
+    garray[0] = Main::accessNode(Main::makeTree(2_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(2_n, 0_n));
+
+    collect();
+    uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
+    collect();
+
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+
+    verifyTest();
+
+    return 1_i;
+}
+
+__CoreCpp::Int wideTreeTestMulti_1()
+{
+    garray[0] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[2] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[3] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[4] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[5] = Main::accessNode(Main::makeTree(1_n, 0_n));
+
+    collect();
+    uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
+    collect();
+
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+    garray[2] = nullptr;
+    garray[3] = nullptr;
+    garray[4] = nullptr;
+    garray[5] = nullptr;
+
+    verifyTest();
+
+    return 1_i;
+}
+
+__CoreCpp::Int wideTreeTestMulti_2()
+{
+    garray[0] = Main::accessNode(Main::makeTree(2_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(2_n, 0_n));
+    garray[2] = Main::accessNode(Main::makeTree(2_n, 0_n));
+    garray[3] = Main::accessNode(Main::makeTree(2_n, 0_n));
+    garray[4] = Main::accessNode(Main::makeTree(2_n, 0_n));
+    garray[5] = Main::accessNode(Main::makeTree(2_n, 0_n));
+
+    collect();
+    uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
+    collect();
+
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+    garray[2] = nullptr;
+    garray[3] = nullptr;
+    garray[4] = nullptr;
+    garray[5] = nullptr;
+
+    verifyTest();
 
     return 1_i;
 }

--- a/src/backend/cpp/gc/test/tree_wide/tree_wide.cpp
+++ b/src/backend/cpp/gc/test/tree_wide/tree_wide.cpp
@@ -1,65 +1,93 @@
-#define verifyTest() do{ collect(); std::cout << "wide "<< gtl_info.mstats.total_live_bytes << std::endl; 𝐚𝐬𝐬𝐞𝐫𝐭(gtl_info.mstats.total_live_bytes == 0); }while(0)
+#define verifyTest() do{ collect(); 𝐚𝐬𝐬𝐞𝐫𝐭(gtl_info.mstats.total_live_bytes == 0); }while(0)
 
 __CoreCpp::Int wideTreeTest_1()
 {
-    [[maybe_unused]] Main::WideTree t = Main::makeTree(1_n, 0_n);
-    [[maybe_unused]] Main::WideTree tt = Main::makeTree(1_n, 0_n);
+    garray[0] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(1_n, 0_n));
 
     collect();
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
     𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+
+    verifyTest();
 
     return 1_i;
 }
 
 __CoreCpp::Int wideTreeTest_2()
 {
-    [[maybe_unused]] Main::WideTree t = Main::makeTree(2_n, 0_n);
-    [[maybe_unused]] Main::WideTree tt = Main::makeTree(2_n, 0_n);
+    garray[0] = Main::accessNode(Main::makeTree(2_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(2_n, 0_n));
 
     collect();
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
     𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+
+    verifyTest();
 
     return 1_i;
 }
 
 __CoreCpp::Int wideTreeTestMulti_1()
 {
-    [[maybe_unused]] Main::WideTree t1 = Main::makeTree(1_n, 0_n);
-    [[maybe_unused]] Main::WideTree t2 = Main::makeTree(1_n, 0_n);
-    [[maybe_unused]] Main::WideTree t3 = Main::makeTree(1_n, 0_n);
-    [[maybe_unused]] Main::WideTree t4 = Main::makeTree(1_n, 0_n);
-    [[maybe_unused]] Main::WideTree t5 = Main::makeTree(1_n, 0_n);
-    [[maybe_unused]] Main::WideTree t6 = Main::makeTree(1_n, 0_n);
+    garray[0] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[2] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[3] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[4] = Main::accessNode(Main::makeTree(1_n, 0_n));
+    garray[5] = Main::accessNode(Main::makeTree(1_n, 0_n));
 
     collect();
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
     𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+    garray[2] = nullptr;
+    garray[3] = nullptr;
+    garray[4] = nullptr;
+    garray[5] = nullptr;
+
+    verifyTest();
 
     return 1_i;
 }
 
 __CoreCpp::Int wideTreeTestMulti_2()
 {
-    [[maybe_unused]] Main::WideTree t1 = Main::makeTree(2_n, 0_n);
-    [[maybe_unused]] Main::WideTree t2 = Main::makeTree(2_n, 0_n);
-    [[maybe_unused]] Main::WideTree t3 = Main::makeTree(2_n, 0_n);
-    [[maybe_unused]] Main::WideTree t4 = Main::makeTree(2_n, 0_n);
-    [[maybe_unused]] Main::WideTree t5 = Main::makeTree(2_n, 0_n);
-    [[maybe_unused]] Main::WideTree t6 = Main::makeTree(2_n, 0_n);
+    garray[0] = Main::accessNode(Main::makeTree(2_n, 0_n));
+    garray[1] = Main::accessNode(Main::makeTree(2_n, 0_n));
+    garray[2] = Main::accessNode(Main::makeTree(2_n, 0_n));
+    garray[3] = Main::accessNode(Main::makeTree(2_n, 0_n));
+    garray[4] = Main::accessNode(Main::makeTree(2_n, 0_n));
+    garray[5] = Main::accessNode(Main::makeTree(2_n, 0_n));
 
     collect();
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
     𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+
+    garray[0] = nullptr;
+    garray[1] = nullptr;
+    garray[2] = nullptr;
+    garray[3] = nullptr;
+    garray[4] = nullptr;
+    garray[5] = nullptr;
+
+    verifyTest();
 
     return 1_i;
 }

--- a/src/backend/cpp/gc/test/tree_wide/tree_wide.cpp
+++ b/src/backend/cpp/gc/test/tree_wide/tree_wide.cpp
@@ -1,4 +1,4 @@
-#define verifyTest() do{ collect(); 𝐚𝐬𝐬𝐞𝐫𝐭(gtl_info.mstats.total_live_bytes == 0); }while(0)
+#define verifyTest() do{ collect(); std::cout << "wide "<< gtl_info.mstats.total_live_bytes << std::endl; 𝐚𝐬𝐬𝐞𝐫𝐭(gtl_info.mstats.total_live_bytes == 0); }while(0)
 
 __CoreCpp::Int wideTreeTest_1()
 {

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -8,7 +8,8 @@
 #include <csetjmp>
 #include <variant> // TODO: Need to remove dependency!
 
-#define 𝐚𝐛𝐨𝐫𝐭 (std::longjmp(__CoreCpp::info.error_handler, true))
+//#define 𝐚𝐛𝐨𝐫𝐭 (std::longjmp(__CoreCpp::info.error_handler, true))
+#define 𝐚𝐛𝐨𝐫𝐭 (assert(false))
 #define 𝐚𝐬𝐬𝐞𝐫𝐭(E) if(!(E)) { 𝐚𝐛𝐨𝐫𝐭; }
 
 namespace __CoreCpp {

--- a/src/backend/cpp/runtime/makefile
+++ b/src/backend/cpp/runtime/makefile
@@ -23,7 +23,7 @@ BUILD := dev
 ALLOC := gc
 
 CC=g++
-CSTDFLAGS=-Wall -Wextra -Wno-unused-parameter -Wuninitialized -Werror -std=gnu++20 -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-omit-frame-pointer -fno-stack-protector -pedantic -Wshadow -Weffc++
+CSTDFLAGS=-Wall -Wextra -Wno-unused-parameter -Wuninitialized -Werror -std=gnu++20 -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-omit-frame-pointer -fno-stack-protector -Wshadow -Weffc++
 
 INTERNAL_FLAGS.gc= 
 INTERNAL_FLAGS.epsilon=-DEPSILON

--- a/src/backend/cpp/runtime/makefile
+++ b/src/backend/cpp/runtime/makefile
@@ -23,7 +23,7 @@ BUILD := dev
 ALLOC := gc
 
 CC=g++
-CSTDFLAGS=-Wall -Wextra -Wno-unused-parameter -Wuninitialized -Werror -std=gnu++20 -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-omit-frame-pointer -fno-stack-protector
+CSTDFLAGS=-Wall -Wextra -Wno-unused-parameter -Wuninitialized -Werror -std=gnu++20 -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-omit-frame-pointer -fno-stack-protector -pedantic -Wshadow -Weffc++
 
 INTERNAL_FLAGS.gc= 
 INTERNAL_FLAGS.epsilon=-DEPSILON

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1700,6 +1700,10 @@ function generateVTableEntry(entry: CPPAssembly::MemberFieldDecl, resolved_name:
 }
 
 function generateVTable(ant: CPPAssembly::AbstractNominalTypeDecl, fields: List<CPPAssembly::MemberFieldDecl>, ctx: Context, indent: String): String {
+    if(fields.size() == 0n) {
+        return "";
+    }
+    
     let nctx = ctx.updateCurrentNamespace(ant.declaredInNS, ant.fullns);
     let full_indent = String::concat("    ", indent);
     
@@ -1713,6 +1717,10 @@ function generateVTable(ant: CPPAssembly::AbstractNominalTypeDecl, fields: List<
 }
 
 function generateEntriesEnum(ant: CPPAssembly::AbstractNominalTypeDecl, fields: List<CPPAssembly::MemberFieldDecl>, ctx: Context, indent: String): String {
+    if(fields.size() == 0n) {
+        return "";
+    }
+    
     let nctx = ctx.updateCurrentNamespace(ant.declaredInNS, ant.fullns);
     let full_indent = String::concat("    ", indent);
     
@@ -1743,7 +1751,7 @@ function emitTypeInfo(info: CPPAssembly::TypeInfo, ant: Option<CPPAssembly::Abst
     }
     else {
         let e = ctx.asm.lookupNominalTypeDeclaration($ant.tkey);
-        if(e?<CPPAssembly::ConceptTypeDecl> || e?<CPPAssembly::DatatypeTypeDecl>) {
+        if((e?<CPPAssembly::ConceptTypeDecl> || e?<CPPAssembly::DatatypeTypeDecl>) && e.saturatedBFieldInfo.size() > 0n) {
             needsvtable = true; 
         }
         else {

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -1002,15 +1002,22 @@ entity CPPTransformer {
 
             if(subant)@<BSQAssembly::AbstractEntityTypeDecl> {
                 let finfo, ntic = this.generateFieldInfo(none, some(subtk), true, acc.2);
+                var size = finfo.slotsize;
+
+                %% Just a pointer so only one slot
+                let subtypetag = this.determineTag(some($subant.tkey), none);
+                if(subtypetag === CPPAssembly::Tag#Ref) {
+                    size = 1n;
+                }
 
                 %% If all subtypes are not of the same tag we must return tagged 
                 var tag = acc.1;
-                if(tag !== CPPAssembly::Tag#Tagged && this.determineTag(some($subant.tkey), none) !== tag) {
+                if(tag !== CPPAssembly::Tag#Tagged && subtypetag !== tag) {
                     tag = CPPAssembly::Tag#Tagged;
                 }
 
-                if(finfo.slotsize > acc.0) {
-                    return finfo.slotsize, tag, ntic;
+                if(size > acc.0) {
+                    return size, tag, ntic;
                 }
                 return acc.0, tag, ntic;
             }

--- a/test/gc/gc_nf.ts
+++ b/test/gc/gc_nf.ts
@@ -46,7 +46,11 @@ function generateCPPFiles(header: string, src: string, cppmain: string, cpp_test
     }
 
     try {
-        let tests = cpp_testcode.concat(src);
+        //
+        // We may need more slots for heavy testing!
+        //
+        let garray = "void* garray[15] { nullptr };\n";
+        let tests = garray.concat(cpp_testcode).concat(src);
         const srcname = path.join(dir, "emit.cpp");
         let updated = srcbase.replace("//CODE", tests);
         let insert = updated.replace(/__CoreCpp::\w+\s+main\s*\([^)]*\)\s*\w*\s*\{[^}]*\}/gs, cppmain);

--- a/test/gc/tree/tree_basic.test.js
+++ b/test/gc/tree/tree_basic.test.js
@@ -3,7 +3,7 @@
 import { runMainCodeGC } from "../../../bin/test/gc/gc_nf.js"
 import { describe, it } from "node:test";
 
-const base = "__CoreCpp::Bool main() {gtl_info.disable_automatic_collections = true;";
+const base = "__CoreCpp::Bool main() {";
 const end = "verifyTest();return true;}"
 
 const test_1 = base.concat("basicTreeTest_1();", end);

--- a/test/gc/tree/tree_basic.test.js
+++ b/test/gc/tree/tree_basic.test.js
@@ -3,8 +3,9 @@
 import { runMainCodeGC } from "../../../bin/test/gc/gc_nf.js"
 import { describe, it } from "node:test";
 
-const base = "__CoreCpp::Bool main() {";
-const end = "verifyTest();return true;}"
+// set up global array, disable stack refs
+const base = "__CoreCpp::Bool main() { GlobalDataStorage::g_global_data.initialize(sizeof(garray), (void**)garray); gtl_info.disable_stack_refs_for_tests = true;\n";
+const end = "\nreturn true;}"
 
 const test_1 = base.concat("basicTreeTest_1();", end);
 const test_3 = base.concat("basicTreeTest_3();", end);

--- a/test/gc/tree/tree_wide.test.js
+++ b/test/gc/tree/tree_wide.test.js
@@ -3,8 +3,9 @@
 import { runMainCodeGC } from "../../../bin/test/gc/gc_nf.js"
 import { describe, it } from "node:test";
 
-const base = "__CoreCpp::Bool main() {";
-const end = "verifyTest();return true;}"
+// set up global array, disable stack refs
+const base = "void* garray[6] { nullptr };\n __CoreCpp::Bool main() { GlobalDataStorage::g_global_data.initialize(sizeof(garray), (void**)garray); gtl_info.disable_stack_refs_for_tests = true;\n";
+const end = "\nreturn true;}"
 
 const test_1 = base.concat("wideTreeTest_1();", end);
 const test_2 = base.concat("wideTreeTest_2();", end);

--- a/test/gc/tree/tree_wide.test.js
+++ b/test/gc/tree/tree_wide.test.js
@@ -3,7 +3,7 @@
 import { runMainCodeGC } from "../../../bin/test/gc/gc_nf.js"
 import { describe, it } from "node:test";
 
-const base = "__CoreCpp::Bool main() {gtl_info.disable_automatic_collections = true;";
+const base = "__CoreCpp::Bool main() {";
 const end = "verifyTest();return true;}"
 
 const test_1 = base.concat("wideTreeTest_1();", end);


### PR DESCRIPTION
This fixes a few various bugs that appeared with the runtime and gc:
 - Our emitted typeinfo was not correctly building the pointer mask for ref type objects, it was just assuming they were value type and inlining their data, leading to very large objects and far too frequent collections as a byproduct
 - We ensure that forwarded objects new locations are in memory are now correctly reflected in whatever object may point to it
 - I fixed our gc tests as they relied heavily on the call stack which lead to some very confusing results, so now they utilize our global data storage to ensure we aren't accidentally running into old data still seen on the stack