### PR TITLE
Cpp Emit Pre Conditions

### DIFF
--- a/src/backend/cpp/cpprepr/cppassembly.bsq
+++ b/src/backend/cpp/cpprepr/cppassembly.bsq
@@ -38,11 +38,8 @@ concept AbstractCoreDecl provides AbstractDecl {
     field name: Identifier;
 }
 
-%%
-%% TODO: We 100% want to support condition decls
-%%
 datatype ConditionDecl provides AbstractDecl using {
-%%    field diagnosticTag: Option<CString>;
+    field diagnosticTag: Option<CString>;
     field ikey: InvokeKey;
     field exp: Expression;
 }
@@ -91,15 +88,19 @@ concept AbstractNominalTypeDecl provides AbstractDecl {
     field tkey: TypeKey;
     field name: CString;
 
+    %%
+    %% TODO: Lets get these two up and running!
+    %%
+    %%field invariants: List<InvariantDecl>;
+    %%field validates: List<ValidateDecl>;
+
     field staticmethods: List<InvokeKey>;
     field virtmethods: List<InvokeKey>;
     field absmethods: List<InvokeKey>;
     field overmethods: List<InvokeKey>;
     
     field saturatedProvides: List<NominalTypeSignature>;
-    field saturatedBFieldInfo: List<SaturatedFieldInfo>;
-    
-    %% invariants, validates, as well
+    field saturatedBFieldInfo: List<SaturatedFieldInfo>;    
 }
 
 concept AbstractInvokeDecl provides AbstractDecl {
@@ -108,6 +109,14 @@ concept AbstractInvokeDecl provides AbstractDecl {
     field params: List<ParameterDecl>;
     field resultType: TypeSignature;
     field body: BodyImplementation;
+}
+
+concept ExplicitInvokeDecl provides AbstractInvokeDecl {
+    field preconditions: List<PreConditionDecl>;
+    field postconditions: List<PostConditionDecl>;
+}
+
+concept FunctionInvokeDecl provides ExplicitInvokeDecl {
 }
 
 concept AbstractEntityTypeDecl provides AbstractNominalTypeDecl {
@@ -212,7 +221,7 @@ entity TypeInfo {
     field tag: Tag;
 }
 
-datatype MethodDecl provides AbstractInvokeDecl using {
+datatype MethodDecl provides ExplicitInvokeDecl using {
 }
 of
 MethodDeclStatic { }
@@ -229,10 +238,10 @@ entity ParameterDecl {
     %% TODO: Support ref/rest param
 }
 
-entity NamespaceFunctionDecl provides AbstractInvokeDecl {
+entity NamespaceFunctionDecl provides FunctionInvokeDecl {
 }
 
-entity TypeFunctionDecl provides AbstractInvokeDecl {
+entity TypeFunctionDecl provides FunctionInvokeDecl {
 }
 
 %% This is not actively being used but MAY prove some use as the emitter expands so ill leave it 

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -10,6 +10,8 @@
 
 #define 𝐚𝐛𝐨𝐫𝐭 (std::longjmp(__CoreCpp::info.error_handler, true))
 #define 𝐚𝐬𝐬𝐞𝐫𝐭(E) if(!(E)) { 𝐚𝐛𝐨𝐫𝐭; }
+#define 𝐫𝐞𝐪𝐮𝐢𝐫𝐞𝐬(𝐄) 𝐚𝐬𝐬𝐞𝐫𝐭(𝐄)
+#define 𝐞𝐧𝐬𝐮𝐫𝐞𝐬(𝐄) 𝐚𝐬𝐬𝐞𝐫𝐭(𝐄)
 
 namespace __CoreCpp {
 

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1698,6 +1698,12 @@ function emitThisType(tk: CPPAssembly::TypeKey, ctx: Context): String {
     return String::concat("[[maybe_unused]] ", resolved_type);
 }
 
+function emitPreConditions(preconds: List<CPPAssembly::PreConditionDecl>, ctx: Context, indent: String): String {    
+    return preconds.reduce<String>("", fn(acc, pc) => {
+        return String::concat(indent, "𝐫𝐞𝐪𝐮𝐢𝐫𝐞𝐬(", emitExpression(pc.exp, ctx), ");%n;");
+    });    
+}
+
 function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
     let nctx = ctx.updateCurrentNamespace(m.declaredInNS, m.fullns);
     let full_indent = String::concat("    ", indent);
@@ -1719,7 +1725,13 @@ function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::Typ
         params_impl = String::concat(base, emitSpecialThis(), ", ", params, ") noexcept");           
     }
 
-    return String::concat(pre, params_impl, " {%n;", emitBodyImplementation(m.body, nctx, indent), indent, "}%n;");
+    let body = emitBodyImplementation(m.body, nctx, indent);
+    let preconds = emitPreConditions(m.preconditions, nctx, full_indent);
+%%  let postconds = emitPostConditions(m.postconditions);
+
+    let fullbody = String::concat(preconds, body);
+
+    return String::concat(pre, params_impl, " {%n;", fullbody, indent, "}%n;");
 }
 
 function emitMethods(ant: CPPAssembly::AbstractNominalTypeDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
@@ -1736,10 +1748,11 @@ function emitMethods(ant: CPPAssembly::AbstractNominalTypeDecl, declaredIn: CPPA
 }
 
 %% Type funcs are fully resolved before cpp emission so we can group them with nsfuncs
-function emitFunctionDecl(func: CPPAssembly::AbstractInvokeDecl, ctx: Context, indent: String): String {
+function emitFunctionDecl(func: CPPAssembly::FunctionInvokeDecl, ctx: Context, indent: String): String {
     let ikey = func.ikey;   
     let ns = func.fullns;
     let nctx = ctx.updateCurrentNamespace(func.declaredInNS, ns);
+    let full_indent = String::concat("    ", indent);
 
     var name = emitInvokeKey(ikey, nctx);
     let params, templates = emitParameters(func.params, nctx);
@@ -1749,7 +1762,13 @@ function emitFunctionDecl(func: CPPAssembly::AbstractInvokeDecl, ctx: Context, i
     let pre: String = String::concat(template, indent, rtype, " ", name );
     let params_impl: String = String::concat("(", params, ") noexcept ");
 
-    return String::concat(pre, params_impl, " {%n;", emitBodyImplementation(func.body, nctx, indent), indent, "}%n;");
+    let body = emitBodyImplementation(func.body, nctx, indent);
+    let preconds = emitPreConditions(func.preconditions, nctx, full_indent);
+%%  let postconds = emitPostConditions(func.postconditions);
+
+    let fullbody = String::concat(preconds, body);
+
+    return String::concat(pre, params_impl, " {%n;", fullbody, indent, "}%n;");
 }
 
 function emitSaturatedFieldInfo(sfi: CPPAssembly::SaturatedFieldInfo, ctx: Context, indent: String): String {
@@ -2218,11 +2237,15 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
 
     %% Emit functions in current namespace
     let nsfuncs = nsdecl.nsfuncs.reduce<String>(methods , fn(acc, ikey) => {
-        return String::concat(acc, emitFunctionDecl(ctx.asm.nsfuncs.get(ikey)@<CPPAssembly::AbstractInvokeDecl>, ctx, full_indent)); 
+        let func = ctx.asm.nsfuncs.get(ikey)@<CPPAssembly::FunctionInvokeDecl>;
+        let efunc = emitFunctionDecl(func, ctx, full_indent);
+        return String::concat(acc, efunc); 
     });
 
     let typefuncs = nsdecl.typefuncs.reduce<String>(nsfuncs, fn(acc, ikey) => {
-        return String::concat(acc, emitFunctionDecl(ctx.asm.typefuncs.get(ikey)@<CPPAssembly::AbstractInvokeDecl>, ctx, full_indent)); 
+        let func = ctx.asm.typefuncs.get(ikey)@<CPPAssembly::FunctionInvokeDecl>;
+        let efunc = emitFunctionDecl(func, ctx, full_indent);
+        return String::concat(acc, efunc); 
     });
 
     return String::concat(typefuncs, indent, "}%n;");

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -1350,35 +1350,60 @@ entity CPPTransformer {
             this.convertTypeSignature(decl.resultType), this.transformBodyToCpp(decl.body)|);
     }
 
+    method transformPreConditionDecl(decl: BSQAssembly::PreConditionDecl): CPPAssembly::PreConditionDecl {
+        let declaredInNS = CPPTransformNameManager::convertNamespaceKey(decl.declaredInNS);
+        let ikey = CPPTransformNameManager::convertInvokeKey(decl.ikey);
+        let exp = this.transformExpressionToCpp(decl.exp);
+        
+        return CPPAssembly::PreConditionDecl{ declaredInNS, decl.fullns, decl.diagnosticTag, ikey, exp, decl.issoft };
+    }
+
+    method transformPostConditionDecl(decl: BSQAssembly::PostConditionDecl): CPPAssembly::PostConditionDecl {
+        let declaredInNS = CPPTransformNameManager::convertNamespaceKey(decl.declaredInNS);
+        let ikey = CPPTransformNameManager::convertInvokeKey(decl.ikey);
+        let exp = this.transformExpressionToCpp(decl.exp);
+        
+        return CPPAssembly::PostConditionDecl{ declaredInNS, decl.fullns, decl.diagnosticTag, ikey, exp, decl.issoft };
+    }
+
+    method transformExplicitInvokeDecl(decl: BSQAssembly::ExplicitInvokeDecl): (|CPPAssembly::NamespaceKey, List<CString>, CString, CPPAssembly::InvokeKey,
+        List<CPPAssembly::ParameterDecl>, CPPAssembly::TypeSignature, CPPAssembly::BodyImplementation, List<CPPAssembly::PreConditionDecl>, List<CPPAssembly::PostConditionDecl>|) {
+            let base = this.transformAbstractInvokeDecl(decl);
+            let preconds = decl.preconditions.map<CPPAssembly::PreConditionDecl>(fn(pcd) => this.transformPreConditionDecl(pcd));
+            let postconds = decl.postconditions.map<CPPAssembly::PostConditionDecl>(fn(pcd) => this.transformPostConditionDecl(pcd));
+
+            return (|base.0, base.1, base.2, base.3, base.4, base.5, base.6, preconds, postconds |);
+        }
+
     method transformStaticMethodDecl(m: BSQAssembly::MethodDeclStatic): CPPAssembly::MethodDeclStatic {
-        let base = this.transformAbstractInvokeDecl(m);
-        return CPPAssembly::MethodDeclStatic{ base.0, base.1, base.2, base.3, base.4, base.5, base.6 };
+        let base = this.transformExplicitInvokeDecl(m);
+        return CPPAssembly::MethodDeclStatic{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8 };
     }
 
     %% Virtual, abstract, and override methods should not emit for now
     method transformVirtualMethodDecl(m: BSQAssembly::MethodDeclVirtual): CPPAssembly::MethodDeclVirtual {
-        let base = this.transformAbstractInvokeDecl(m);
-        return CPPAssembly::MethodDeclVirtual{ base.0, base.1, base.2, base.3, base.4, base.5, base.6 };
+        let base = this.transformExplicitInvokeDecl(m);
+        return CPPAssembly::MethodDeclVirtual{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8 };
     }
 
     method transformAbstractMethodDecl(m: BSQAssembly::MethodDeclAbstract): CPPAssembly::MethodDeclAbstract {
-        let base = this.transformAbstractInvokeDecl(m);
-        return CPPAssembly::MethodDeclAbstract{ base.0, base.1, base.2, base.3, base.4, base.5, base.6 };
+        let base = this.transformExplicitInvokeDecl(m);
+        return CPPAssembly::MethodDeclAbstract{ base.0, base.1, base.2, base.3, base.4, base.5, base.6 , base.7, base.8};
     }
 
     method transformOverrideMethodDecl(m: BSQAssembly::MethodDeclOverride): CPPAssembly::MethodDeclOverride {
-        let base = this.transformAbstractInvokeDecl(m);
-        return CPPAssembly::MethodDeclOverride{ base.0, base.1, base.2, base.3, base.4, base.5, base.6 };
+        let base = this.transformExplicitInvokeDecl(m);
+        return CPPAssembly::MethodDeclOverride{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8 };
     }
 
     method transformNamespaceFunctionDeclToCpp(decl: BSQAssembly::NamespaceFunctionDecl): CPPAssembly::NamespaceFunctionDecl {
-        let base = this.transformAbstractInvokeDecl(decl);
-        return CPPAssembly::NamespaceFunctionDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6 };
+        let base = this.transformExplicitInvokeDecl(decl);
+        return CPPAssembly::NamespaceFunctionDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8 };
     }  
 
     method transformTypeFunctionDeclToCpp(decl: BSQAssembly::TypeFunctionDecl): CPPAssembly::TypeFunctionDecl {
-        let base = this.transformAbstractInvokeDecl(decl);
-        return CPPAssembly::TypeFunctionDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6 };
+        let base = this.transformExplicitInvokeDecl(decl);
+        return CPPAssembly::TypeFunctionDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8 };
     } 
 
     method transformNamespaceConstDeclToCpp(decl: BSQAssembly::NamespaceConstDecl): CPPAssembly::NamespaceConstDecl {

--- a/test/cppoutput/fcall_exps/ns_fcalls_prepost.test.js
+++ b/test/cppoutput/fcall_exps/ns_fcalls_prepost.test.js
@@ -1,0 +1,14 @@
+"use strict";
+
+import { runMainCode, runMainCodeError } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("CPP Emit Evaluate -- NamespaceFunction Pre/Post", () => {
+    it("should exec simple positional", function () {
+        runMainCode("function foo(x: Int): Int requires x > 0i; { return 1i; } public function main(): Int { return foo(3i); }", "1_i");
+    });
+
+    it("should exec simple (fail) positional", function () {
+        runMainCodeError("function foo(x: Int): Int requires x > 0i; { return 1i; } public function main(): Int { return foo(0i); }", "Assertion failed! Or perhaps over/underflow?\n");
+    });
+});

--- a/test/cppoutput/map/map_access.test.js
+++ b/test/cppoutput/map/map_access.test.js
@@ -31,8 +31,6 @@ describe ("CPP Emit Evaluate -- Map access", () => {
         runMainCode('public function main(): Bool { return Map<Int, Int>{1i => 2i, 2i => 3i}.tryGet(5i)?none; }', "true"); 
     });
 
-    // CPP Emitter is lacking pre and post conds so this does not work!
-/*
     it("should fail get empty", function () {
         runMainCodeError('public function main(): Int { return Map<Int, Int>{}.kmin().value; }', "Assertion failed! Or perhaps over/underflow?\n");
         runMainCodeError('public function main(): Int { return Map<Int, Int>{}.kmax().value; }', "Assertion failed! Or perhaps over/underflow?\n");
@@ -43,7 +41,6 @@ describe ("CPP Emit Evaluate -- Map access", () => {
         runMainCodeError('public function main(): Int { return Map<Int, Int>{}.single().value; }', "Assertion failed! Or perhaps over/underflow?\n");
         runMainCodeError('public function main(): Int { return Map<Int, Int>{0i => 5i, 2i => 4i}.single().value; }', "Assertion failed! Or perhaps over/underflow?\n");
     });
-*/
 
     it("should fail get missing", function () {
         runMainCodeError('public function main(): Int { return Map<Int, Int>{1i => 2i, 2i => 3i}.get(3i); }', "Assertion failed! Or perhaps over/underflow?\n");

--- a/test/cppoutput/map/map_delete.test.js
+++ b/test/cppoutput/map/map_delete.test.js
@@ -20,11 +20,8 @@ describe ("CPP Emit Evaluate -- Map delete", () => {
         runMainCode('public function main(): Bool { return Map<Int, Int>{ 7i => 2i}.insert(3i, 1i).delete(3i).delete(7i).size() === 0n; }', "true"); 
     });
 
-    // CPP Emitter is lacking pre and post conds so this does not work!
-/*
     it("should fail delete doesnt exist", function () {
         runMainCodeError('public function main(): Bool { return Map<Int, Bool>{ 1i => true, 2i => false }.delete(3i).size() === 1n; }', "Assertion failed! Or perhaps over/underflow?\n"); 
         runMainCodeError('public function main(): Bool { return Map<Int, Bool>{ 1i => true, 2i => false }.insert(3i, true).delete(1i).get(1i) === true; }', "Assertion failed! Or perhaps over/underflow?\n"); 
     });
-*/
 });


### PR DESCRIPTION
Closes #328.

Adds support for emission of pre conditions. I noticed post conditions aren't used anywhere currently so I decided to just lay out a skeleton for their support but no implementation.