### PR TITLE
Rope Prepend and removePrefixString

### DIFF
--- a/src/backend/cpp/runtime/cppruntime.cpp
+++ b/src/backend/cpp/runtime/cppruntime.cpp
@@ -152,6 +152,39 @@ Bool cbufferLess(CCharBuffer& cb1, CCharBuffer& cb2) noexcept {
     return false;
 }
 
+Bool cbufferIsPrefix(CCharBuffer cb, CCharBuffer& pre) noexcept {
+    assert(pre.size <= cb.size);   
+
+    const uint64_t presize = pre.size.get();
+
+    for(uint64_t i = 0; i < presize; i++) {
+        if(cb.chars[i] != pre.chars[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// Removes prefix from cb1, invariant is cb1 starts with pre
+CCharBuffer& cbufferRemove(CCharBuffer& cb, CCharBuffer& pre) noexcept {
+    assert(pre.size <= cb.size);
+    
+    const uint64_t remove_count = pre.size.get();
+    
+    // Shift chars not in pre then nuke whats left
+    for(uint64_t i = 0; i < cb.size.get() - remove_count; i++) {
+        cb.chars[i] = cb.chars[i + remove_count];
+    }
+    for(uint64_t i = cb.size.get() - remove_count; i < static_cast<uint64_t>(maxCCharBufferSize); i++) {
+        cb.chars[i] = 0;
+    }
+    
+    cb.size -= Nat(remove_count);
+    return cb;
+}
+
+
 UnicodeCharBuffer UnicodeCharBuffer::create_empty() {
     return {{}, 0_n};
 }

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -678,6 +678,8 @@ CCharBuffer& cbufferMerge(CCharBuffer& cb1, CCharBuffer& cb2) noexcept;
 CCharBuffer& cbufferRemainder(CCharBuffer& cb, Nat split) noexcept;
 Bool cbufferEqual(CCharBuffer& cb1, CCharBuffer& cb2) noexcept;
 Bool cbufferLess(CCharBuffer& cb1, CCharBuffer& cb2) noexcept;
+Bool cbufferIsPrefix(CCharBuffer cb, CCharBuffer& pre) noexcept;
+CCharBuffer& cbufferRemove(CCharBuffer& cb1, CCharBuffer& pre) noexcept;
 
 const int maxUnicodeCharBufferSize = 8;
 struct UnicodeCharBuffer {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1509,6 +1509,8 @@ function emitBuiltinBodyImplementation(body: CPPAssembly::BuiltinBodyImplementat
         | "ccharbuffer_maxsize" => { return String::concat(indent, "    return __CoreCpp::Nat(__CoreCpp::maxCCharBufferSize);%n;"); }
         | "ccharbuffer_equal" => { return String::concat(indent, "    return __CoreCpp::cbufferEqual(cb1, cb2);%n;"); }
         | "ccharbuffer_less" => { return String::concat(indent, "    return __CoreCpp::cbufferLess(cb1, cb2);%n;"); }
+        | "ccharbuffer_remove" => { return String::concat(indent, "    return __CoreCpp::cbufferRemove(cb, pre);%n;"); }
+        | "ccharbuffer_isprefix" => { return String::concat(indent, "    return __CoreCpp::cbufferIsPrefix(cb, pre);%n;"); }
         | "nat_to_ccharbuffer" => { return String::concat(indent, "    return __CoreCpp::cbufferFromNat(v);%n;"); }
         | "ccharbuffer_merge" => { return String::concat(indent, "    return __CoreCpp::cbufferMerge(cb1, cb2);%n;"); }
         | "ccharbuffer_remainder" => { return String::concat(indent, "    return __CoreCpp::cbufferRemainder(cb, split);%n;"); }
@@ -1529,6 +1531,9 @@ function emitBuiltinBodyImplementation(body: CPPAssembly::BuiltinBodyImplementat
         | "unicodecharbuffer_remainder" => { return String::concat(indent, "    return __CoreCpp::ubufferRemainder(ub, split);%n;"); }        
         | "cstring_concat2" => { return String::concat(indent, "    return Core::CRopeOps::s_crope_concat2(s1, s2);%n;"); }
         | "cstring_empty" => { return String::concat(indent, "    return Core::CRopeOps::s_crope_empty(s);%n;"); }
+        | "cstring_remove_prefix_string" => { return String::concat(indent, "    return Core::CRopeOps::s_crope_remove_prefix_crope(s, prefix);%n;"); }
+        | "cstring_prepend" => { return String::concat(indent, "    return Core::CRopeOps::s_crope_prepend(s, prefix);%n;"); }
+        | "cstring_starts_with_string" => { return String::concat(indent, "    return Core::CRopeOps::s_crope_starts_with_crope(s, prefix);%n;"); }
         | "string_concat2" => { return String::concat(indent, "    return Core::CRopeOps::s_unicoderope_concat2(s1, s2);%n;"); }
         | "string_empty" => { return String::concat(indent, "    return Core::CRopeOps::s_unicoderope_empty(s);%n;"); }
         | "s_nat_to_cstring" => { return String::concat(indent, "    return Core::CRopeOps::s_nat_to_crope(v);%n;"); }

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -1603,7 +1603,9 @@ entity CPPTransformer {
                     fn(decl) => {
                         let npconcepts = decl.pconcepts.pushBack(cpptk);
                         let nalltypes = decl.alltypes.pushBack(cpptk);
-                        return decl[pconcepts=npconcepts, alltypes=nalltypes];
+                        let ndecl = transformer.updateNSMethods(decl, cpppc@<CPPAssembly::AbstractNominalTypeDecl>);
+
+                        return ndecl[pconcepts=npconcepts, alltypes=nalltypes];
                     });                     
             }); 
 
@@ -1619,7 +1621,9 @@ entity CPPTransformer {
                     fn(decl) => {
                         let nconstructables = decl.constructables.pushBack(cpptk);
                         let nalltypes = decl.alltypes.pushBack(cpptk);
-                        return decl[constructables=nconstructables, alltypes=nalltypes];
+                        let ndecl = transformer.updateNSMethods(decl, cppctd@<CPPAssembly::AbstractNominalTypeDecl>);
+
+                        return ndecl[constructables=nconstructables, alltypes=nalltypes];
                     });                     
             });
 
@@ -1635,7 +1639,9 @@ entity CPPTransformer {
                     fn(decl) => {
                         let ncollections = decl.collections.pushBack(cpptk);
                         let nalltypes = decl.alltypes.pushBack(cpptk);
-                        return decl[collections=ncollections, alltypes=nalltypes];
+                        let ndecl = transformer.updateNSMethods(decl, cppctd@<CPPAssembly::AbstractNominalTypeDecl>);
+
+                        return ndecl[collections=ncollections, alltypes=nalltypes];
                     });                     
             });
 

--- a/src/core/xcore_crope_exec.bsq
+++ b/src/core/xcore_crope_exec.bsq
@@ -14,6 +14,8 @@ namespace CCharBufferOps {
     function natToCBuffer(v: Nat): CCharBuffer = nat_to_ccharbuffer;
     function mergeCBuffers(cb1: CCharBuffer, cb2: CCharBuffer): CCharBuffer = ccharbuffer_merge;
     function remainder(cb: CCharBuffer, split: Nat): CCharBuffer = ccharbuffer_remainder;
+    function remove(cb: CCharBuffer, pre: CCharBuffer): CCharBuffer = ccharbuffer_remove;
+    function isPrefix(cb: CCharBuffer, pre: CCharBuffer): Bool = ccharbuffer_isprefix;
 
     function mergeCBuffers2(cb1: CCharBuffer, cb2: CCharBuffer): (|CCharBuffer, CCharBuffer|) {
         let cb1size = getMaxSize() - cb1.size();
@@ -45,6 +47,14 @@ namespace CRopeOps {
         return XCore::s_createDirect<Rope, CRope>(append(r.value, buf));
     }
 
+    function s_crope_prepend(r1: CRope, r2: CRope): CRope {
+        return XCore::s_createDirect<Rope, CRope>(prepend(r1.value, r2.value));
+    }
+
+    function s_crope_remove_prefix_crope(r: CRope, pre: CRope): CRope {
+        return XCore::s_createDirect<Rope, CRope>(removepre(r.value, pre.value));
+    }
+
     function s_crope_empty(cr: CRope): Bool {
         return cr.value?<BBLeaf>;
     }
@@ -67,6 +77,10 @@ namespace CRopeOps {
 
     function s_crope_less(cr1: CRope, cr2: CRope): Bool {
         return less(cr1.value, cr2.value);
+    }
+
+    function s_crope_starts_with_crope(cr: CRope, pre: CRope): Bool {
+        return startsWithRope(cr.value, pre.value);
     }
 
     function s_nat_to_crope(v: Nat): CRope {
@@ -358,6 +372,10 @@ namespace CRopeOps {
         return Rope::createNode(c, tleft, tright);
     }
 
+    function length(r: Rope): Nat {
+        return Rope::getCharacterCount(r);
+    }
+
     %% We keep track of the closest buffer (current nodes parents left child) for merging
     recursive function append_helper(t: Rope, l: Rope, v: CCharBuffer): Rope {
         match(t)@ {
@@ -370,11 +388,6 @@ namespace CRopeOps {
 
                 %% Merge chars from v into t.buf until t.buf is full
                 if($t.buf.size() < CCharBufferOps::getMaxSize()) {
-
-                    %%
-                    %% TODO: once multi assignment is supported for emission lets one line this
-                    %%
-
                     let tmp = CCharBufferOps::mergeCBuffers2($t.buf, v);
                     let cb1 = tmp.0;
                     let cb2 = tmp.1;
@@ -391,98 +404,160 @@ namespace CRopeOps {
     }
 
     function append(t: Rope, v: CCharBuffer): Rope {
-        var tt: Rope;
         match(t)@ {
             BBLeaf => { 
-                tt = Rope::createLeaf(v); 
+                return Rope::createLeaf(v); 
             }
             | Leaf => {
-                tt = append_helper(t, t, v);
+                return append_helper(t, t, v);
             }
             | Node => {
-                tt = append_helper(t, $t.l, v);
+                return append_helper(t, $t.l, v);
             }
         }
-        
-        let nt = tt@<Node>;    
-        let ntt = if(nt.c === Color#Red) 
-            then Rope::createNode(Color#Black, nt.l, nt.r) 
-            else nt;
-    
-        return ntt;
-        
     }
 
-    function concat(l: Rope, r: Rope): Rope {
-        let nn = Rope::createNode(Color#Red, l, r);
-        let tt = balance(nn.c, nn.l, nn.r);
+    function prepend(r1: Rope, r2: Rope): Rope {
+        return concat(r2, r1);
+    }
 
-        if(tt)@<Node> {
-            let nt = if($tt.c === Color#Red) 
-                then Rope::createNode(Color#Black, $tt.l, $tt.r) 
-                else $tt;
-            return nt;
+    recursive function concat_helper(l: Rope, r: Rope): Rope {
+        let buffers = get_buffers(r);
+        let nl = buffers.reduce<Rope>(l, fn(acc, buf) => append(acc, buf));
+        
+        return nl;
+    }
+
+    %% Append R to L buffer by buffer to ensure buffers are full (if possible) 
+    function concat(l: Rope, r: Rope): Rope {
+        return concat_helper(l, r);
+    }
+
+    recursive function startsWithRope_helper(rbuffers: List<CCharBuffer>, prebuffers: List<CCharBuffer>): Bool {
+        let rbuf, nrbuffers = rbuffers.popFront();
+        let prebuf, nprebuffers = prebuffers.popFront();
+
+        if(prebuf.size() < CCharBufferOps::getMaxSize()) {
+            return CCharBufferOps::isPrefix(rbuf, prebuf);
         }
         else {
-            return tt;
+            return startsWithRope_helper[recursive](nrbuffers, nprebuffers);
         }
-    }     
+    }
+
+    function startsWithRope(r: Rope, pre: Rope): Bool {
+        return startsWithRope_helper(get_buffers(r), get_buffers(pre));
+    }
+
+    function removepre_rebuild(basebuffer: CCharBuffer, buffers: List<CCharBuffer>, split: Nat): Rope {
+        let baserope: Rope = Rope::createLeaf(basebuffer);
+    
+        let res = buffers.reduce<(|Rope, Nat|)>((|baserope, 0n|), fn(acc, buf) => {
+            let current_rope = acc.0;
+            let current_index = acc.1;
+
+            if(current_index >= split) {
+                return append(current_rope, buf), current_index + 1n;
+            }
+            else {
+                return current_rope, current_index + 1n;
+            }
+        }).0;
+
+        return res;
+    }
+
+    function removepre_helper(r: Rope, pre: Rope): Rope {
+        let rbuffers = get_buffers(r);
+        let prebuffers = get_buffers(pre);
+
+        let lastbuffer_idx = prebuffers.size() - 1n;
+
+        let last_prebuffer = prebuffers.back();
+        let last_rbuffer = rbuffers.get(lastbuffer_idx);
+ 
+        let nbuffer = CCharBufferOps::remove(last_rbuffer, last_prebuffer);
+        return removepre_rebuild(nbuffer, rbuffers, lastbuffer_idx + 1n);
+    }
+
+    %% Eventually we will want to turn this into a generic delete function
+    function removepre(r: Rope, pre: Rope): Rope {
+        return removepre_helper(r, pre);
+    }
+
+    recursive function equal_helper(r1buffers: List<CCharBuffer>, r2buffers: List<CCharBuffer>): Bool {
+        if(r1buffers.size() == 0n) {
+            return true;
+        }
+
+        let b1, nr1buffers = r1buffers.popFront();
+        let b2, nr2buffers = r2buffers.popFront();
+
+        if(!CCharBufferOps::equal(b1, b2)) {
+            return false;
+        }
+        else {
+            return equal_helper[recursive](nr1buffers, nr2buffers);
+        }
+    }
 
     function equal(r1: Rope, r2: Rope): Bool {
-        if(r1?<Leaf> && r2?<Leaf>) {
-            let nr1 = r1@<Leaf>;
-            let nr2 = r2@<Leaf>;
+        let r1buffers = get_buffers(r1);
+        let r2buffers = get_buffers(r2);
 
-            return CCharBufferOps::equal(nr1.buf, nr2.buf);
+        if(r1buffers.size() != r2buffers.size()) {
+            return false;
+        } 
+
+        return equal_helper(r1buffers, r2buffers);
+    }
+
+    recursive function less_helper(r1buffers: List<CCharBuffer>, r2buffers: List<CCharBuffer>): Bool {
+        let size1 = r1buffers.size();
+        let size2 = r2buffers.size();
+
+        %% No buffers left in either, must be equal
+        if(size1 == 0n && size2 == 0n) {
+            return false;
         }
 
-        if(r1?<Node> && r2?<Node>) {
-            let nr1 = r1@<Node>;
-            let nr2 = r2@<Node>;
-
-            if(nr1.w != nr2.w) {
-                return false;
-            }
-
-            return equal(nr1.l, nr2.l) && equal(nr1.r, nr2.r);
+        %% All characters of r1 match r2 but r1 is shorter string
+        if(size1 == 0n) {
+            return true;
         }
-    
-        return false;
+        
+        %% All characters of r2 match r1 but r1 is longer string
+        if(size2 == 0n) {
+            return false;
+        }
+
+        let cb1, nr1buffers = r1buffers.popFront();
+        let cb2, nr2buffers = r2buffers.popFront();
+        if(CCharBufferOps::equal(cb1, cb2)) {
+            return less_helper[recursive](nr1buffers, nr2buffers);
+        }
+        else {
+            return CCharBufferOps::less(cb1, cb2);
+        } 
     }
 
     function less(r1: Rope, r2: Rope): Bool {
-        return less_helper(r1, r2, 0n);
+        return less_helper(get_buffers(r1), get_buffers(r2));
+    }
+    
+    recursive function get_buffers_helper(r: Rope, acc: List<CCharBuffer>): List<CCharBuffer> {
+        match(r)@ {
+            BBLeaf => { return acc; }
+            | Leaf => { return acc.pushBack($r.buf); }
+            | Node => {  
+                let left_buffers = get_buffers_helper[recursive]($r.l, acc);   
+                return get_buffers_helper[recursive]($r.r, left_buffers);
+            }
+        }
     }
 
-    recursive function less_helper(r1: Rope, r2: Rope, idx: Nat): Bool {
-        let cb1 = get_buffer(r1, idx);
-        let cb2 = get_buffer(r2, idx);
-
-        let maxbufsize = CCharBufferOps::getMaxSize();
-        if(cb1.size() < maxbufsize) {
-            return CCharBufferOps::less(cb1, cb2);
-        }
-
-        if(CCharBufferOps::equal(cb1, cb2)) {
-            return less_helper[recursive](r1, r2, idx + maxbufsize);
-        }
-        else {
-            return CCharBufferOps::less(cb1, cb2);
-        } 
-    }
-
-    recursive function get_buffer(r: Rope, idx: Nat): CCharBuffer {
-        if(r)@<Leaf> {
-            return $r.buf;
-        }
-        
-        let nr = r@<Node>;
-        if(idx < nr.w) {
-            return get_buffer[recursive](nr.l, idx);
-        }
-        else {
-            return get_buffer[recursive](nr.r, idx - nr.w);
-        } 
+    function get_buffers(r: Rope): List<CCharBuffer> {
+        return get_buffers_helper(r, List<CCharBuffer>{});
     }
 
     datatype Rope of 
@@ -490,10 +565,8 @@ namespace CRopeOps {
         | Leaf { buf: CCharBuffer }
         | Node { c: Color, w: Nat, l: Rope, r: Rope }
     & {
-        function createEmpty(): BBLeaf {
-            return BBLeaf{ };
-        }
-
+        const emptyRope: Rope = BBLeaf{};
+    
         function createLeaf(buf: CCharBuffer): Leaf {
             return Leaf{ buf };
         }

--- a/src/core/xcore_list_exec.bsq
+++ b/src/core/xcore_list_exec.bsq
@@ -861,8 +861,11 @@ namespace ListOps {
 
                 return ntt;
             }
-            | _ => { 
+            | Leaf<T> => { 
                 return nt; 
+            }
+            | BBLeaf<T> => {
+                return nt;
             }
         }
     }

--- a/src/frontend/closed_terms.ts
+++ b/src/frontend/closed_terms.ts
@@ -214,6 +214,14 @@ class InstantiationPropagator {
                     const emptydecl = nns.functions.find((tt) => tt.name === "s_crope_empty") as NamespaceFunctionDecl;
                     this.instantiateNamespaceFunction(nns, emptydecl, []);
                 }
+                if(fkey.endsWith("startsWithString")) {
+                    const emptydecl = nns.functions.find((tt) => tt.name === "s_crope_starts_with_crope") as NamespaceFunctionDecl;
+                    this.instantiateNamespaceFunction(nns, emptydecl, []);
+                }
+                if(fkey.endsWith("removePrefixString")) {
+                    const emptydecl = nns.functions.find((tt) => tt.name === "s_crope_remove_prefix_crope") as NamespaceFunctionDecl;
+                    this.instantiateNamespaceFunction(nns, emptydecl, []);
+                }
             }
         } 
 
@@ -227,6 +235,14 @@ class InstantiationPropagator {
                 }
                 if(fkey.endsWith("s_empty")) {
                     const emptydecl = nns.functions.find((tt) => tt.name === "s_unicoderope_empty") as NamespaceFunctionDecl;
+                    this.instantiateNamespaceFunction(nns, emptydecl, []);
+                }
+                if(fkey.endsWith("startsWithString")) {
+                    const emptydecl = nns.functions.find((tt) => tt.name === "s_unicoderope_starts_with_unicoderope") as NamespaceFunctionDecl;
+                    this.instantiateNamespaceFunction(nns, emptydecl, []);
+                }
+                if(fkey.endsWith("removePrefixString")) {
+                    const emptydecl = nns.functions.find((tt) => tt.name === "s_unicoderope_remove_prefix_unicoderope") as NamespaceFunctionDecl;
                     this.instantiateNamespaceFunction(nns, emptydecl, []);
                 }
             }

--- a/test/cppoutput/mcall_exps/simple_resolved.test.js
+++ b/test/cppoutput/mcall_exps/simple_resolved.test.js
@@ -41,6 +41,18 @@ describe ("CPP Emit Evaluate -- builtin methods", () => {
         runMainCode("public function main(): Bool { return 4611686018427387902n.toCString() === '4611686018427387903'; }", "false");
         runMainCode("public function main(): Bool { return 2048n.toCString() === '1234'; }", "false");
     });
+
+    it("should exec cstring(rope) prepend builtin", function () {
+        runMainCode("public function main(): Bool { return ', World!'.prepend('Hello') === 'Hello, World!'; }", "true");
+        runMainCode("public function main(): Bool { return '.14159'.prepend('3') === '3.14159'; }", "true");
+        runMainCode("public function main(): Bool { return ''.prepend('') === ''; }", "true");
+    });
+
+    it("should exec cstring(rope) removePrefixString builtin", function () {
+        runMainCode("public function main(): Bool { return 'HelloHello, World!'.removePrefixString('Hello') === 'Hello, World!'; }", "true");
+        runMainCode("public function main(): Bool { return '3.141593.14159'.removePrefixString('3.14159') === '3.14159'; }", "true");
+        runMainCode("public function main(): Bool { return 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'.removePrefixString('Lorem ipsum dolor sit amet, ') === 'consectetur adipiscing elit'; }", "true");
+    });
 });
 
 describe ("CPP Emit Evaluate -- eADT methods", () => {


### PR DESCRIPTION
Adds support for rope prepend and removing prefix rope. I also had to add support for testing whether a rope starts with another rope to get these to work and decided to rework a bit of how I structured our rope ops. They now use an iterator based approach where we generate the buffers present in order then walk to simplify comparison logic.