### PR TITLE
Rope Iterator

### DIFF
--- a/src/backend/cpp/runtime/cppruntime.cpp
+++ b/src/backend/cpp/runtime/cppruntime.cpp
@@ -275,10 +275,9 @@ void CRopeIterator::goRight() noexcept {
 }
 
 //
-// This is looking much better but we do still lack proper handling
-// for comparison of buffers that are the same length. I suspect this
-// function is fine, but the startsWithString function needs a 
-// `hasNext` function that is checked before calling next.
+// Sadly there is still a big bug with our stack overflowing, 
+// it appears that we are not properly decrementing index somewhere
+// which causes us to run out of stack space for large strings
 //
 CCharBuffer CRopeIterator::next() noexcept {
     __CRope leaf = this->pathstack.pop(); 
@@ -323,7 +322,7 @@ Bool startsWithCRope(__CRope s, __CRope prefix) noexcept {
     CCharBuffer s_cb = sit.next();
     CCharBuffer p_cb = pit.next();   
     while(true) {
-        if(p_cb.size.get() < maxCCharBufferSize || !cbufferEqual(s_cb, p_cb)) {
+        if(!pit.hasNext() || !cbufferEqual(s_cb, p_cb)) {
             break;
         }
 

--- a/src/backend/cpp/runtime/cppruntime.cpp
+++ b/src/backend/cpp/runtime/cppruntime.cpp
@@ -3,19 +3,6 @@
 namespace __CoreCpp {
 
 ThreadLocalInfo& info = ThreadLocalInfo::get();
-    
-PathStack PathStack::create() {
-    return {0, 0};
-}
-PathStack PathStack::left() const {
-    return { bits << 1, index + 1 };
-}
-PathStack PathStack::right() const {
-    return { bits << 1 | 1, index + 1 };
-}
-PathStack PathStack::up() const {
-    return { bits >> 1, index - 1 };
-}
 
 CCharBuffer CCharBuffer::create_empty() {
     return {{}, 0_n};
@@ -268,6 +255,22 @@ UnicodeCharBuffer& ubufferRemainder(UnicodeCharBuffer& ub, Nat split) noexcept {
     }
 
     return ub;
+}
+
+//
+// TODO: We need to better understand reference semantics here
+// to figure out in what cases we can prevent copying
+//
+
+template<typename Rope>
+Rope RopeStack<Rope>::top() noexcept {
+    return this->stack[this->index - 1];
+}
+
+CCharBuffer CRopeIterator::pop() noexcept {
+    __CRope leaf = this->stack.top();
+
+    return leaf.access<CCharBuffer>();
 }
 
 std::string to_string(MainType v) noexcept {

--- a/src/backend/cpp/runtime/cppruntime.cpp
+++ b/src/backend/cpp/runtime/cppruntime.cpp
@@ -262,6 +262,11 @@ UnicodeCharBuffer& ubufferRemainder(UnicodeCharBuffer& ub, Nat split) noexcept {
 // to figure out in what cases we can prevent copying
 //
 
+//
+// These two are 100% the source of our current bug. I do not believe
+// they correctly access the underlying value, causing two pushes.
+// Not quite sure what this should look like though...
+//
 void CRopeIterator::goLeft() noexcept {
     uintptr_t* nodeptr = this->pathstack.top().access_ref<uintptr_t>();
     __CRope left = *reinterpret_cast<__CRope*>(&nodeptr[CRopeIterator::ltype_offset]);

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -739,13 +739,13 @@ typedef Boxed<sizeof(UnicodeCharBuffer) / 8> __UnicodeRope;
 class Path {
     uint64_t path;
 
-    static const uint64_t left  = 0ull;
+    static const uint64_t path_left  = 0ull;
     static const uint64_t top_mask = 0x1ull; 
 public:
     Path() = default;
 
     inline bool isLeft() const noexcept {
-        return this->path & top_mask == Path::left;
+        return (this->path & top_mask) == Path::path_left;
     }
 
     void left() noexcept;
@@ -758,7 +758,7 @@ class RopeStack {
     Rope stack[64];
     size_t index;
 public:
-    RopeStack() = default;
+    RopeStack() : stack(), index(0) {};
 
     inline bool empty() const noexcept {
         return index == 0;
@@ -772,7 +772,7 @@ public:
         return this->stack[--this->index];
     }
 
-    inline Rope top() noexcept {
+    inline Rope top() const noexcept {
         return this->stack[this->index - 1];
     }
 };
@@ -783,18 +783,18 @@ class CRopeIterator {
 
     // Probably want to actually compute these using the pointer mask
     static const size_t ltype_offset = 2;
-    static const size_t rtype_offset = ltype_offset + 2;
+    static const size_t rtype_offset = ltype_offset + 3;
 
     void front(__CRope& r) noexcept;
 
     inline bool isLeaf() const noexcept {
-        return stack.top().typeinfo->tag == __CoreGC::Tag::Value;
+        return this->stack.top().typeinfo->tag == __CoreGC::Tag::Value;
     }
 
     __CRope getLeft() noexcept;
     __CRope getRight() noexcept;
 public:    
-    CRopeIterator(__CRope& r) noexcept {
+    CRopeIterator(__CRope& r) noexcept : stack(), path() {
         this->front(r);
     };
 
@@ -805,10 +805,12 @@ class UnicodeRopeIterator {
     RopeStack<__UnicodeRope> stack;
     Path path;
 public:
-    UnicodeRopeIterator(__UnicodeRope& r) {};
+    UnicodeRopeIterator(__UnicodeRope& r) : stack(), path() {};
 
     UnicodeCharBuffer pop() noexcept;
 };
+
+Bool startsWithCRope(__CRope s, __CRope prefix) noexcept;
 
 // Will need to support Bosque CString and String eventually
 typedef std::variant<Int, Nat, BigInt, BigNat, Float, Bool> MainType; 

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -739,7 +739,7 @@ typedef Boxed<sizeof(UnicodeCharBuffer) / 8> __UnicodeRope;
 class Path {
     uint64_t path;
 
-    static const uint64_t path_left  = 0ull;
+    static const uint64_t path_left  = 1ull;
     static const uint64_t top_mask = 0x1ull; 
 public:
     Path() = default;
@@ -755,7 +755,7 @@ public:
 
 template<typename Rope>
 class RopeStack {
-    Rope stack[64];
+    Rope* stack[64];
     size_t index;
 public:
     RopeStack() : stack(), index(0) {};
@@ -764,15 +764,15 @@ public:
         return index == 0;
     }
     
-    inline void push(Rope r) noexcept {
-        this->stack[this->index++] = r;
+    inline void push(Rope& r) noexcept {
+        this->stack[this->index++] = &r;
     }
 
-    inline Rope pop() noexcept {
-        return this->stack[--this->index];
+    inline Rope& pop() noexcept {
+        return *this->stack[--this->index];
     }
 
-    inline Rope top() const noexcept {
+    inline Rope& top() const noexcept {
         return this->stack[this->index - 1];
     }
 };
@@ -791,14 +791,14 @@ class CRopeIterator {
         return this->stack.top().typeinfo->tag == __CoreGC::Tag::Value;
     }
 
-    __CRope getLeft() noexcept;
-    __CRope getRight() noexcept;
+    __CRope& getLeft() noexcept;
+    __CRope& getRight() noexcept;
 public:    
     CRopeIterator(__CRope& r) noexcept : stack(), path() {
         this->front(r);
     };
 
-    CCharBuffer next() noexcept;
+    CCharBuffer& next() noexcept;
 };
 
 class UnicodeRopeIterator {
@@ -810,7 +810,7 @@ public:
     UnicodeCharBuffer pop() noexcept;
 };
 
-Bool startsWithCRope(__CRope s, __CRope prefix) noexcept;
+Bool startsWithCRope(__CRope& s, __CRope& prefix) noexcept;
 
 // Will need to support Bosque CString and String eventually
 typedef std::variant<Int, Nat, BigInt, BigNat, Float, Bool> MainType; 

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -755,7 +755,7 @@ public:
 
 template<typename Rope>
 class RopeStack {
-    Rope* stack[64];
+    Rope stack[64];
     size_t index;
 public:
     RopeStack() : stack(), index(0) {};
@@ -764,15 +764,15 @@ public:
         return index == 0;
     }
     
-    inline void push(Rope& r) noexcept {
-        this->stack[this->index++] = &r;
+    inline void push(Rope r) noexcept {
+        this->stack[this->index++] = r;
     }
 
-    inline Rope& pop() noexcept {
-        return *this->stack[--this->index];
+    inline Rope pop() noexcept {
+        return this->stack[--this->index];
     }
 
-    inline Rope& top() const noexcept {
+    inline Rope top() const noexcept {
         return this->stack[this->index - 1];
     }
 };
@@ -791,14 +791,14 @@ class CRopeIterator {
         return this->stack.top().typeinfo->tag == __CoreGC::Tag::Value;
     }
 
-    __CRope& getLeft() noexcept;
-    __CRope& getRight() noexcept;
+    __CRope getLeft() noexcept;
+    __CRope getRight() noexcept;
 public:    
     CRopeIterator(__CRope& r) noexcept : stack(), path() {
         this->front(r);
     };
 
-    CCharBuffer& next() noexcept;
+    CCharBuffer next() noexcept;
 };
 
 class UnicodeRopeIterator {
@@ -810,7 +810,7 @@ public:
     UnicodeCharBuffer pop() noexcept;
 };
 
-Bool startsWithCRope(__CRope& s, __CRope& prefix) noexcept;
+Bool startsWithCRope(__CRope s, __CRope prefix) noexcept;
 
 // Will need to support Bosque CString and String eventually
 typedef std::variant<Int, Nat, BigInt, BigNat, Float, Bool> MainType; 

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -835,6 +835,10 @@ public:
     };
 
     CCharBuffer next() noexcept;
+
+    inline bool hasNext() noexcept {
+        return !this->pathstack.empty();
+    }
 };
 
 class UnicodeRopeIterator {

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1636,7 +1636,7 @@ function emitBuiltinBodyImplementation(body: CPPAssembly::BuiltinBodyImplementat
         | "cstring_empty" => { return String::concat(indent, "    return Core::CRopeOps::s_crope_empty(s);%n;"); }
         | "cstring_remove_prefix_string" => { return String::concat(indent, "    return Core::CRopeOps::s_crope_remove_prefix_crope(s, prefix);%n;"); }
         | "cstring_prepend" => { return String::concat(indent, "    return Core::CRopeOps::s_crope_prepend(s, prefix);%n;"); }
-        | "cstring_starts_with_string" => { return String::concat(indent, "    return Core::CRopeOps::s_crope_starts_with_crope(s, prefix);%n;"); }
+        | "cstring_starts_with_string" => { return String::concat(indent, "    return __CoreCpp::startsWithCRope(s, prefix);%n;"); }
         | "string_concat2" => { return String::concat(indent, "    return Core::CRopeOps::s_unicoderope_concat2(s1, s2);%n;"); }
         | "string_empty" => { return String::concat(indent, "    return Core::CRopeOps::s_unicoderope_empty(s);%n;"); }
         | "s_nat_to_cstring" => { return String::concat(indent, "    return Core::CRopeOps::s_nat_to_crope(v);%n;"); }

--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -1636,7 +1636,8 @@ function emitBuiltinBodyImplementation(body: CPPAssembly::BuiltinBodyImplementat
         | "cstring_empty" => { return String::concat(indent, "    return Core::CRopeOps::s_crope_empty(s);%n;"); }
         | "cstring_remove_prefix_string" => { return String::concat(indent, "    return Core::CRopeOps::s_crope_remove_prefix_crope(s, prefix);%n;"); }
         | "cstring_prepend" => { return String::concat(indent, "    return Core::CRopeOps::s_crope_prepend(s, prefix);%n;"); }
-        | "cstring_starts_with_string" => { return String::concat(indent, "    return __CoreCpp::startsWithCRope(s, prefix);%n;"); }
+        | "cstring_starts_with_string" => { return String::concat(indent, "    return Core::CRopeOps::s_crope_starts_with_crope(s, prefix);%n;"); }
+        | "crope_starts_with_crope" => { return String::concat(indent, "    return __CoreCpp::startsWithCRope(r, pre);%n;"); }
         | "string_concat2" => { return String::concat(indent, "    return Core::CRopeOps::s_unicoderope_concat2(s1, s2);%n;"); }
         | "string_empty" => { return String::concat(indent, "    return Core::CRopeOps::s_unicoderope_empty(s);%n;"); }
         | "s_nat_to_cstring" => { return String::concat(indent, "    return Core::CRopeOps::s_nat_to_crope(v);%n;"); }

--- a/src/core/xcore_crope_exec.bsq
+++ b/src/core/xcore_crope_exec.bsq
@@ -6,8 +6,10 @@ __internal entity CCharBuffer {
     }
 }
 
+%*
 __internal entity CRopeIterator {
 }
+*%
 
 namespace CCharBufferOps {
     function size(cb: CCharBuffer): Nat = ccharbuffer_size;
@@ -80,10 +82,6 @@ namespace CRopeOps {
 
     function s_crope_less(cr1: CRope, cr2: CRope): Bool {
         return less(cr1.value, cr2.value);
-    }
-
-    function s_crope_starts_with_crope(cr: CRope, pre: CRope): Bool {
-        return startsWithRope(cr.value, pre.value);
     }
 
     function s_nat_to_crope(v: Nat): CRope
@@ -424,6 +422,9 @@ namespace CRopeOps {
         return concat(r2, r1);
     }
 
+    %%
+    %% Ouch, concat really needs some love
+    %%
     recursive function concat_helper(l: Rope, r: Rope): Rope {
         let buffers = get_buffers(r);
         let nl = buffers.reduce<Rope>(l, fn(acc, buf) => append(acc, buf));
@@ -434,25 +435,6 @@ namespace CRopeOps {
     %% Append R to L buffer by buffer to ensure buffers are full (if possible) 
     function concat(l: Rope, r: Rope): Rope {
         return concat_helper(l, r);
-    }
-
-    recursive function startsWithRope_helper(rit: CRopeIterator, preit: CRopeIterator): Bool {
-        let rbuf, nrbuffers = rbuffers.popFront();
-        let prebuf, nprebuffers = prebuffers.popFront();
-
-        if(prebuf.size() < CCharBufferOps::getMaxSize()) {
-            return CCharBufferOps::isPrefix(rbuf, prebuf);
-        }
-        else {
-            return startsWithRope_helper[recursive](nrbuffers, nprebuffers);
-        }
-    }
-
-    function startsWithRope(r: Rope, pre: Rope): Bool {
-        let rit = CRopeIterator::initialize(r);
-        let preit = CRopeIterator::initialize(pre);
-
-        return startsWithRope_helper(get_buffers(r), get_buffers(pre));
     }
 
     function removepre_rebuild(basebuffer: CCharBuffer, buffers: List<CCharBuffer>, split: Nat): Rope {

--- a/src/core/xcore_crope_exec.bsq
+++ b/src/core/xcore_crope_exec.bsq
@@ -6,6 +6,9 @@ __internal entity CCharBuffer {
     }
 }
 
+__internal entity CRopeIterator {
+}
+
 namespace CCharBufferOps {
     function size(cb: CCharBuffer): Nat = ccharbuffer_size;
     function getMaxSize(): Nat = ccharbuffer_maxsize;
@@ -83,9 +86,9 @@ namespace CRopeOps {
         return startsWithRope(cr.value, pre.value);
     }
 
-    function s_nat_to_crope(v: Nat): CRope {
-        %% TODO: Once invariant is added to cpp emitter lets use that instead
-        assert CCharBufferOps::getMaxSize() == 8n;
+    function s_nat_to_crope(v: Nat): CRope
+        requires CCharBufferOps::getMaxSize() == 8n;
+    {
       
         let maxNatSizeForBuffer = 99999999n;
         let remainder = 100000000n;
@@ -433,7 +436,7 @@ namespace CRopeOps {
         return concat_helper(l, r);
     }
 
-    recursive function startsWithRope_helper(rbuffers: List<CCharBuffer>, prebuffers: List<CCharBuffer>): Bool {
+    recursive function startsWithRope_helper(rit: CRopeIterator, preit: CRopeIterator): Bool {
         let rbuf, nrbuffers = rbuffers.popFront();
         let prebuf, nprebuffers = prebuffers.popFront();
 
@@ -446,6 +449,9 @@ namespace CRopeOps {
     }
 
     function startsWithRope(r: Rope, pre: Rope): Bool {
+        let rit = CRopeIterator::initialize(r);
+        let preit = CRopeIterator::initialize(pre);
+
         return startsWithRope_helper(get_buffers(r), get_buffers(pre));
     }
 

--- a/src/core/xcore_crope_exec.bsq
+++ b/src/core/xcore_crope_exec.bsq
@@ -60,6 +60,14 @@ namespace CRopeOps {
         return XCore::s_createDirect<Rope, CRope>(removepre(r.value, pre.value));
     }
 
+    function s_crope_starts_with_crope(cr: CRope, pre: CRope): Bool {
+        if(length(pre.value) > length(cr.value)) {
+            return false;
+        }
+
+        return startsWithRope(cr.value, pre.value);
+    }
+
     function s_crope_empty(cr: CRope): Bool {
         return cr.value?<BBLeaf>;
     }
@@ -472,6 +480,8 @@ namespace CRopeOps {
     function removepre(r: Rope, pre: Rope): Rope {
         return removepre_helper(r, pre);
     }
+
+    function startsWithRope(r: Rope, pre: Rope): Bool = crope_starts_with_crope;
 
     recursive function equal_helper(r1buffers: List<CCharBuffer>, r2buffers: List<CCharBuffer>): Bool {
         if(r1buffers.size() == 0n) {

--- a/src/core/xcore_crope_exec.bsq
+++ b/src/core/xcore_crope_exec.bsq
@@ -385,44 +385,45 @@ namespace CRopeOps {
         return Rope::getCharacterCount(r);
     }
 
-    %% We keep track of the closest buffer (current nodes parents left child) for merging
-    recursive function append_helper(t: Rope, l: Rope, v: CCharBuffer): Rope {
-        match(t)@ {
+    recursive function append_helper(r: Rope, v: CCharBuffer): Rope {
+        match(r)@ {
             Leaf => { 
-                %% Merge all of v into t.buf
-                if($t.buf.size() + v.size() <= CCharBufferOps::getMaxSize()) {
-                    let merge = CCharBufferOps::mergeCBuffers($t.buf, v);
+                %% Try to merge buffers
+                if($r.buf.size() + v.size() <= CCharBufferOps::getMaxSize()) {
+                    let merge = CCharBufferOps::mergeCBuffers($r.buf, v);
                     return Rope::createLeaf(merge);
                 }
 
-                %% Merge chars from v into t.buf until t.buf is full
-                if($t.buf.size() < CCharBufferOps::getMaxSize()) {
-                    let tmp = CCharBufferOps::mergeCBuffers2($t.buf, v);
-                    let cb1 = tmp.0;
-                    let cb2 = tmp.1;
+                if($r.buf.size() < CCharBufferOps::getMaxSize()) {
+                    let cb1, cb2 = CCharBufferOps::mergeCBuffers2($r.buf, v);
                     return balance(Color#Red, Rope::createLeaf(cb1), Rope::createLeaf(cb2)); 
-                }
+                } 
 
-                return balance(Color#Red, $t, Rope::createLeaf(v)); 
+                %% Otherwise create a new node with the original leaf and new leaf
+                return balance(Color#Red, $r, Rope::createLeaf(v));
             }
             | Node => { 
-                let nr = append_helper[recursive]($t.r, $t.l, v);
-                return balance($t.c, $t.l, nr); 
+                %% Recurse on the right child, then balance
+                let nr = append_helper[recursive]($r.r, v);
+                return balance($r.c, $r.l, nr); 
             }
         }
     }
 
-    function append(t: Rope, v: CCharBuffer): Rope {
-        match(t)@ {
-            BBLeaf => { 
-                return Rope::createLeaf(v); 
-            }
-            | Leaf => {
-                return append_helper(t, t, v);
-            }
-            | Node => {
-                return append_helper(t, $t.l, v);
-            }
+    function append(r: Rope, v: CCharBuffer): Rope {
+        if(r)<BBLeaf> {
+            return Rope::createLeaf(v); 
+        }
+            
+        let nr = append_helper(r, v);
+        if(nr)@!<Node> {
+            return nr;
+        }
+        else {
+            return if($nr.c === Color#Red) 
+                then Rope::createNode(Color#Black, $nr.l, $nr.r)
+                else $nr;
+            
         }
     }
 

--- a/src/frontend/closed_terms.ts
+++ b/src/frontend/closed_terms.ts
@@ -214,10 +214,12 @@ class InstantiationPropagator {
                     const emptydecl = nns.functions.find((tt) => tt.name === "s_crope_empty") as NamespaceFunctionDecl;
                     this.instantiateNamespaceFunction(nns, emptydecl, []);
                 }
+                /*
                 if(fkey.endsWith("startsWithString")) {
                     const emptydecl = nns.functions.find((tt) => tt.name === "s_crope_starts_with_crope") as NamespaceFunctionDecl;
                     this.instantiateNamespaceFunction(nns, emptydecl, []);
                 }
+                */
                 if(fkey.endsWith("removePrefixString")) {
                     const emptydecl = nns.functions.find((tt) => tt.name === "s_crope_remove_prefix_crope") as NamespaceFunctionDecl;
                     this.instantiateNamespaceFunction(nns, emptydecl, []);

--- a/src/frontend/closed_terms.ts
+++ b/src/frontend/closed_terms.ts
@@ -214,12 +214,10 @@ class InstantiationPropagator {
                     const emptydecl = nns.functions.find((tt) => tt.name === "s_crope_empty") as NamespaceFunctionDecl;
                     this.instantiateNamespaceFunction(nns, emptydecl, []);
                 }
-                /*
                 if(fkey.endsWith("startsWithString")) {
                     const emptydecl = nns.functions.find((tt) => tt.name === "s_crope_starts_with_crope") as NamespaceFunctionDecl;
                     this.instantiateNamespaceFunction(nns, emptydecl, []);
                 }
-                */
                 if(fkey.endsWith("removePrefixString")) {
                     const emptydecl = nns.functions.find((tt) => tt.name === "s_crope_remove_prefix_crope") as NamespaceFunctionDecl;
                     this.instantiateNamespaceFunction(nns, emptydecl, []);

--- a/test/cppoutput/cstring/cstring_startends.test.js
+++ b/test/cppoutput/cstring/cstring_startends.test.js
@@ -1,0 +1,23 @@
+"use strict";
+
+import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
+import { describe, it } from "node:test";
+
+describe ("CString -- startsString/endsString", () => {
+    it("should startsString", function () {
+        runMainCode("public function main(): Bool { return ''.startsWithString('ok'); }", "false");
+
+        runMainCode("public function main(): Bool { return 'ok'.startsWithString('x'); }", "false"); 
+        runMainCode("public function main(): Bool { return 'a-ok'.startsWithString('a-'); }", "true");  
+    });
+
+/*
+    it("should endsString", function () {
+        runMainCode("public function main(): Bool { return ''.endsWithString('ok'); }", "false");
+        
+        runMainCode("public function main(): Bool { return 'ok'.endsWithString('x'); }", "false"); 
+        runMainCode("public function main(): Bool { return 'a-ok'.endsWithString('ok'); }", "true");  
+    });
+*/
+
+});

--- a/test/cppoutput/cstring/cstring_startends.test.js
+++ b/test/cppoutput/cstring/cstring_startends.test.js
@@ -3,12 +3,18 @@
 import { runMainCode } from "../../../bin/test/cppoutput/cppemit_nf.js"
 import { describe, it } from "node:test";
 
-describe ("CString -- startsString/endsString", () => {
+describe ("CPP Emit Evaluate -- CString(rope) startsString/endsString", () => {
     it("should startsString", function () {
         runMainCode("public function main(): Bool { return ''.startsWithString('ok'); }", "false");
 
         runMainCode("public function main(): Bool { return 'ok'.startsWithString('x'); }", "false"); 
-        runMainCode("public function main(): Bool { return 'a-ok'.startsWithString('a-'); }", "true");  
+        runMainCode("public function main(): Bool { return 'a-ok'.startsWithString('a-'); }", "true");
+    });
+    it("should startsString on long-ish string", function () {
+        runMainCode("public function main(): Bool { return 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'.startsWithString('Lorem ipsum dolor sit amet, consectetur adipiscing elit'); }", "true");
+
+        runMainCode("public function main(): Bool { return 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'.startsWithString('Lorem ipsum dolor sit amet'); }", "true");
+        runMainCode("public function main(): Bool { return 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'.startsWithString('Lorem ipsum dolor sit amet, $'); }", "false");
     });
 
 /*


### PR DESCRIPTION
Adds support for rope iteration done in C++. For now I converted `startsWithString()` to use our C++ rope iterators - so there are still quite a few functions left to convert.

Also fixed a bug in append that prevented our ropes from rebalancing!