### PR TITLE
GC Bug Fixes

### DIFF
--- a/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
@@ -99,16 +99,9 @@ void GCAllocator::processPage(PageInfo* p) noexcept
     if(insertPageInBucket(this, p)) {
         return ;
     }
-    
-    // Full page
-    if(p == this->evac_page) {
-        p->next = this->filled_pages;
-        filled_pages = p;
-    }
-    else {
-        p->next = this->pendinggc_pages;
-        pendinggc_pages = p;
-    } 
+     
+    p->next = this->filled_pages;
+    filled_pages = p;
 }
 
 void GCAllocator::processCollectorPages() noexcept

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.h
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.h
@@ -211,7 +211,7 @@ public:
 #define SETUP_ALLOC_INITIALIZE_CONVERT_OLD_META(META, T) (*(META)) = { .type=(T), .isalloc=true, .isyoung=false, .ismarked=false, .isroot=false, .forward_index=NON_FORWARDED, .ref_count=0 }
 #else
 #define SETUP_ALLOC_INITIALIZE_FRESH_META(META, T)       { ZERO_METADATA(META); SET_TYPE_PTR(META, T); ((META)->meta |= (ISALLOC_MASK | ISYOUNG_MASK)); } 
-#define SETUP_ALLOC_INITIALIZE_CONVERT_OLD_META(META, T) { ZERO_METADATA(META); SET_TYPE_PTR(META, T); (META)->meta = ((META)->meta & ~ISYOUNG_MASK) | ISALLOC_MASK; }
+#define SETUP_ALLOC_INITIALIZE_CONVERT_OLD_META(META, T) { ZERO_METADATA(META); SET_TYPE_PTR(META, T); (META)->meta |= ISALLOC_MASK; }
 #endif
 
 template<typename T>
@@ -331,18 +331,19 @@ public:
         if(p == alloc_page || p == evac_page) {
             return nullptr;
         }
