### PR TITLE
GC Fixes/Improvements

### DIFF
--- a/src/backend/cpp/gc/src/runtime/common.h
+++ b/src/backend/cpp/gc/src/runtime/common.h
@@ -167,6 +167,8 @@ static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #define GC_REF_COUNT(O) (GC_GET_META_DATA_ADDR(O))->ref_count
 #define GC_TYPE(O) (GC_GET_META_DATA_ADDR(O))->type
 
+#define GC_RESET_ALLOC(META) { (META)->isalloc = false; }
+
 #define GC_SHOULD_VISIT(META) ((META)->isyoung && !(META)->ismarked)
 
 #define GC_SHOULD_PROCESS_AS_ROOT(META) ((META)->isalloc && !(META)->isroot)

--- a/src/backend/cpp/gc/src/runtime/common.h
+++ b/src/backend/cpp/gc/src/runtime/common.h
@@ -167,9 +167,6 @@ static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #define GC_REF_COUNT(O) (GC_GET_META_DATA_ADDR(O))->ref_count
 #define GC_TYPE(O) (GC_GET_META_DATA_ADDR(O))->type
 
-#define GC_SET_ALLOC(META)   { (META)->isalloc = true; }
-#define GC_RESET_ALLOC(META) { (META)->isalloc = false; }
-
 #define GC_SHOULD_VISIT(META) ((META)->isyoung && !(META)->ismarked)
 
 #define GC_SHOULD_PROCESS_AS_ROOT(META) ((META)->isalloc && !(META)->isroot)

--- a/src/backend/cpp/gc/src/runtime/common.h
+++ b/src/backend/cpp/gc/src/runtime/common.h
@@ -178,4 +178,7 @@ static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #define GC_CLEAR_YOUNG_MARK(META) { (META)->isyoung = false; }
 #define GC_CLEAR_ROOT_MARK(META) { (META)->ismarked = false; (META)->isroot = false; }
 
-#define GC_SHOULD_FREE_LIST_ADD(META) (!(META)->isalloc || ((META)->ref_count == 0 && !(META)->isroot) || (!(META)->isroot && !(META)->ismarked))
+//
+// Pretty sure this was trying to do too much...
+//
+#define GC_SHOULD_FREE_LIST_ADD(META) (!(META)->isalloc)

--- a/src/backend/cpp/gc/src/runtime/common.h
+++ b/src/backend/cpp/gc/src/runtime/common.h
@@ -152,7 +152,7 @@ typedef struct MetaData
 static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #endif
 
-#define NON_FORWARDED -1
+#define NON_FORWARDED 0
 
 // Resets an objects metadata and updates with index into forward table
 #define RESET_METADATA_FOR_OBJECT(M, FP) ((*(M)) = { .type=nullptr, .isalloc=false, .isyoung=false, .ismarked=false, .isroot=false, .forward_index=FP, .ref_count=0 })
@@ -167,6 +167,9 @@ static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #define GC_REF_COUNT(O) (GC_GET_META_DATA_ADDR(O))->ref_count
 #define GC_TYPE(O) (GC_GET_META_DATA_ADDR(O))->type
 
+#define GC_SET_ALLOC(META)   { (META)->isalloc = true; }
+#define GC_RESET_ALLOC(META) { (META)->isalloc = false; }
+
 #define GC_SHOULD_VISIT(META) ((META)->isyoung && !(META)->ismarked)
 
 #define GC_SHOULD_PROCESS_AS_ROOT(META) ((META)->isalloc && !(META)->isroot)
@@ -178,7 +181,4 @@ static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #define GC_CLEAR_YOUNG_MARK(META) { (META)->isyoung = false; }
 #define GC_CLEAR_ROOT_MARK(META) { (META)->ismarked = false; (META)->isroot = false; }
 
-//
-// Pretty sure this was trying to do too much...
-//
 #define GC_SHOULD_FREE_LIST_ADD(META) (!(META)->isalloc)

