### PR TITLE
GC Bug Fixes

### DIFF
--- a/src/backend/cpp/gc/src/runtime/common.h
+++ b/src/backend/cpp/gc/src/runtime/common.h
@@ -277,6 +277,15 @@ do { \
 
 #endif
 
+/*
+Closes #317.
+
+This adds verification that potential roots point to the start of an object (not sure how I made it this far without this check!) and the resetting of metadata when initializing a page to ensure we don't try to access garbage metadata left behind by a page's previous owner. Also added some metadata invariant logic.
+
+There are still likely a few bugs left in the GC and I believe there are still a few subtle logic errors hanging around in the ropes, but this should have all the hacky bandages gone.
+*/
+
+
 #ifdef MEM_STATS
 #define TOTAL_ALLOC_COUNT(E)      (E).mstats.total_alloc_count
 #define TOTAL_ALLOC_MEMORY(E)     (E).mstats.total_alloc_memory

--- a/src/backend/cpp/gc/src/runtime/common.h
+++ b/src/backend/cpp/gc/src/runtime/common.h
@@ -183,12 +183,8 @@ static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #define ZERO_METADATA(M) ((*(M)) = {})
 
 #define GC_IS_MARKED(O) (GC_GET_META_DATA_ADDR(O))->ismarked
-
 #define GC_IS_YOUNG(O) (GC_GET_META_DATA_ADDR(O))->isyoung
-#define GC_IS_YOUNG_M(M) (M->isyoung)
-
 #define GC_IS_ALLOCATED(O) (GC_GET_META_DATA_ADDR(O))->isalloc
-
 #define GC_IS_ROOT(O) (GC_GET_META_DATA_ADDR(O))->isroot
 
 #define GC_FWD_INDEX(O) (GC_GET_META_DATA_ADDR(O))->forward_index

--- a/src/backend/cpp/gc/src/runtime/common.h
+++ b/src/backend/cpp/gc/src/runtime/common.h
@@ -277,15 +277,6 @@ do { \
 
 #endif
 
-/*
-Closes #317.
-
-This adds verification that potential roots point to the start of an object (not sure how I made it this far without this check!) and the resetting of metadata when initializing a page to ensure we don't try to access garbage metadata left behind by a page's previous owner. Also added some metadata invariant logic.
-
-There are still likely a few bugs left in the GC and I believe there are still a few subtle logic errors hanging around in the ropes, but this should have all the hacky bandages gone.
-*/
-
-
 #ifdef MEM_STATS
 #define TOTAL_ALLOC_COUNT(E)      (E).mstats.total_alloc_count
 #define TOTAL_ALLOC_MEMORY(E)     (E).mstats.total_alloc_memory

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
@@ -4,17 +4,14 @@
 
 GlobalDataStorage GlobalDataStorage::g_global_data{};
 
-/*
 #ifdef ALLOC_DEBUG_CANARY
 #define RESET_META_FROM_FREELIST(E) ZERO_METADATA(reinterpret_cast<MetaData*>(reinterpret_cast<uint8_t*>(E) + ALLOC_DEBUG_CANARY_SIZE));
 #else
 #define RESET_META_FROM_FREELIST(E) ZERO_METADATA(reinterpret_cast<MetaData*>(reinterpret_cast<uint8_t*>(entry)));
 #endif
-*/
 
 PageInfo* PageInfo::initialize(void* block, uint16_t allocsize, uint16_t realsize) noexcept
 {
-    xmem_zerofillpage(block);
     PageInfo* pp = (PageInfo*)block;
 
     pp->freelist = nullptr;
@@ -32,7 +29,7 @@ PageInfo* PageInfo::initialize(void* block, uint16_t allocsize, uint16_t realsiz
 
     for(int64_t i = pp->entrycount - 1; i >= 0; i--) {
         FreeListEntry* entry = pp->getFreelistEntryAtIndex(i);
-        //RESET_META_FROM_FREELIST(entry);
+        RESET_META_FROM_FREELIST(entry);
         entry->next = pp->freelist;
         pp->freelist = entry;
     }

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
@@ -6,7 +6,6 @@ GlobalDataStorage GlobalDataStorage::g_global_data{};
 
 PageInfo* PageInfo::initialize(void* block, uint16_t allocsize, uint16_t realsize) noexcept
 {
-    xmem_zerofillpage(block);
     PageInfo* pp = (PageInfo*)block;
 
     pp->freelist = nullptr;

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
@@ -7,7 +7,7 @@ GlobalDataStorage GlobalDataStorage::g_global_data{};
 #ifdef ALLOC_DEBUG_CANARY
 #define RESET_META_FROM_FREELIST(E) ZERO_METADATA(reinterpret_cast<MetaData*>(reinterpret_cast<uint8_t*>(E) + ALLOC_DEBUG_CANARY_SIZE));
 #else
-#define RESET_META_FROM_FREELIST(E) ZERO_METADATA(reinterpret_cast<MetaData*>(reinterpret_cast<uint8_t*>(entry)));
+#define RESET_META_FROM_FREELIST(E) ZERO_METADATA(reinterpret_cast<MetaData*>(entry));
 #endif
 
 PageInfo* PageInfo::initialize(void* block, uint16_t allocsize, uint16_t realsize) noexcept

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.h
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.h
@@ -229,7 +229,7 @@ T* MEM_ALLOC_CHECK(T* alloc)
 #define GC_ALLOC_OBJECT(A, L) MEM_ALLOC_CHECK((A).allocate((L)))
 #endif
 
-#define 𝐀𝐥𝐥𝐨𝐜𝐓𝐲𝐩𝐞(T, A, L, ...) (new (GC_ALLOC_OBJECT(A, L)) T(__VA_ARGS__))
+#define 𝐀𝐥𝐥𝐨𝐜𝐓𝐲𝐩𝐞(T, A, L, ...) (allocTypeImpl<T>(A, L, __VA_ARGS__))
 
 #define CALC_APPROX_UTILIZATION(P) 1.0f - ((float)P->freecount / (float)P->entrycount)
 
@@ -406,3 +406,9 @@ public:
     //Get new page for evacuation, append old to filled pages
     void allocatorRefreshEvacuationPage() noexcept;
 };
+
+template<typename T, typename... Args>
+inline T* allocTypeImpl(GCAllocator& alloc, __CoreGC::TypeInfoBase* typeinfo, Args... args) 
+{
+    return new (GC_ALLOC_OBJECT(alloc, typeinfo)) T(args...);
+}

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.h
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.h
@@ -229,17 +229,6 @@ T* MEM_ALLOC_CHECK(T* alloc)
 #define GC_ALLOC_OBJECT(A, L) MEM_ALLOC_CHECK((A).allocate((L)))
 #endif
 
-/*
-    Our bug here is related to how placement new inserts the values associated
-    with an allocated object. The issue is it will first completely finish
-    the outer most allocation (i.e. Alloc1(Alloc2()), Alloc1 completes first)
-    then goes and evaluates our args where it encounters other allocs. The thing is
-    the outer most alloc _will_ end up on the stack as a root or pointed to by something.
-    When we go and walk the pointer of said alloc, it'll point to garbage as its data
-    is just whatever was left behind from old allocations. Not really sure of a good way
-    to handle this that is clean and fast. We need to be very careful to not introduce
-    much extra complexity ESPECIALLY inside our hot path allocations.
-*/
 #define 𝐀𝐥𝐥𝐨𝐜𝐓𝐲𝐩𝐞(T, A, L, ...) (new (GC_ALLOC_OBJECT(A, L)) T(__VA_ARGS__))
 
 #define CALC_APPROX_UTILIZATION(P) 1.0f - ((float)P->freecount / (float)P->entrycount)

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.h
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.h
@@ -229,6 +229,17 @@ T* MEM_ALLOC_CHECK(T* alloc)
 #define GC_ALLOC_OBJECT(A, L) MEM_ALLOC_CHECK((A).allocate((L)))
 #endif
 
+/*
+    Our bug here is related to how placement new inserts the values associated
+    with an allocated object. The issue is it will first completely finish
+    the outer most allocation (i.e. Alloc1(Alloc2()), Alloc1 completes first)
+    then goes and evaluates our args where it encounters other allocs. The thing is
+    the outer most alloc _will_ end up on the stack as a root or pointed to by something.
+    When we go and walk the pointer of said alloc, it'll point to garbage as its data
+    is just whatever was left behind from old allocations. Not really sure of a good way
+    to handle this that is clean and fast. We need to be very careful to not introduce
+    much extra complexity ESPECIALLY inside our hot path allocations.
+*/
 #define 𝐀𝐥𝐥𝐨𝐜𝐓𝐲𝐩𝐞(T, A, L, ...) (new (GC_ALLOC_OBJECT(A, L)) T(__VA_ARGS__))
 
 #define CALC_APPROX_UTILIZATION(P) 1.0f - ((float)P->freecount / (float)P->entrycount)

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -10,8 +10,6 @@
 // Used to determine if a pointer points into the data segment of an object
 #define POINTS_TO_DATA_SEG(P) P >= (void*)PAGE_FIND_OBJ_BASE(P) && P < (void*)((char*)PAGE_FIND_OBJ_BASE(P) + PAGE_MASK_EXTRACT_PINFO(P)->entrysize)
 
-#define CHECK_INITIALIZED(O) { if((O) == nullptr) [[unlikely]] { return ; } }
-
 static void walkPointerMaskForDecrements(BSQMemoryTheadLocalInfo& tinfo, __CoreGC::TypeInfoBase* typeinfo, void** slots) noexcept;
 static void updatePointers(void** slots, BSQMemoryTheadLocalInfo& tinfo) noexcept;
 static void walkPointerMaskForMarking(BSQMemoryTheadLocalInfo& tinfo, __CoreGC::TypeInfoBase* typeinfo, void** slots) noexcept; 
@@ -82,8 +80,6 @@ static void computeDeadRootsForDecrement(BSQMemoryTheadLocalInfo& tinfo) noexcep
 
 static inline void handleTaggedObjectDecrement(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept 
 {
-    CHECK_INITIALIZED(*slots);
-
     __CoreGC::TypeInfoBase* tagged_typeinfo = (__CoreGC::TypeInfoBase*)*slots;
     switch(tagged_typeinfo->tag) {
         case __CoreGC::Tag::Ref: {
@@ -217,7 +213,6 @@ static void* forward(void* ptr, BSQMemoryTheadLocalInfo& tinfo)
 static inline void updateRef(void** obj, BSQMemoryTheadLocalInfo& tinfo)
 {
     void* ptr = *obj;
-    CHECK_INITIALIZED(ptr);
 
     // Root points to root case (may be a false root)
     if(GC_IS_ROOT(ptr) || !GC_IS_YOUNG(ptr)) {
@@ -238,8 +233,6 @@ static inline void updateRef(void** obj, BSQMemoryTheadLocalInfo& tinfo)
 
 static inline void handleTaggedObjectUpdate(void** slots, BSQMemoryTheadLocalInfo& tinfo) noexcept 
 {
-    CHECK_INITIALIZED(*slots);
-
     __CoreGC::TypeInfoBase* tagged_typeinfo = static_cast<__CoreGC::TypeInfoBase*>(*slots);
     switch(tagged_typeinfo->tag) {
         case __CoreGC::Tag::Ref: {
@@ -371,8 +364,6 @@ static void walkStack(BSQMemoryTheadLocalInfo& tinfo) noexcept
 
 static void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
 {
-    CHECK_INITIALIZED(*slots);
-
     MetaData* meta = GC_GET_META_DATA_ADDR(*slots);
     GC_INVARIANT_CHECK(meta != nullptr);
 
@@ -384,8 +375,6 @@ static void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
 
 static void handleMarkingTaggedObject(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept 
 { 
-    CHECK_INITIALIZED(*slots);
-    
     __CoreGC::TypeInfoBase* tagged_typeinfo = static_cast<__CoreGC::TypeInfoBase*>(*slots);
     switch(tagged_typeinfo->tag) {
         case __CoreGC::Tag::Ref: {

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -305,9 +305,14 @@ static void processMarkedYoungObjects(BSQMemoryTheadLocalInfo& tinfo) noexcept
     GC_REFCT_LOCK_RELEASE();
 }
 
-inline bool pointsToObjectStart(void* addr) noexcept 
+static inline bool pointsToObjectStart(void* addr) noexcept 
 {
     uintptr_t offset = *reinterpret_cast<uintptr_t*>(addr) & PAGE_MASK;
+    bool pointsToPageInfo = offset < sizeof(PageInfo);
+    if(!pointsToPageInfo) {
+        return false;
+    }
+
     PageInfo* p = PageInfo::extractPageFromPointer(addr);
     bool isStart = GET_SLOT_START_FROM_OFFSET(offset);
 

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -308,8 +308,7 @@ static void processMarkedYoungObjects(BSQMemoryTheadLocalInfo& tinfo) noexcept
 static inline bool pointsToObjectStart(void* addr) noexcept 
 {
     uintptr_t offset = *reinterpret_cast<uintptr_t*>(addr) & PAGE_MASK;
-    bool pointsToPageInfo = offset < sizeof(PageInfo);
-    if(!pointsToPageInfo) {
+    if(offset < sizeof(PageInfo)) {
         return false;
     }
 
@@ -383,8 +382,8 @@ static void walkStack(BSQMemoryTheadLocalInfo& tinfo) noexcept
 static void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
 {
     MetaData* meta = GC_GET_META_DATA_ADDR(*slots);
-    GC_INVARIANT_CHECK(meta != nullptr);
-
+    GC_CHECK_BOOL_BYTES(meta);
+    
     if(GC_SHOULD_VISIT(meta)) { 
         GC_MARK_AS_MARKED(meta);
         tinfo.visit_stack.push_back({*slots, MARK_STACK_NODE_COLOR_GREY});

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -307,15 +307,15 @@ static void processMarkedYoungObjects(BSQMemoryTheadLocalInfo& tinfo) noexcept
 
 static inline bool pointsToObjectStart(void* addr) noexcept 
 {
-    uintptr_t offset = *reinterpret_cast<uintptr_t*>(addr) & PAGE_MASK;
+    uintptr_t offset = reinterpret_cast<uintptr_t>(addr) & PAGE_MASK;
     if(offset < sizeof(PageInfo)) {
         return false;
     }
 
     PageInfo* p = PageInfo::extractPageFromPointer(addr);
-    bool isStart = GET_SLOT_START_FROM_OFFSET(offset);
+    uintptr_t start = GET_SLOT_START_FROM_OFFSET(offset);
 
-    return isStart % p->realsize == 0;
+    return start % p->realsize == 0;
 }
 
 static void checkPotentialPtr(void* addr, BSQMemoryTheadLocalInfo& tinfo) noexcept


### PR DESCRIPTION
Closes #317.

- Verification that potential roots point to the start of an object (not sure how I made it this far without this check!) 
- To allow us to move alloc/evac pages during cleanup, we zero metadata in page initialization
- AllocType now uses a variadic function instead of a macro to ensure params are evaluated before placement new
- Added some metadata invariant logic

There are still likely a few bugs left in the GC and I believe there are a few subtle logic errors hanging around in the ropes, but this should have all the hacky bandages gone.