-
+    
         PageInfo* prev = nullptr;
         PageInfo* cur = this->filled_pages;
         while(cur != nullptr) {
             if(cur == p) {
                 if(prev == nullptr) {
-                    this->filled_pages = nullptr;
+                    this->filled_pages = cur->next;
                 }
                 else {
                     prev->next = cur->next;
-                    return p;
                 }
+                cur->next = nullptr;
+                return p;
             }
             prev = cur;
             cur = cur->next;

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -294,8 +294,10 @@ static void processMarkedYoungObjects(BSQMemoryTheadLocalInfo& tinfo) noexcept
 
         updatePointers((void**)obj, tinfo);
 
-        MetaData* m = GC_GET_META_DATA_ADDR(obj);
-        GC_CLEAR_YOUNG_MARK(m);
+        if(GC_IS_ROOT(obj)) {
+            MetaData* m = GC_GET_META_DATA_ADDR(obj);
+            GC_CLEAR_YOUNG_MARK(m);
+        }
     }
 
     MEM_STATS_END(evacuation_times);

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -214,9 +214,8 @@ static void* forward(void* ptr, BSQMemoryTheadLocalInfo& tinfo)
 
 static inline void updateRef(void** obj, BSQMemoryTheadLocalInfo& tinfo)
 {
-    CHECK_INITIALIZED(*obj);
-
     void* ptr = *obj;
+    CHECK_INITIALIZED(ptr);
 
     // Root points to root case (may be a false root)
     if(GC_IS_ROOT(ptr) || !GC_IS_YOUNG(ptr)) {
@@ -368,6 +367,8 @@ static void walkStack(BSQMemoryTheadLocalInfo& tinfo) noexcept
 
 static void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
 {
+    CHECK_INITIALIZED(*slots);
+
     MetaData* meta = GC_GET_META_DATA_ADDR(*slots);
     GC_INVARIANT_CHECK(meta != nullptr);
 

--- a/src/backend/cpp/gc/src/runtime/memory/threadinfo.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/threadinfo.cpp
@@ -33,7 +33,7 @@ void BSQMemoryTheadLocalInfo::initialize(size_t ntl_id, void** caller_rbp) noexc
     xmem_zerofill(this->old_roots, BSQ_MAX_ROOTS);
 
     this->forward_table = forward_table_array;
-    this->forward_table_index = 0;
+    this->forward_table_index = FWD_TABLE_START;
     xmem_zerofill(this->forward_table, BSQ_MAX_FWD_TABLE_ENTRIES);
 
     this->g_gcallocs = g_gcallocs_array;

--- a/src/backend/cpp/gc/src/runtime/support/arraylist.h
+++ b/src/backend/cpp/gc/src/runtime/support/arraylist.h
@@ -52,30 +52,42 @@ private:
     {
         DSA_INVARIANT_CHECK(this->head == this->head_max);
 
-        ArrayListSegment<T>* xseg = this->head_segment;
-        this->head_segment = this->head_segment->next;
-        this->head_segment->prev = nullptr;
-
-        this->head_min = this->head_segment->data;
-        this->head_max = (T*)((uint8_t*)this->head_segment + BSQ_BLOCK_ALLOCATION_SIZE);
-        this->head = this->head_min;
-
-        XAllocPageManager::g_page_manager.freePage(xseg);
+        if(this->head_segment == this->tail_segment) {
+            this->head = this->head_min;
+            this->tail = this->tail_min;
+        } 
+        else {
+            ArrayListSegment<T>* xseg = this->head_segment;
+            this->head_segment = this->head_segment->next;
+            this->head_segment->prev = nullptr;
+    
+            this->head_min = this->head_segment->data;
+            this->head_max = (T*)((uint8_t*)this->head_segment + BSQ_BLOCK_ALLOCATION_SIZE);
+            this->head = this->head_min;
+    
+            XAllocPageManager::g_page_manager.freePage(xseg);
+        }
     }
 
     void shift_back_slow() noexcept
     {
         DSA_INVARIANT_CHECK(this->tail == this->tail_min);
 
-        ArrayListSegment<T>* xseg = this->tail_segment;
-        this->tail_segment = this->tail_segment->prev;
-        this->tail_segment->next = nullptr;
+        if(this->head_segment == this->tail_segment) {
+            this->head = this->head_min;
+            this->tail = this->tail_min;
+        } 
+        else {
+            ArrayListSegment<T>* xseg = this->tail_segment;
+            this->tail_segment = this->tail_segment->prev;
+            this->tail_segment->next = nullptr;
 
-        this->tail_min = this->tail_segment->data;
-        this->tail_max = (T*)((uint8_t*)this->tail_segment + BSQ_BLOCK_ALLOCATION_SIZE);
-        this->tail = this->tail_max;
+            this->tail_min = this->tail_segment->data;
+            this->tail_max = (T*)((uint8_t*)this->tail_segment + BSQ_BLOCK_ALLOCATION_SIZE);
+            this->tail = this->tail_max;
 
-        XAllocPageManager::g_page_manager.freePage(xseg);
+            XAllocPageManager::g_page_manager.freePage(xseg);
+        }
     }
 
 public:


### PR DESCRIPTION
- We ensure for an object to be forwarded it must be a non root young object 
- When computing dead roots, before putting a root that was dropped from the `old_roots` list onto our `pending_decs` list we ensure its ref count is 0 to handle the root points to root case
- Removed buggy logic in `processPage()` which created the possibility of a page on the `pendinggc_pages` list to be re-inserted onto the same list
- When moving the roots list over to the old roots list we ensure these objects `isyoung` flag is set to false
- Fixed page deletion bug in `tryRemoveFromFilledPages()` where if our page was first item in list we would just keep iterating instead of removing and returning
- If array list is only one page with one element and we try to `shift_front_slow()` or `shift_back_slow()` we now ensure we dont attempt to free the only page left