--- a/src/backend/cpp/gc/src/runtime/common.h
+++ b/src/backend/cpp/gc/src/runtime/common.h
@@ -181,4 +181,4 @@ static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #define GC_CLEAR_YOUNG_MARK(META) { (META)->isyoung = false; }
 #define GC_CLEAR_ROOT_MARK(META) { (META)->ismarked = false; (META)->isroot = false; }
 
-#define GC_SHOULD_FREE_LIST_ADD(META) (!(META)->isalloc)
+#define GC_SHOULD_FREE_LIST_ADD(META) (!(META)->isalloc || (!(META)->isroot && (META)->ref_count == 0))

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
@@ -6,6 +6,7 @@ GlobalDataStorage GlobalDataStorage::g_global_data{};
 
 PageInfo* PageInfo::initialize(void* block, uint16_t allocsize, uint16_t realsize) noexcept
 {
+    xmem_zerofillpage(block);
     PageInfo* pp = (PageInfo*)block;
 
     pp->freelist = nullptr;
@@ -67,9 +68,6 @@ PageInfo* GlobalPageGCManager::allocateFreshPage(uint16_t entrysize, uint16_t re
         void* page = this->empty_pages;
         this->empty_pages = this->empty_pages->next;
 
-        // I wonder if there is any way to avoid zerofill here?
-        // At the very least we could likely zerofill empty pages on a separate thread? 
-        xmem_zerofillpage(page);
         pp = PageInfo::initialize(page, entrysize, realsize);
         UPDATE_TOTAL_EMPTY_GC_PAGES(gtl_info, --);
     }

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
@@ -118,23 +118,9 @@ void GCAllocator::processPage(PageInfo* p) noexcept
     } 
 }
 
