### PR TITLE
Rope Iterator Inline String Bug Fix

### DIFF
--- a/src/backend/cpp/runtime/cppruntime.cpp
+++ b/src/backend/cpp/runtime/cppruntime.cpp
@@ -275,6 +275,8 @@ void CRopeIterator::initializeTraversal(__CRope& root) noexcept {
     if(root.typeinfo->tag == __CoreGC::Tag::Value) {
         this->inlineString = root;
         this->isInline = true;
+        
+        return ;
     }
 
     this->traversalStack.push(root);
@@ -286,6 +288,7 @@ void CRopeIterator::initializeTraversal(__CRope& root) noexcept {
 
 CCharBuffer CRopeIterator::next() noexcept {
     if(this->isInline) {
+        this->isInline = false;
         return this->inlineString.access<CCharBuffer>();
     }
 

--- a/src/backend/cpp/runtime/cppruntime.cpp
+++ b/src/backend/cpp/runtime/cppruntime.cpp
@@ -258,17 +258,17 @@ UnicodeCharBuffer& ubufferRemainder(UnicodeCharBuffer& ub, Nat split) noexcept {
 }
 
 void CRopeIterator::traverseLeft() noexcept {
-    __CRope& currentNode = this->traversalStack.top();
+    __CRope currentNode = this->traversalStack.top();
     uintptr_t* nodePtr = currentNode.access_ref<uintptr_t>();
-    __CRope& leftChild = *reinterpret_cast<__CRope*>(&nodePtr[LEFT_CHILD_OFFSET]);
-    this->traversalStack.left(leftChild);
+    __CRope* leftChild = reinterpret_cast<__CRope*>(&nodePtr[LEFT_CHILD_OFFSET]);
+    this->traversalStack.left(*leftChild);
 }
 
 void CRopeIterator::traverseRight() noexcept {
-    __CRope& currentNode = this->traversalStack.top();
+    __CRope currentNode = this->traversalStack.top();
     uintptr_t* nodePtr = currentNode.access_ref<uintptr_t>();
-    __CRope& rightChild = *reinterpret_cast<__CRope*>(&nodePtr[RIGHT_CHILD_OFFSET]);
-    this->traversalStack.right(rightChild);
+    __CRope* rightChild = reinterpret_cast<__CRope*>(&nodePtr[RIGHT_CHILD_OFFSET]);
+    this->traversalStack.right(*rightChild);
 }
 
 void CRopeIterator::initializeTraversal(__CRope& root) noexcept {
@@ -280,7 +280,7 @@ void CRopeIterator::initializeTraversal(__CRope& root) noexcept {
 }
 
 CCharBuffer CRopeIterator::next() noexcept {
-    __CRope& leaf = this->traversalStack.pop(); 
+    __CRope leaf = this->traversalStack.pop(); 
     CCharBuffer result = leaf.access<CCharBuffer>();
 
     // Pop all fully visited nodes (nodes where we've visited both children)

--- a/src/backend/cpp/runtime/cppruntime.cpp
+++ b/src/backend/cpp/runtime/cppruntime.cpp
@@ -273,8 +273,8 @@ void CRopeIterator::traverseRight() noexcept {
 
 void CRopeIterator::initializeTraversal(__CRope& root) noexcept {
     if(root.typeinfo->tag == __CoreGC::Tag::Value) {
-        this->inlineRope = root;
-        this->isSingle = true;
+        this->inlineString = root;
+        this->isInline = true;
     }
 
     this->traversalStack.push(root);
@@ -285,8 +285,8 @@ void CRopeIterator::initializeTraversal(__CRope& root) noexcept {
 }
 
 CCharBuffer CRopeIterator::next() noexcept {
-    if(this->isSingle) {
-        return this->inlineRope.access<CCharBuffer>();
+    if(this->isInline) {
+        return this->inlineString.access<CCharBuffer>();
     }
 
     __CRope& leaf = this->traversalStack.pop(); 

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -765,7 +765,7 @@ public:
 
 template<typename Rope>
 class PathStack {
-    Rope* stack[64];
+    Rope stack[64];
     size_t index;
 
     Path path;
@@ -786,7 +786,7 @@ public:
     }
 
     inline void push(Rope& r) noexcept {
-        this->stack[this->index++] = &r;
+        this->stack[this->index++] = r;
     }
 
     inline void left(Rope& r) noexcept {
@@ -801,14 +801,14 @@ public:
         this->path.right();
     }
 
-    inline Rope& pop() noexcept {
+    inline Rope pop() noexcept {
         this->storeLastDirection();
         this->path.up();
-        return *this->stack[--this->index];
+        return this->stack[--this->index];
     }
 
-    inline Rope& top() const noexcept {
-        return *this->stack[this->index - 1];
+    inline Rope top() const noexcept {
+        return this->stack[this->index - 1];
     }
 };
 

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -816,8 +816,8 @@ public:
 class CRopeIterator {
     PathStack<__CRope> traversalStack;
     
-    __CRope inlineRope;
-    bool isSingle;
+    __CRope inlineString;
+    bool isInline;
 
     // We will eventually want to compute these via ptr mask in constructor
     static const size_t LEFT_CHILD_OFFSET = 2;
@@ -832,14 +832,14 @@ class CRopeIterator {
     void traverseLeft() noexcept;
     void traverseRight() noexcept;
 public:    
-    CRopeIterator(__CRope& root) noexcept : traversalStack(), inlineRope(), isSingle(false) {
+    CRopeIterator(__CRope& root) noexcept : traversalStack(), inlineString(), isInline(false) {
         this->initializeTraversal(root);
     };
 
     CCharBuffer next() noexcept;
 
     inline bool hasNext() noexcept {
-        return !this->traversalStack.empty() || this->isSingle;
+        return !this->traversalStack.empty() || this->isInline;
     }
 };
 

--- a/src/backend/cpp/runtime/cppruntime.hpp
+++ b/src/backend/cpp/runtime/cppruntime.hpp
@@ -765,7 +765,7 @@ public:
 
 template<typename Rope>
 class PathStack {
-    Rope stack[64];
+    Rope* stack[64];
     size_t index;
 
     Path path;
@@ -786,7 +786,7 @@ public:
     }
 
     inline void push(Rope& r) noexcept {
-        this->stack[this->index++] = r;
+        this->stack[this->index++] = &r;
     }
 
     inline void left(Rope& r) noexcept {
@@ -801,19 +801,23 @@ public:
         this->path.right();
     }
 
-    inline Rope pop() noexcept {
+    inline Rope& pop() noexcept {
         this->storeLastDirection();
         this->path.up();
-        return this->stack[--this->index];
+            
+        return *this->stack[--this->index];
     }
 
-    inline Rope top() const noexcept {
-        return this->stack[this->index - 1];
+    inline Rope& top() const noexcept {
+        return *this->stack[this->index - 1];
     }
 };
 
 class CRopeIterator {
     PathStack<__CRope> traversalStack;
+    
+    __CRope inlineRope;
+    bool isSingle;
 
     // We will eventually want to compute these via ptr mask in constructor
     static const size_t LEFT_CHILD_OFFSET = 2;
@@ -828,14 +832,14 @@ class CRopeIterator {
     void traverseLeft() noexcept;
     void traverseRight() noexcept;
 public:    
-    CRopeIterator(__CRope& root) noexcept : traversalStack() {
+    CRopeIterator(__CRope& root) noexcept : traversalStack(), inlineRope(), isSingle(false) {
         this->initializeTraversal(root);
     };
 
     CCharBuffer next() noexcept;
 
     inline bool hasNext() noexcept {
-        return !this->traversalStack.empty();
+        return !this->traversalStack.empty() || this->isSingle;
     }
 };
 

--- a/src/core/xcore_crope_exec.bsq
+++ b/src/core/xcore_crope_exec.bsq
@@ -491,13 +491,10 @@ namespace CRopeOps {
 
         var r1_it = CRopeIterator::initialize(r1);
         var r2_it = CRopeIterator::initialize(r2);
-
-        let eq = Algorithm::while<Bool>(true,
+        return Algorithm::while<Bool>(true,
             pred(cond) => r1_it.hasNext(),
             fn(acc) => acc && CCharBufferOps::equal(r1_it.next(), r2_it.next())
         );
-
-        return eq;
     }
 
     function less(r1: Rope, r2: Rope): Bool {

--- a/src/core/xcore_crope_exec.bsq
+++ b/src/core/xcore_crope_exec.bsq
@@ -491,10 +491,13 @@ namespace CRopeOps {
 
         var r1_it = CRopeIterator::initialize(r1);
         var r2_it = CRopeIterator::initialize(r2);
-        return Algorithm::while<Bool>(true,
+
+        let eq = Algorithm::while<Bool>(true,
             pred(cond) => r1_it.hasNext(),
             fn(acc) => acc && CCharBufferOps::equal(r1_it.next(), r2_it.next())
         );
+
+        return eq;
     }
 
     function less(r1: Rope, r2: Rope): Bool {


### PR DESCRIPTION
Discovered a bug with the rope iterators, I forgot about small strings (one buffer) always being stack allocated, so I was previously storing stale stack references! This popped up with higher optimization levels on, as the optimizer was freely moving around the stack allocated buffers I stored a reference to. We now have a special case for only one buffer being present where we do an inexpensive copy.