### PR TITLE
Op-Pass Benchmark Through Simplify & Explicitify

### DIFF
--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -628,15 +628,40 @@ entity ConstantSimplification {
     }
 
     recursive method processKeyCmpEqualExpression(e: KeyCmpEqualExpression): Expression {
-        let nlhs, nrhs = this.processBinaryArgs[recursive](e.lhs, e.rhs);
+        let nlhs = this.processExpression[recursive](e.lhs);
+        let nrhs = this.processExpression[recursive](e.rhs);
 
-        return e[lhs=nlhs, rhs=nrhs];
+        if(nlhs?!<LiteralSimpleExpression> || nrhs?!<LiteralSimpleExpression>) {
+            return e[lhs=nlhs, rhs=nrhs];
+        }
+        else {
+            if(nlhs@<LiteralSimpleExpression>.value === nrhs@<LiteralSimpleExpression>.value) {
+                return ConstantSimplification::trueExp;
+            }
+            else {
+                return ConstantSimplification::falseExp;
+            }
+        }
     }
 
     recursive method processKeyCmpLessExpression(e: KeyCmpLessExpression): Expression {
-        let nlhs, nrhs = this.processBinaryArgs[recursive](e.lhs, e.rhs);
+        let nlhs = this.processExpression[recursive](e.lhs);
+        let nrhs = this.processExpression[recursive](e.rhs);
 
-        return e[lhs=nlhs, rhs=nrhs];
+        if(nlhs?!<LiteralSimpleExpression> || nrhs?!<LiteralSimpleExpression>) {
+            return e[lhs=nlhs, rhs=nrhs];
+        }
+        else {
+            %%
+            %% Eventually we might want to perform numeric checks here
+            %%
+            if(nlhs@<LiteralSimpleExpression>.value === nrhs@<LiteralSimpleExpression>.value) {
+                return ConstantSimplification::falseExp;
+            }
+            else {
+                 return e[lhs=nlhs, rhs=nrhs];
+            }
+        }
     }
 
     recursive method processBinaryNumericExpression(e: BinaryNumericExpression): Expression {

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -259,6 +259,16 @@ entity ConstantSimplification {
         return e[args=nargs];
     }
 
+    recursive method processConstructorPrimaryMapExpression(e: ConstructorPrimaryMapExpression): Expression {
+        let nargs = this.processArgumentListSimple[recursive](e.args);
+        return e[args=nargs];
+    }
+
+    recursive method processConstructorPrimarySpecialMapEntryExpression(e: ConstructorPrimarySpecialMapEntryExpression): Expression {
+        let nval = this.processUnaryArg[recursive](e.value);
+        return e[value=nval];
+    }
+
     recursive method processConstructorTypeDeclExpression(e: ConstructorTypeDeclExpression): Expression {
         let nval = this.processUnaryArg[recursive](e.value);
         return e[value=nval];
@@ -283,7 +293,8 @@ entity ConstantSimplification {
     recursive method processConstructorExpression(e: ConstructorExpression): Expression {
         match(e)@ {
             ConstructorPrimaryListExpression => { return this.processConstructorPrimaryListExpression[recursive]($e); }
-            | ConstructorPrimaryMapExpression => { abort; }
+            | ConstructorPrimaryMapExpression => { return this.processConstructorPrimaryMapExpression[recursive]($e); }
+            | ConstructorPrimarySpecialMapEntryExpression => { return this.processConstructorPrimarySpecialMapEntryExpression[recursive]($e); }
             | ConstructorPrimarySpecialSomeExpression => { return this.processConstructorPrimarySpecialSomeExpression[recursive]($e); }
             | ConstructorPrimarySpecialOkExpression => { abort; }
             | ConstructorPrimarySpecialFailExpression => { abort; }
@@ -313,6 +324,11 @@ entity ConstantSimplification {
     recursive method processCallTypeFunctionExpression(e: CallTypeFunctionExpression): Expression {
         let ninfo = this.processInvokeArgumentInfoStatic[recursive](e.argsinfo);
         return e[argsinfo=ninfo];
+    }
+
+    recursive method processCallTypeFunctionSpecialExpression(e: CallTypeFunctionSpecialExpression): Expression {
+        let nexp = this.processUnaryArg[recursive](e.exp);
+        return e[exp=nexp];
     }
 
     recursive method processLogicActionAndExpression(e: LogicActionAndExpression): Expression {
@@ -388,6 +404,17 @@ entity ConstantSimplification {
         return e[exp=nexp];
     }
 
+    recursive method processPostfixAssignFields(op: PostfixAssignFields): PostfixAssignFields {
+        let nupdates = op.updates.map<(|NominalTypeSignature, Identifier, NominalTypeSignature, Expression|)>(
+            fn(upd) => {
+                let nupdate = this.processUnaryArg[recursive](upd.3);
+                return upd.0, upd.1, upd.2, nupdate;
+            }
+        );
+
+        return op[updates=nupdates];
+    }
+
     recursive method processPostfixInvokeStatic(op: PostfixInvokeStatic): PostfixInvokeStatic {
         let ninfo = this.processInvokeArgumentInfoStatic[recursive](op.argsinfo);
         return op[argsinfo=ninfo];
@@ -402,7 +429,7 @@ entity ConstantSimplification {
                 | PostfixAccessFromIndex => { return $op; }
                 | PostfixIsTest => { return this.processITestAsTest($op.sinfo, $op.baseType, $op.ttest); }
                 | PostfixAsConvert => { return this.processITestAsConvert($op.sinfo, $op.baseType, $op.ttest); }
-                | PostfixAssignFields => { abort; }
+                | PostfixAssignFields => { return this.processPostfixAssignFields($op); }
                 | PostfixInvokeStatic => { return this.processPostfixInvokeStatic($op); }
                 | PostfixInvokeVirtual => { abort; }
                 | PostfixLiteralKeyAccess => { abort; }
@@ -600,6 +627,18 @@ entity ConstantSimplification {
         }
     }
 
+    recursive method processKeyCmpEqualExpression(e: KeyCmpEqualExpression): Expression {
+        let nlhs, nrhs = this.processBinaryArgs[recursive](e.lhs, e.rhs);
+
+        return e[lhs=nlhs, rhs=nrhs];
+    }
+
+    recursive method processKeyCmpLessExpression(e: KeyCmpLessExpression): Expression {
+        let nlhs, nrhs = this.processBinaryArgs[recursive](e.lhs, e.rhs);
+
+        return e[lhs=nlhs, rhs=nrhs];
+    }
+
     recursive method processBinaryNumericExpression(e: BinaryNumericExpression): Expression {
         let nlhs, nrhs = this.processBinaryArgs[recursive](e.lhs, e.rhs);
 
@@ -766,7 +805,7 @@ entity ConstantSimplification {
             | LambdaInvokeExpression => { return this.processLambdaInvokeExpression[recursive]($e); }
             | CallNamespaceFunctionExpression => { return this.processCallNamespaceFunctionExpression[recursive]($e); }
             | CallTypeFunctionExpression => { return this.processCallTypeFunctionExpression[recursive]($e); }
-            | CallTypeFunctionSpecialExpression => { abort; }
+            | CallTypeFunctionSpecialExpression => { return this.processCallTypeFunctionSpecialExpression[recursive]($e); }
             | CallRefInvokeStaticResolveExpression => { abort; }
             | CallRefInvokeVirtualExpression => { abort; }
             | LogicActionAndExpression => { return this.processLogicActionAndExpression[recursive]($e); }
@@ -780,8 +819,8 @@ entity ConstantSimplification {
             | UnaryExpression => { return this.processUnaryExpression[recursive]($e); }
             | BinaryArithExpression => { return this.processBinaryArithExpression[recursive]($e); }
             | BinaryKeyEqExpression => { return this.processBinaryKeyEqExpression[recursive]($e); }
-            | KeyCmpEqualExpression => { abort; }
-            | KeyCmpLessExpression => { abort; }
+            | KeyCmpEqualExpression => { return this.processKeyCmpEqualExpression[recursive]($e); }
+            | KeyCmpLessExpression => { return this.processKeyCmpLessExpression[recursive]($e); }
             | BinaryNumericExpression => { return this.processBinaryNumericExpression[recursive]($e); }
             | BinLogicExpression => { return this.processBinLogicExpression[recursive]($e); }
             | MapEntryConstructorExpression => { abort; }

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -260,6 +260,16 @@ entity ExplicitifyTransform {
         return e[args=nargs];
     }
 
+    recursive method processConstructorPrimaryMapExpression(e: ConstructorPrimaryMapExpression, vmap: VarMapping): Expression {
+        let nargs = this.processArgumentListConstructCollection[recursive](e.args, e.elemtype, vmap);
+        return e[args=nargs]; 
+    }
+
+    recursive method processConstructorPrimarySpecialMapEntryExpression(e: ConstructorPrimarySpecialMapEntryExpression, vmap: VarMapping): Expression {
+        let nval = this.processUnaryConstructorArg[recursive](e.value, e.valuetype, vmap);
+        return e[value=nval];
+    }
+
     recursive method processConstructorTypeDeclExpression(e: ConstructorTypeDeclExpression, vmap: VarMapping): Expression {
         let nval = this.processUnaryConstructorArg[recursive](e.value, e.valuetype, vmap);
         return e[value=nval];
@@ -287,7 +297,8 @@ entity ExplicitifyTransform {
     recursive method processConstructorExpression(e: ConstructorExpression, vmap: VarMapping): Expression {
         match(e)@ {
             ConstructorPrimaryListExpression => { return this.processConstructorPrimaryListExpression[recursive]($e, vmap); }
-            | ConstructorPrimaryMapExpression => { abort; }
+            | ConstructorPrimaryMapExpression => { return this.processConstructorPrimaryMapExpression[recursive]($e, vmap); }
+            | ConstructorPrimarySpecialMapEntryExpression => { return this.processConstructorPrimarySpecialMapEntryExpression[recursive]($e, vmap); }
             | ConstructorPrimarySpecialSomeExpression => { return this.processConstructorPrimarySpecialSomeExpression[recursive]($e, vmap); }
             | ConstructorPrimarySpecialOkExpression => { abort; }
             | ConstructorPrimarySpecialFailExpression => { abort; }
@@ -323,6 +334,14 @@ entity ExplicitifyTransform {
         let nargs = this.processInvokeArgumentInfoStatic[recursive](e.sinfo, params, e.argsinfo, vmap);
 
         return e[argsinfo=nargs];
+    }
+
+    %% TODO: Try to understand this a tad better
+    recursive method processCallTypeFunctionSpecialExpression(e: CallTypeFunctionSpecialExpression, vmap: VarMapping): Expression {
+        let nexp = this.processExpression[recursive](e.exp, vmap);
+        let cexp = this.processCoerceTypeAsNeeded(nexp, e.resolvedDeclType);
+
+        return e[exp=cexp];
     }
 
     recursive method processLogicActionAndExpression(e: LogicActionAndExpression, vmap: VarMapping): Expression {
@@ -382,6 +401,19 @@ entity ExplicitifyTransform {
         return e[exp=cexp];
     }
 
+    recursive method processPostfixAssignFields(op: PostfixAssignFields, vmap: VarMapping): PostfixAssignFields {
+        let nupdates = op.updates.map<(|NominalTypeSignature, Identifier, NominalTypeSignature, Expression|)>(
+            fn(upd) => {
+                let nupdate = this.processExpression[recursive](upd.3, vmap);
+                let cupdate = this.processCoerceTypeAsNeeded(nupdate, upd.2);
+
+                return upd.0, upd.1, upd.2, cupdate;
+            }
+        );
+
+        return op[updates=nupdates];
+    }
+
     recursive method processPostfixInvokeStatic(op: PostfixInvokeStatic, vmap: VarMapping): PostfixInvokeStatic {
         let smdecl = this.assembly.staticmethods.get(op.resolvedTrgt);
         let nargs = this.processInvokeArgumentInfoStatic[recursive](op.sinfo, smdecl.params, op.argsinfo, vmap);
@@ -398,7 +430,7 @@ entity ExplicitifyTransform {
                 | PostfixAccessFromIndex => { return $op; }
                 | PostfixIsTest => { return $op; }
                 | PostfixAsConvert => { return $op; }
-                | PostfixAssignFields => { abort; }
+                | PostfixAssignFields => { return this.processPostfixAssignFields[recursive]($op, vmap); }
                 | PostfixInvokeStatic => { return this.processPostfixInvokeStatic[recursive]($op, vmap); }
                 | PostfixInvokeVirtual => { abort; }
                 | PostfixLiteralKeyAccess => { abort; }
@@ -496,6 +528,28 @@ entity ExplicitifyTransform {
         }
     }
 
+    recursive method processKeyCmpEqualExpression(e: KeyCmpEqualExpression, vmap: VarMapping): Expression {
+        let nlhs = this.processExpression[recursive](e.lhs, vmap); 
+        let nrhs = this.processExpression[recursive](e.rhs, vmap);
+
+        %%
+        %% What work to do? any?
+        %%
+
+        return e[lhs=nlhs, rhs=nrhs];
+    }
+
+    recursive method processKeyCmpLessExpression(e: KeyCmpLessExpression, vmap: VarMapping): Expression {
+        let nlhs = this.processExpression[recursive](e.lhs, vmap); 
+        let nrhs = this.processExpression[recursive](e.rhs, vmap);
+
+        %%
+        %% What work to do? any?
+        %%
+
+        return e[lhs=nlhs, rhs=nrhs];
+    }
+
     recursive method processBinaryNumericExpression(e: BinaryNumericExpression, vmap: VarMapping): Expression {
         var nlhs, nrhs = this.processBinaryArgs[recursive](e.lhs, e.rhs, vmap);
 
@@ -588,7 +642,7 @@ entity ExplicitifyTransform {
             | LambdaInvokeExpression => { return this.processLambdaInvokeExpression[recursive]($e, vmap); }
             | CallNamespaceFunctionExpression => { return this.processCallNamespaceFunctionExpression[recursive]($e, vmap); }
             | CallTypeFunctionExpression => { return this.processCallTypeFunctionExpression[recursive]($e, vmap); }
-            | CallTypeFunctionSpecialExpression => { abort; }
+            | CallTypeFunctionSpecialExpression => { return this.processCallTypeFunctionSpecialExpression[recursive]($e, vmap); }
             | CallRefInvokeStaticResolveExpression => { abort; }
             | CallRefInvokeVirtualExpression => { abort; }
             | LogicActionAndExpression => { return this.processLogicActionAndExpression[recursive]($e, vmap); }
@@ -602,8 +656,8 @@ entity ExplicitifyTransform {
             | UnaryExpression => { return this.processUnaryExpression[recursive]($e, vmap); }
             | BinaryArithExpression => { return this.processBinaryArithExpression[recursive]($e, vmap); }
             | BinaryKeyEqExpression => { return this.processBinaryKeyEqExpression[recursive]($e, vmap); }
-            | KeyCmpEqualExpression => { abort; }
-            | KeyCmpLessExpression => { abort; }
+            | KeyCmpEqualExpression => { return this.processKeyCmpEqualExpression[recursive]($e, vmap); }
+            | KeyCmpLessExpression => { return this.processKeyCmpLessExpression[recursive]($e, vmap); }
             | BinaryNumericExpression => { return this.processBinaryNumericExpression[recursive]($e, vmap); }
             | BinLogicExpression => { return this.processBinLogicExpression[recursive]($e, vmap); }
             | MapEntryConstructorExpression => { abort; }

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -336,9 +336,6 @@ entity ExplicitifyTransform {
         return e[argsinfo=nargs];
     }
 
-    %%
-    %% TODO: Try to understand this a tad better
-    %%
     recursive method processCallTypeFunctionSpecialExpression(e: CallTypeFunctionSpecialExpression, vmap: VarMapping): Expression {
         let nexp = this.processExpression[recursive](e.exp, vmap);
         let cexp = this.processCoerceTypeAsNeeded(nexp, e.resolvedDeclType);

--- a/src/bsqir/simplifier/explicitify.bsq
+++ b/src/bsqir/simplifier/explicitify.bsq
@@ -336,7 +336,9 @@ entity ExplicitifyTransform {
         return e[argsinfo=nargs];
     }
 
+    %%
     %% TODO: Try to understand this a tad better
+    %%
     recursive method processCallTypeFunctionSpecialExpression(e: CallTypeFunctionSpecialExpression, vmap: VarMapping): Expression {
         let nexp = this.processExpression[recursive](e.exp, vmap);
         let cexp = this.processCoerceTypeAsNeeded(nexp, e.resolvedDeclType);
@@ -531,23 +533,39 @@ entity ExplicitifyTransform {
     recursive method processKeyCmpEqualExpression(e: KeyCmpEqualExpression, vmap: VarMapping): Expression {
         let nlhs = this.processExpression[recursive](e.lhs, vmap); 
         let nrhs = this.processExpression[recursive](e.rhs, vmap);
+        var clhs = this.processCoerceTypeAsNeeded(nlhs, e.ktype);
+        var crhs = this.processCoerceTypeAsNeeded(nrhs, e.ktype);
 
-        %%
-        %% What work to do? any?
-        %%
+        let lhstype = this.assembly.lookupNominalTypeDeclaration(clhs.etype.tkeystr);
+        if(lhstype)@<TypedeclTypeDecl> {
+            clhs = TypeDeclPrimitiveFieldAccessExpression{ clhs.sinfo, $lhstype.valuetype, clhs };
+        }
 
-        return e[lhs=nlhs, rhs=nrhs];
+        let rhstype = this.assembly.lookupNominalTypeDeclaration(crhs.etype.tkeystr);
+        if(rhstype)@<TypedeclTypeDecl> {
+            crhs = TypeDeclPrimitiveFieldAccessExpression{ crhs.sinfo, $rhstype.valuetype, crhs };
+        }
+
+        return e[lhs=clhs, rhs=crhs];
     }
 
     recursive method processKeyCmpLessExpression(e: KeyCmpLessExpression, vmap: VarMapping): Expression {
         let nlhs = this.processExpression[recursive](e.lhs, vmap); 
         let nrhs = this.processExpression[recursive](e.rhs, vmap);
+        var clhs = this.processCoerceTypeAsNeeded(nlhs, e.ktype);
+        var crhs = this.processCoerceTypeAsNeeded(nrhs, e.ktype);
 
-        %%
-        %% What work to do? any?
-        %%
+        let lhstype = this.assembly.lookupNominalTypeDeclaration(clhs.etype.tkeystr);
+        if(lhstype)@<TypedeclTypeDecl> {
+            clhs = TypeDeclPrimitiveFieldAccessExpression{ clhs.sinfo, $lhstype.valuetype, clhs };
+        }
 
-        return e[lhs=nlhs, rhs=nrhs];
+        let rhstype = this.assembly.lookupNominalTypeDeclaration(crhs.etype.tkeystr);
+        if(rhstype)@<TypedeclTypeDecl> {
+            crhs = TypeDeclPrimitiveFieldAccessExpression{ crhs.sinfo, $rhstype.valuetype, crhs };
+        }
+
+        return e[lhs=clhs, rhs=crhs];
     }
 
     recursive method processBinaryNumericExpression(e: BinaryNumericExpression, vmap: VarMapping): Expression {

--- a/src/frontend/bsqir_emit.ts
+++ b/src/frontend/bsqir_emit.ts
@@ -553,7 +553,6 @@ class BSQIREmitter {
         if(cdecl instanceof SomeTypeDecl) {
             const oftype = this.emitTypeSignature(exp.ctype.alltermargs[0]);
 
-
             return `BSQAssembly::ConstructorPrimarySpecialSomeExpression{ ${cbase}, value=${vexp}, ofttype=${oftype} }`;
         }
         if(cdecl instanceof MapEntryTypeDecl) {
@@ -563,7 +562,6 @@ class BSQIREmitter {
             return `BSQAssembly::ConstructorPrimarySpecialMapEntryExpression{ ${cbase}, value=${vexp}, keytype=${keytype}, valuetype=${valuetype} }`;
         }
         else {
-            console.log(cdecl);
             assert(false, "Not implemented -- SpecialConstructableConstructor");
         }
     }


### PR DESCRIPTION
Adds necessary support for our compiler optimization pass benchmark to make it through const simplify and explicitify.