-// Zerofills rest of cached freelists to aid in page rebuilding
-static void fillFreeListRemainder(FreeListEntry* flist, uint16_t size) 
-{
-    FreeListEntry* cur = flist;
-    while(cur != nullptr) {
-        FreeListEntry* next = cur->next;
-
-        xmem_zerofill(cur, size);
-
-        cur = next;
-    }
-}
-
 void GCAllocator::processCollectorPages() noexcept
 {
     if(this->alloc_page != nullptr) {
-        fillFreeListRemainder(this->freelist, this->realsize / sizeof(void*));
         this->alloc_page->rebuild();
         this->processPage(this->alloc_page);
 
@@ -143,7 +129,6 @@ void GCAllocator::processCollectorPages() noexcept
     }
     
     if(this->evac_page != nullptr) {
-        fillFreeListRemainder(this->evacfreelist, this->realsize / sizeof(void*));
         this->evac_page->rebuild();
         this->processPage(this->evac_page);
 

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
@@ -44,6 +44,12 @@ void PageInfo::rebuild() noexcept
         
         GC_INVARIANT_CHECK(meta->ref_count >= 0);
 
+        //
+        // This doesnt interact correctly with evacuation page.
+        // These objects do not have their mark bit set, but they are
+        // very much live and should not be freed
+        //
+
         if(GC_SHOULD_FREE_LIST_ADD(meta)) {
             FreeListEntry* entry = this->getFreelistEntryAtIndex(i);
             entry->next = this->freelist;

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
@@ -46,7 +46,6 @@ void PageInfo::rebuild() noexcept
         GC_INVARIANT_CHECK(meta->forward_index >= 0);
 
         if(GC_SHOULD_FREE_LIST_ADD(meta)) {
-            RESET_METADATA_FOR_OBJECT(meta, NON_FORWARDED);
             FreeListEntry* entry = this->getFreelistEntryAtIndex(i);
             entry->next = this->freelist;
             this->freelist = entry;
@@ -68,6 +67,9 @@ PageInfo* GlobalPageGCManager::allocateFreshPage(uint16_t entrysize, uint16_t re
         void* page = this->empty_pages;
         this->empty_pages = this->empty_pages->next;
 
+        // I wonder if there is any way to avoid zerofill here?
+        // At the very least we could likely zerofill empty pages on a separate thread? 
+        xmem_zerofillpage(page);
         pp = PageInfo::initialize(page, entrysize, realsize);
         UPDATE_TOTAL_EMPTY_GC_PAGES(gtl_info, --);
     }

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
@@ -119,6 +119,15 @@ void GCAllocator::processPage(PageInfo* p) noexcept
     } 
 }
 
+//
+// TODO: Lets write a function that walks the remaining
+// freelist of 'this->freelist' for the active allocator and 
+// evacuator where we zero fill the entire block. 
+// This would cause us to not need to do zerofill on whole pages
+// and we would only hit this 0-2 times per collection.
+//
+// Would fix the metadata bug in rebuilding.
+//
 void GCAllocator::processCollectorPages() noexcept
 {
     if(this->alloc_page != nullptr) {

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.h
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.h
@@ -182,12 +182,8 @@ public:
 #define SET_ALLOC_LAYOUT_HANDLE_CANARY(BASEALLOC, T) PageInfo::initializeWithDebugInfo(BASEALLOC, T)
 #endif
 
-//
-// Not totally sure if this is correct, but an idea to make freelist rebuild even easier
-// is we instead when initailizing an object (fresh meta) set its isalloc flag to false,
-// then when we do our marking we set it to true once we know the object is reachable?
-//
-#define SETUP_ALLOC_INITIALIZE_FRESH_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=true, .ismarked=false, .isroot=false, .forward_index=NON_FORWARDED, .ref_count=0 }
+// New objects will have their alloc bit set once they have been marked (meaning they are known to be live)
+#define SETUP_ALLOC_INITIALIZE_FRESH_META(META, T) *(META) = { .type=(T), .isalloc=false, .isyoung=true, .ismarked=false, .isroot=false, .forward_index=NON_FORWARDED, .ref_count=0 }
 #define SETUP_ALLOC_INITIALIZE_CONVERT_OLD_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=false, .ismarked=false, .isroot=false, .forward_index=NON_FORWARDED, .ref_count=0 }
 
 template<typename T>

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.h
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.h
@@ -133,6 +133,12 @@ public:
         uint64_t* post = (uint64_t*)((uint8_t*)mem + ALLOC_DEBUG_CANARY_SIZE + sizeof(MetaData) + type->type_size);
         *post = ALLOC_DEBUG_CANARY_VALUE;
     }
+
+    inline void decrementPendingDecs() noexcept 
+    {
+        GC_INVARIANT_CHECK(this->pending_decs_count > 0);
+        this->pending_decs_count--;
+    }
 };
 
 class GlobalPageGCManager
@@ -176,6 +182,11 @@ public:
 #define SET_ALLOC_LAYOUT_HANDLE_CANARY(BASEALLOC, T) PageInfo::initializeWithDebugInfo(BASEALLOC, T)
 #endif
 
+//
+// Not totally sure if this is correct, but an idea to make freelist rebuild even easier
+// is we instead when initailizing an object (fresh meta) set its isalloc flag to false,
+// then when we do our marking we set it to true once we know the object is reachable?
+//
 #define SETUP_ALLOC_INITIALIZE_FRESH_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=true, .ismarked=false, .isroot=false, .forward_index=NON_FORWARDED, .ref_count=0 }
 #define SETUP_ALLOC_INITIALIZE_CONVERT_OLD_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=false, .ismarked=false, .isroot=false, .forward_index=NON_FORWARDED, .ref_count=0 }
 

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.h
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.h
@@ -283,13 +283,13 @@ public:
     {
         assert(type->type_size == this->allocsize);
 
-        if(this->freelist == nullptr) [[unlikely]] {
+        if(this->freelist == nullptr) [[unlikely]] { 
             this->allocatorRefreshAllocationPage();
         }
-
+        
         void* entry = this->freelist;
         this->freelist = this->freelist->next;
-            
+        
         SET_ALLOC_LAYOUT_HANDLE_CANARY(entry, type);
         SETUP_ALLOC_INITIALIZE_FRESH_META(SETUP_ALLOC_LAYOUT_GET_META_PTR(entry), type);
 

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.h
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.h
@@ -68,6 +68,8 @@ struct FreeListEntry
 };
 static_assert(sizeof(FreeListEntry) <= sizeof(MetaData), "BlockHeader size is not 8 bytes");
 
+#define PAGE_OFFSET_MASK 0xFFF
+
 class PageInfo
 {
 public:

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.h
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.h
@@ -182,8 +182,7 @@ public:
 #define SET_ALLOC_LAYOUT_HANDLE_CANARY(BASEALLOC, T) PageInfo::initializeWithDebugInfo(BASEALLOC, T)
 #endif
 
-// New objects will have their alloc bit set once they have been marked (meaning they are known to be live)
-#define SETUP_ALLOC_INITIALIZE_FRESH_META(META, T) *(META) = { .type=(T), .isalloc=false, .isyoung=true, .ismarked=false, .isroot=false, .forward_index=NON_FORWARDED, .ref_count=0 }
+#define SETUP_ALLOC_INITIALIZE_FRESH_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=true, .ismarked=false, .isroot=false, .forward_index=NON_FORWARDED, .ref_count=0 }
 #define SETUP_ALLOC_INITIALIZE_CONVERT_OLD_META(META, T) *(META) = { .type=(T), .isalloc=true, .isyoung=false, .ismarked=false, .isroot=false, .forward_index=NON_FORWARDED, .ref_count=0 }
 
 template<typename T>

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -144,9 +144,6 @@ static inline void updateDecrementedObject(void* obj, BSQMemoryTheadLocalInfo& t
     __CoreGC::TypeInfoBase* typeinfo = GC_TYPE(obj);
     if(typeinfo->ptr_mask != PTR_MASK_LEAF && GC_REF_COUNT(obj) == 0) {
         walkPointerMaskForDecrements(tinfo, typeinfo, static_cast<void**>(obj));
-
-        MetaData* m = GC_GET_META_DATA_ADDR(obj);
-        GC_RESET_ALLOC(m);
     }
 }
 

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -350,6 +350,11 @@ static void walkStack(BSQMemoryTheadLocalInfo& tinfo) noexcept
 
 static void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
 {
+    void* obj = *slots;
+    if(obj == nullptr) {
+        return ; // Non-initialized object
+    }
+    
     MetaData* meta = GC_GET_META_DATA_ADDR(*slots);
     GC_INVARIANT_CHECK(meta != nullptr);
 

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -80,7 +80,12 @@ static void computeDeadRootsForDecrement(BSQMemoryTheadLocalInfo& tinfo) noexcep
 }
 
 static inline void handleTaggedObjectDecrement(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept 
-{    
+{
+    // Uninitialized object
+    if(*slots == nullptr) {
+        return ;
+    }
+
     __CoreGC::TypeInfoBase* tagged_typeinfo = (__CoreGC::TypeInfoBase*)*slots;
     switch(tagged_typeinfo->tag) {
         case __CoreGC::Tag::Ref: {
@@ -372,6 +377,11 @@ static void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
 
 static void handleMarkingTaggedObject(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept 
 {
+    // Uninitialized object
+    if(*slots == nullptr) [[unlikely]] {
+        return ;
+    }
+
     __CoreGC::TypeInfoBase* tagged_typeinfo = static_cast<__CoreGC::TypeInfoBase*>(*slots);
     switch(tagged_typeinfo->tag) {
         case __CoreGC::Tag::Ref: {

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -144,6 +144,9 @@ static inline void updateDecrementedObject(void* obj, BSQMemoryTheadLocalInfo& t
     __CoreGC::TypeInfoBase* typeinfo = GC_TYPE(obj);
     if(typeinfo->ptr_mask != PTR_MASK_LEAF && GC_REF_COUNT(obj) == 0) {
         walkPointerMaskForDecrements(tinfo, typeinfo, static_cast<void**>(obj));
+
+        MetaData* m = GC_GET_META_DATA_ADDR(obj);
+        GC_RESET_ALLOC(m);
     }
 }
 

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -46,12 +46,6 @@ static void computeDeadRootsForDecrement(BSQMemoryTheadLocalInfo& tinfo) noexcep
     // First we need to sort the roots we find
     qsort(tinfo.roots, 0, tinfo.roots_count - 1, tinfo.roots_count);
 
-    //
-    // We need to be cautious here, it appears the compiler attemps
-    // to optimize out tinfo.roots_count when it detects there is 
-    // no path that needs it other that qsort
-    //
-
     int32_t roots_idx = 0;
     int32_t oldroots_idx = 0;
 
@@ -469,13 +463,6 @@ static void markingWalk(BSQMemoryTheadLocalInfo& tinfo) noexcept
     MEM_STATS_END(marking_times);
 }
 
-//
-// I believe the last major bug left hanging about is our handling
-// of potential false roots. I think certain cases exercise this, like
-// a root object being created, its children being created with a few
-// still floating on the stack, then a collection triggers causing
-// them to be considered roots.
-//
 void collect() noexcept
 {   
     MEM_STATS_START();

--- a/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
+++ b/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
@@ -9,6 +9,8 @@
 #define MARK_STACK_NODE_COLOR_GREY 0
 #define MARK_STACK_NODE_COLOR_BLACK 1
 
+#define FWD_TABLE_START 1
+
 struct MarkStackEntry
 {
     void* obj;
@@ -71,10 +73,10 @@ struct BSQMemoryTheadLocalInfo
     RegisterContents native_register_contents; //the contents of the native registers extracted in the mark phase
 
     //We assume that the roots always fit in a single page block
-    size_t roots_count;
+    int32_t roots_count;
     void** roots;
     
-    size_t old_roots_count;
+    int32_t old_roots_count;
     void** old_roots;
 
     int forward_table_index;
@@ -106,7 +108,7 @@ struct BSQMemoryTheadLocalInfo
     bool disable_stack_refs_for_tests = false;
 #endif
 
-    BSQMemoryTheadLocalInfo() noexcept : tl_id(0), g_gcallocs(nullptr), native_stack_base(nullptr), native_stack_contents(), native_register_contents(), roots_count(0), roots(nullptr), old_roots_count(0), old_roots(nullptr), forward_table_index(1), forward_table(nullptr), pending_roots(), visit_stack(), pending_young(), pending_decs(), max_decrement_count(BSQ_INITIAL_MAX_DECREMENT_COUNT), mstats() { }
+    BSQMemoryTheadLocalInfo() noexcept : tl_id(0), g_gcallocs(nullptr), native_stack_base(nullptr), native_stack_contents(), native_register_contents(), roots_count(0), roots(nullptr), old_roots_count(0), old_roots(nullptr), forward_table_index(FWD_TABLE_START), forward_table(nullptr), pending_roots(), visit_stack(), pending_young(), pending_decs(), max_decrement_count(BSQ_INITIAL_MAX_DECREMENT_COUNT), mstats() { }
 
     inline GCAllocator* getAllocatorForPageSize(PageInfo* page) noexcept {
         uint8_t idx = this->g_gcallocs_lookuptable[page->allocsize >> 3];

--- a/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
+++ b/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
@@ -77,7 +77,7 @@ struct BSQMemoryTheadLocalInfo
     size_t old_roots_count;
     void** old_roots;
 
-    int forward_table_index = 0;
+    int forward_table_index;
     void** forward_table;
 
     uint32_t newly_filled_pages_count = 0;
@@ -106,7 +106,7 @@ struct BSQMemoryTheadLocalInfo
     bool disable_stack_refs_for_tests = false;
 #endif
 
-    BSQMemoryTheadLocalInfo() noexcept : tl_id(0), g_gcallocs(nullptr), native_stack_base(nullptr), native_stack_contents(), native_register_contents(), roots_count(0), roots(nullptr), old_roots_count(0), old_roots(nullptr), forward_table_index(0), forward_table(nullptr), pending_roots(), visit_stack(), pending_young(), pending_decs(), max_decrement_count(BSQ_INITIAL_MAX_DECREMENT_COUNT), mstats() { }
+    BSQMemoryTheadLocalInfo() noexcept : tl_id(0), g_gcallocs(nullptr), native_stack_base(nullptr), native_stack_contents(), native_register_contents(), roots_count(0), roots(nullptr), old_roots_count(0), old_roots(nullptr), forward_table_index(1), forward_table(nullptr), pending_roots(), visit_stack(), pending_young(), pending_decs(), max_decrement_count(BSQ_INITIAL_MAX_DECREMENT_COUNT), mstats() { }
 
     inline GCAllocator* getAllocatorForPageSize(PageInfo* page) noexcept {
         uint8_t idx = this->g_gcallocs_lookuptable[page->allocsize >> 3];

--- a/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
+++ b/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
@@ -142,7 +142,7 @@ struct BSQMemoryTheadLocalInfo
 #ifdef MEM_STATS
     #include <iostream>
     
-    #define BUCKET_VARIANCE 0.2
+    #define BUCKET_VARIANCE 0.05
     #define BUCKET_AVERAGE ((BUCKET_VARIANCE) / 2)
 
     #define NUM_ALLOCS(E)           (E).mstats.num_allocs

--- a/src/backend/cpp/gc/src/runtime/support/qsort.h
+++ b/src/backend/cpp/gc/src/runtime/support/qsort.h
@@ -7,19 +7,19 @@
 //in a void**
 //
 
-void swap(void** arr, int first, int second) 
+void swap(void** arr, int32_t first, int32_t second) 
 {
     void* tmp = arr[first];
     arr[first] = arr[second];
     arr[second] = tmp;
 }
 
-int partition(void** arr, int low, int high) 
+int32_t partition(void** arr, int32_t low, int32_t high) 
 {
     void* pi = arr[high];
-    int i = low - 1;
+    int32_t i = low - 1;
 
-    for(int j = low; j < high ; j++) {
+    for(int32_t j = low; j < high ; j++) {
         if(arr[j] < pi) {
             i++;
             swap(arr, i, j);
@@ -29,12 +29,20 @@ int partition(void** arr, int low, int high)
     return i + 1;
 }
 
-void qsort(void** arr, int low, int high, int size)
+void __qsort(void** arr, int32_t low, int32_t high, int32_t size) noexcept 
 {
     if(low < high) {
-        int pi = partition(arr, low, high);
+        int32_t pi = partition(arr, low, high);
 
-        qsort(arr, low, pi - 1, size);
-        qsort(arr, pi + 1, high, size);
+        __qsort(arr, low, pi - 1, size);
+        __qsort(arr, pi + 1, high, size);
+    }   
+}
+
+void qsort(void** arr, int32_t low, int32_t high, int32_t size)
+{
+    if(high <= 0) {
+        return ;
     }
+    __qsort(arr, low, high, size);
 }

--- a/src/backend/cpp/gc/test/tree_basic/tree_basic.cpp
+++ b/src/backend/cpp/gc/test/tree_basic/tree_basic.cpp
@@ -9,7 +9,7 @@ __CoreCpp::Int basicTreeTest_1()
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;
@@ -28,7 +28,7 @@ __CoreCpp::Int basicTreeTest_3()
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;
@@ -47,7 +47,7 @@ __CoreCpp::Int basicTreeTest_6()
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;
@@ -70,7 +70,7 @@ __CoreCpp::Int basicTreeTestMulti_1()
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;
@@ -97,7 +97,7 @@ __CoreCpp::Int basicTreeTestMulti_3()
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;
@@ -124,7 +124,7 @@ __CoreCpp::Int basicTreeTestMulti_6()
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;
@@ -148,7 +148,7 @@ __CoreCpp::Int wideTreeTest_1()
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;
@@ -167,7 +167,7 @@ __CoreCpp::Int wideTreeTest_2()
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;
@@ -189,8 +189,8 @@ __CoreCpp::Int wideTreeTestMulti_1()
     collect();
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
-
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;
@@ -216,8 +216,8 @@ __CoreCpp::Int wideTreeTestMulti_2()
     collect();
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
-
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;

--- a/src/backend/cpp/gc/test/tree_wide/tree_wide.cpp
+++ b/src/backend/cpp/gc/test/tree_wide/tree_wide.cpp
@@ -9,7 +9,7 @@ __CoreCpp::Int wideTreeTest_1()
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;
@@ -28,7 +28,7 @@ __CoreCpp::Int wideTreeTest_2()
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;
@@ -51,7 +51,7 @@ __CoreCpp::Int wideTreeTestMulti_1()
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;
@@ -78,7 +78,7 @@ __CoreCpp::Int wideTreeTestMulti_2()
     uint64_t init_bytes = gtl_info.mstats.total_live_bytes;
     collect();
 
-    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes);
+    𝐚𝐬𝐬𝐞𝐫𝐭(init_bytes == gtl_info.mstats.total_live_bytes && gtl_info.mstats.total_live_bytes != 0);
 
     garray[0] = nullptr;
     garray[1] = nullptr;

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -187,8 +187,8 @@ public:
 template <size_t K0, size_t K1>
 class Tuple2 {
 public:
-    TupleEntry<K0> e0;
-    TupleEntry<K1> e1;
+    TupleEntry<K0> e0 {};
+    TupleEntry<K1> e1 {};
     
     Tuple2() noexcept = default;
     Tuple2(const Tuple2& rhs) noexcept = default; 
@@ -211,9 +211,9 @@ public:
 template <size_t K0, size_t K1, size_t K2>
 class Tuple3 {
 public:
-    TupleEntry<K0> e0;
-    TupleEntry<K1> e1;
-    TupleEntry<K2> e2;
+    TupleEntry<K0> e0 {};
+    TupleEntry<K1> e1 {};
+    TupleEntry<K2> e2 {};
     
     Tuple3() noexcept = default;
     Tuple3(const Tuple3& rhs) noexcept = default;
@@ -238,10 +238,10 @@ public:
 template <size_t K0, size_t K1, size_t K2, size_t K3>
 class Tuple4 {
 public:
-    TupleEntry<K0> e0;
-    TupleEntry<K1> e1;
-    TupleEntry<K2> e2;
-    TupleEntry<K3> e3;
+    TupleEntry<K0> e0 {};
+    TupleEntry<K1> e1 {};
+    TupleEntry<K2> e2 {};
+    TupleEntry<K3> e3 {};
     
     Tuple4() noexcept = default;
     Tuple4(const Tuple4& rhs) noexcept = default; 

--- a/test/gc/tree/tree_wide.test.js
+++ b/test/gc/tree/tree_wide.test.js
@@ -4,7 +4,7 @@ import { runMainCodeGC } from "../../../bin/test/gc/gc_nf.js"
 import { describe, it } from "node:test";
 
 // set up global array, disable stack refs
-const base = "void* garray[6] { nullptr };\n __CoreCpp::Bool main() { GlobalDataStorage::g_global_data.initialize(sizeof(garray), (void**)garray); gtl_info.disable_stack_refs_for_tests = true;\n";
+const base = "__CoreCpp::Bool main() { GlobalDataStorage::g_global_data.initialize(sizeof(garray), (void**)garray); gtl_info.disable_stack_refs_for_tests = true;\n";
 const end = "\nreturn true;}"
 
 const test_1 = base.concat("wideTreeTest_1();", end);


### PR DESCRIPTION
- Fixed bug when forwarding pointers their new location was not properly reflected in parent
- Check for determining whether an object was eligible to be inserted on the freelist was way too complex, now we just check if its not allocated or a non root with a zero ref count 
- Ensured no weird type punning fiasco was happening in my quicksort, as we were initially passing a size_t as an int
- Better handling of the root points to root case

I did end up needing to zerofill pages in initialization to prevent left over garbage seeping its way into the collector. 

With these changes I was able to run nbody using `-O3` and canaries disabled for the typical 50,000,000 cycles in ~2 mins with an average collection time of ~0.27ms. This is without our packed 8 byte metadata (as I haven't gotten around to implementing it yet).