### PR TITLE
stdlib lambda position update

### DIFF
--- a/src/backend/cpp/transformer/cppemitter.bsq
+++ b/src/backend/cpp/transformer/cppemitter.bsq
@@ -105,7 +105,7 @@ function emitBindVar(bname: CPPAssembly::VarIdentifier, convert: String, convert
 
 function findFieldOffset(tk: CPPAssembly::TypeKey, fname: CPPAssembly::Identifier, ctx: Context): Nat {
     return ctx.asm.lookupNominalTypeDeclaration(tk).saturatedBFieldInfo
-        .reduce<(|Nat, Bool|)>((|0n, false|), fn(acc, f) => {
+        .reduce<(|Nat, Bool|)>(fn(acc, f) => {
             if(acc.1 === false) {
                 let found = fname.value === f.fname.value;
                 let size = if(found) then 0n else ctx.asm.typeinfos.get(f.ftype.tkeystr).slotsize;
@@ -114,7 +114,7 @@ function findFieldOffset(tk: CPPAssembly::TypeKey, fname: CPPAssembly::Identifie
             else {
                 return acc;
             }
-        }).0;
+        }, (|0n, false|)).0;
 }
 
 function canUseDirectFieldAccess(act: CPPAssembly::AbstractConceptTypeDecl, fname: CPPAssembly::Identifier, ctx: Context): Bool, Nat {
@@ -123,9 +123,9 @@ function canUseDirectFieldAccess(act: CPPAssembly::AbstractConceptTypeDecl, fnam
     }
     
     let baseidx = findFieldOffset(act.subtypes.front(), fname, ctx);
-    let allsubtypessame = act.subtypes.reduce<Bool>(false, fn(acc, subtype) => {
+    let allsubtypessame = act.subtypes.reduce<Bool>(fn(acc, subtype) => {
         return baseidx == findFieldOffset(subtype, fname, ctx);
-    });
+    }, false);
 
     return allsubtypessame, baseidx;
 }
@@ -343,7 +343,7 @@ function generateAccessorForSpecialTypeConstructor(constype: CPPAssembly::TypeSi
 
 %% Given a namespace key (like Main::Foo::Bar), remove all matching prefix strings
 function emitResolvedNamespace(fullns_list: List<CString>, fullns: String): String {
-    return fullns_list.reduce<String>(fullns, fn(acc, s) => {
+    return fullns_list.reduce<String>(fn(acc, s) => {
         let val = String::fromCString(s);
         if(acc.startsWithString(val)) {
             let nopre = acc.removePrefixString(val);
@@ -357,7 +357,7 @@ function emitResolvedNamespace(fullns_list: List<CString>, fullns: String): Stri
         else {
             return acc;
         }
-    });
+    }, fullns);
 }
 
 function emitLiteralSimpleExpression(exp: CPPAssembly::LiteralSimpleExpression): String {
@@ -666,7 +666,7 @@ function emitPostfixAccessSomeValue(op: CPPAssembly::PostfixAccessSomeValue, acc
 
 recursive function conceptProvidesConcept(lhs: CPPAssembly::AbstractConceptTypeDecl, rhs: CPPAssembly::TypeSignature, ctx: Context): Bool {
     %% Walk subtypes of lhs to find if any provide rhs
-    let providesRHS = lhs.subtypes.reduce<Bool>(false, 
+    let providesRHS = lhs.subtypes.reduce<Bool>( 
         fn(acc, subtype) => {
             if(ctx.asm.isNominalTypeConcrete(subtype)) {
                 let lhs = ctx.asm.lookupNominalTypeDeclaration(subtype)@<CPPAssembly::AbstractEntityTypeDecl>;
@@ -676,7 +676,8 @@ recursive function conceptProvidesConcept(lhs: CPPAssembly::AbstractConceptTypeD
                 let lhs = ctx.asm.lookupNominalTypeDeclaration(subtype)@<CPPAssembly::AbstractConceptTypeDecl>;
                 return conceptProvidesConcept[recursive](lhs, rhs, ctx);
             }
-        }
+        }, 
+        false
     );
 
     return providesRHS;
@@ -797,7 +798,7 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
     let rootExp = emitExpression(pop.rootExp, ctx);
     let rootType = emitTypeSignature(pop.rootExp.etype, false, ctx);
 
-    return pop.ops.reduce<String>(rootExp, fn(acc, op) => {
+    return pop.ops.reduce<String>(fn(acc, op) => {
         match(op)@ {
             | CPPAssembly::PostfixAccessFromName => { return String::concat(acc, emitPostfixAccessFromName($op, ctx)); }
             | CPPAssembly::PostfixAccessFromIndex => { return emitPostfixAccessFromIndex($op, acc, ctx); }
@@ -808,7 +809,7 @@ function emitPostfixOp(pop: CPPAssembly::PostfixOp, ctx: Context): String {
             | CPPAssembly::PostfixBoolConstant => { return if($op.value === true) then "true" else "false"; }
             | CPPAssembly::PostfixAccessSomeValue => { return emitPostfixAccessSomeValue($op, acc, pop.rootExp.etype, ctx); }
         }
-    });
+    }, rootExp);
 }
 
 function emitConstructorPrimarySpecialSomeExpression(cpsse: CPPAssembly::ConstructorPrimarySpecialSomeExpression, ctx: Context): String {
@@ -1530,7 +1531,7 @@ function emitVariableMultiInitilizationImplicitStatement(vmii: CPPAssembly::Vari
 
     %% (| decls, assignment, elist index |)
     let decls = vmii.decls
-        .reduce<(|String, String, Nat|)>((|"", String::concat(full_indent, "{%n;", rhsinit), 0n|), fn(acc, decl) => {
+        .reduce<(|String, String, Nat|)>(fn(acc, decl) => {
             let name = emitIdentifier(decl.0);
             let stype = String::concat("[[maybe_unused]] ", emitTypeSignature(decl.1, true, ctx));
 
@@ -1540,7 +1541,7 @@ function emitVariableMultiInitilizationImplicitStatement(vmii: CPPAssembly::Vari
             let assignment = String::concat(acc.1, fullfull_indent, name, " = elist", access, ";%n;");
 
             return edecl, assignment, acc.2 + 1n;
-        });
+        }, (|"", String::concat(full_indent, "{%n;", rhsinit), 0n|));
 
     return String::concat(decls.0, decls.1, full_indent, "}%n;");
 }
@@ -1671,10 +1672,10 @@ function emitParameters(params: List<CPPAssembly::ParameterDecl>, ctx: Context):
 
     let lambdatypes = params
         .filter(pred(p) => p.ptype?<CPPAssembly::LambdaTypeSignature>)
-        .reduce<List<String>>(List<String>{}, fn(acc, param) => {
+        .reduce<List<String>>(fn(acc, param) => {
             let name = emitIdentifier(param.pname);
             return acc.pushBack(String::concat("typename ", emitTypeSignature(param.ptype, true, ctx), "_", name));
-    });
+    }, List<String>{});
 
     return String::joinAll(", ", all_params), String::joinAll(", ", lambdatypes);
 }
@@ -1695,9 +1696,9 @@ function emitThisType(tk: CPPAssembly::TypeKey, ctx: Context): String {
 }
 
 function emitPreConditions(preconds: List<CPPAssembly::PreConditionDecl>, ctx: Context, indent: String): String {    
-    return preconds.reduce<String>("", fn(acc, pc) => {
+    return preconds.reduce<String>(fn(acc, pc) => {
         return String::concat(indent, "𝐫𝐞𝐪𝐮𝐢𝐫𝐞𝐬(", emitExpression(pc.exp, ctx), ");%n;");
-    });    
+    }, "");
 }
 
 function emitThisForType(declaredIn: CPPAssembly::TypeKey, ctx: Context): String {
@@ -1740,9 +1741,9 @@ function emitMethodDecl(m: CPPAssembly::MethodDecl, declaredIn: CPPAssembly::Typ
 
 function emitMethods(ant: CPPAssembly::AbstractNominalTypeDecl, declaredIn: CPPAssembly::TypeKey, ctx: Context, indent: String): String {
     let staticmethods = ant.staticmethods
-        .reduce<String>("", fn(acc, ik) => {
+        .reduce<String>(fn(acc, ik) => {
             return String::concat(acc, emitMethodDecl(ctx.asm.staticmethods.get(ik), declaredIn, ctx, indent));
-    });
+    }, "");
 
     %%
     %% TODO: Virtual, Abstract, and Override methods
@@ -1792,10 +1793,9 @@ function emitEntityTypeDecl(e: CPPAssembly::EntityTypeDecl, declaredIn: CPPAssem
 
     let base = String::concat(e_enum, e_vtable, e_tinfo);
 
-    let entries = e.saturatedBFieldInfo.reduce<String>(String::concat(base, indent, "struct ", tkey, " { %n;"), 
-        fn(acc, entry) => {
+    let entries = e.saturatedBFieldInfo.reduce<String>( fn(acc, entry) => {
             return String::concat(acc, emitSaturatedFieldInfo(entry, nctx, String::concat("    ", indent)));
-    });
+    }, String::concat(base, indent, "struct ", tkey, " { %n;"));
 
     return String::concat(entries, indent, "};%n;");
 }
@@ -1810,10 +1810,9 @@ function emitDatatypeMemberEntityDecl(dm: CPPAssembly::DatatypeMemberEntityTypeD
 
     let base = String::concat(dm_enum, dm_vtable, dm_tinfo);
 
-    let fields = dm.saturatedBFieldInfo.reduce<String>(String::concat(base, indent, "struct ", tkey, "{ %n;"), 
-        fn(acc, entry) => {
+    let fields = dm.saturatedBFieldInfo.reduce<String>(fn(acc, entry) => {
             return String::concat(acc, emitSaturatedFieldInfo(entry, nctx, String::concat("    ", indent)));
-    });
+    }, String::concat(base, indent, "struct ", tkey, "{ %n;"));
 
     return String::concat(fields, indent, "};%n;");
 }
@@ -2186,19 +2185,19 @@ function emitPrimtiveConceptTypeDecl(pc: CPPAssembly::PrimitiveConceptTypeDecl, 
 recursive function emitFuncForwardDeclarations(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context, indent: String): String {
     let full_indent = String::concat("    ", indent);
 
-    let subns_fwddecls = nsdecl.subns.reduce<String>("", fn(acc, nsname, subns) => {
+    let subns_fwddecls = nsdecl.subns.reduce<String>(fn(acc, nsname, subns) => {
         let ns = String::concat(indent, "namespace ", String::fromCString(nsname), " {%n;");
         return String::concat(acc, ns, emitFuncForwardDeclarations[recursive](subns, ctx, full_indent), indent, "}%n;");
-    });
+    }, "");
 
     %% Emit our method and func fwd decls
-    let nsfunc_fwddecls = nsdecl.nsfuncs.reduce<String>(subns_fwddecls, fn(acc, ikey) => {
+    let nsfunc_fwddecls = nsdecl.nsfuncs.reduce<String>(fn(acc, ikey) => {
         return String::concat(acc, emitFunctionForwardDeclaration(ctx.asm.nsfuncs.get(ikey)@<CPPAssembly::AbstractInvokeDecl>, ctx, indent));
-    });
+    }, subns_fwddecls);
 
-    let typefunc_fwddecls = nsdecl.typefuncs.reduce<String>(nsfunc_fwddecls, fn(acc, ikey) => {
+    let typefunc_fwddecls = nsdecl.typefuncs.reduce<String>(fn(acc, ikey) => {
         return String::concat(acc, emitFunctionForwardDeclaration(ctx.asm.typefuncs.get(ikey)@<CPPAssembly::AbstractInvokeDecl>, ctx, indent));
-    });
+    }, nsfunc_fwddecls);
 
     return typefunc_fwddecls;
 }
@@ -2209,63 +2208,63 @@ recursive function emitNamespaceDecl(nsdecl: CPPAssembly::NamespaceDecl, ctx: Co
     let full_indent = String::concat("    ", indent);
 
     %% Emit sub-namespace declarations
-    let subns = nsdecl.subns.reduce<String>(ns, fn(acc, name, decl) => {
+    let subns = nsdecl.subns.reduce<String>(fn(acc, name, decl) => {
         return String::concat(acc, emitNamespaceDecl[recursive](decl, ctx, full_indent));
-    });
+    }, ns);
 
     let nsconsts_fwddecls = nsdecl.nsconsts
-        .reduce<String>(String::concat(subns, "//%n;// Constants%n;//%n;"), 
-        fn(acc, s) => {
+        .reduce<String>(fn(acc, s) => {
             let nsc = ctx.asm.nsconsts.get(s);
             let def = emitNamespaceConstForwardDecl(nsc, ctx, full_indent);
             return String::concat(acc, def);
-        }
+        },
+        String::concat(subns, "//%n;// Constants%n;//%n;")
     );
 
     let typeconsts_fwddecls = nsdecl.typeconsts
-        .reduce<String>(nsconsts_fwddecls, fn(acc, s) => {
+        .reduce<String>(fn(acc, s) => {
             let tc = ctx.asm.typeconsts.get(s);
             let def = emitConstMemberForwardDecl(tc, ctx, full_indent);
             return String::concat(acc, def);
-    });
+    }, nsconsts_fwddecls);
 
     let nsconsts = nsdecl.nsconsts
-        .reduce<String>(String::concat(typeconsts_fwddecls, "//%n;// Constants%n;//%n;"),
-        fn(acc, s) => {
+        .reduce<String>(fn(acc, s) => {
             let tc = ctx.asm.nsconsts.get(s);
             let def = emitNamespaceConstDecl(tc, ctx, full_indent);
             return String::concat(acc, def);
-        }
+        },
+        String::concat(typeconsts_fwddecls, "//%n;// Constants%n;//%n;")
     );
 
     %% Will need nsdecl consts too, this is just ConstMemberDecls 
     let typeconsts = nsdecl.typeconsts
-        .reduce<String>(nsconsts, fn(acc, s) => {
+        .reduce<String>(fn(acc, s) => {
             let tc = ctx.asm.typeconsts.get(s);
             let def = emitConstMemberDecl(tc, ctx, full_indent);
             return String::concat(acc, def);
-    });
+    }, nsconsts);
 
     %% Emit methods after all type defintions to prevent types not being fully defined but used
     let methods = nsdecl.alltypes
-        .reduce<String>(typeconsts, fn(acc, tk) => {
+        .reduce<String>(fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let func = emitMethods(ant, tk, ctx, full_indent);
             return String::concat(acc, func);
-    });
+    }, typeconsts);
 
     %% Emit functions in current namespace
-    let nsfuncs = nsdecl.nsfuncs.reduce<String>(methods , fn(acc, ikey) => {
+    let nsfuncs = nsdecl.nsfuncs.reduce<String>(fn(acc, ikey) => {
         let func = ctx.asm.nsfuncs.get(ikey)@<CPPAssembly::FunctionInvokeDecl>;
         let efunc = emitFunctionDecl(func, ctx, full_indent);
         return String::concat(acc, efunc); 
-    });
+    }, methods);
 
-    let typefuncs = nsdecl.typefuncs.reduce<String>(nsfuncs, fn(acc, ikey) => {
+    let typefuncs = nsdecl.typefuncs.reduce<String>(fn(acc, ikey) => {
         let func = ctx.asm.typefuncs.get(ikey)@<CPPAssembly::FunctionInvokeDecl>;
         let efunc = emitFunctionDecl(func, ctx, full_indent);
         return String::concat(acc, efunc); 
-    });
+    }, nsfuncs);
 
     return String::concat(typefuncs, indent, "}%n;");
 }
@@ -2278,25 +2277,25 @@ function emitNamespaceDeclFwdDecls(nsdecl: CPPAssembly::NamespaceDecl, ctx: Cont
     let ns = String::concat(indent, "namespace ", String::fromCString(nsdecl.nsname), " {%n;");
 
     let subns_fwddecls = nsdecl.subns
-        .reduce<String>("", fn(acc, name, decl) => {
+        .reduce<String>(fn(acc, name, decl) => {
             return String::concat(acc, emitNamespaceDeclFwdDecls[recursive](decl, ctx, full_indent));
-    });
+    }, "");
 
     let ant_fwddecls = nsdecl.alltypes
         .filter(pred(tk) => !ctx.asm.collections.has(tk) && !ctx.asm.enums.has(tk) && !ctx.asm.primitives.has(tk))
-        .reduce<String>("", fn(acc, tk) => {
+        .reduce<String>(fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let fwddecl = emitAbstractNominalForwardDeclaration(ant, ctx, full_indent); 
             return String::concat(acc, fwddecl);
-    });
+    }, "");
 
     let collections = nsdecl.alltypes
         .filter(pred(tk) => ctx.asm.collections.has(tk))
-        .reduce<String>("", fn(acc, tk) => {
+        .reduce<String>(fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let fwddecl = emitCollectionTypeDecl(ant@<CPPAssembly::CollectionTypeDecl>, ctx, full_indent); 
             return String::concat(acc, fwddecl);
-    });
+    }, "");
 
     return String::concat(ns, ant_fwddecls, subns_fwddecls, collections, indent, "}%n;");
 }
@@ -2311,40 +2310,40 @@ function emitNamespaceDeclTypes(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context
     %% Emit enums first
     let enums = nsdecl.alltypes
         .filter(pred(tk) => ctx.asm.enums.has(tk))
-        .reduce<String>(String::concat(ns, "//%n;// Value Type Definitions%n;//%n;"), fn(acc, tk) => {
+        .reduce<String>(fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let def = emitAbstractNominalTypeDecl(ant, tk, ctx, full_indent);
             return String::concat(acc, def);
-    });
+    }, String::concat(ns, "//%n;// Value Type Definitions%n;//%n;"));
 
     %% Value types
     let values = nsdecl.alltypes
         .filter(pred(tk) => ctx.asm.typeinfos.get(tk).tag === CPPAssembly::Tag#Value && !ctx.asm.enums.has(tk) && !ctx.asm.collections.has(tk) && !ctx.asm.primitives.has(tk))
-        .reduce<String>(enums, fn(acc, tk) => {
+        .reduce<String>(fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let def = emitAbstractNominalTypeDecl(ant, tk, ctx, full_indent);
             return String::concat(acc, def);
-    });
+    }, enums);
 
     %% Ref and Tagged types
     let other = nsdecl.alltypes
         .filter(pred(tk) => ctx.asm.typeinfos.get(tk).tag !== CPPAssembly::Tag#Value)
-        .reduce<String>(String::concat(values, "//%n;// Ref and Tagged Type Definitions%n;//%n;"), fn(acc, tk) => {
+        .reduce<String>(fn(acc, tk) => {
             let ant = ctx.asm.lookupNominalTypeDeclaration(tk);
             let def = emitAbstractNominalTypeDecl(ant, tk, ctx, full_indent);
             return String::concat(acc, def);
-    });
+    }, String::concat(values, "//%n;// Ref and Tagged Type Definitions%n;//%n;"));
 
     %% Only support static methods for now
     let method_fwddecls = nsdecl.staticmethods
-        .reduce<String>(String::concat(other, "//%n;// All Methods%n;//%n;"), fn(acc, mtkey) => {
+        .reduce<String>(fn(acc, mtkey) => {
             return String::concat(acc, emitMethodForwardDeclaration(ctx.asm.staticmethods.get(mtkey.0), mtkey.1, ctx, full_indent));
-    });
+    }, String::concat(other, "//%n;// All Methods%n;//%n;"));
 
     let subns = nsdecl.subns
-        .reduce<String>(method_fwddecls, fn(acc, name, decl) => {
+        .reduce<String>(fn(acc, name, decl) => {
             return String::concat(acc, emitNamespaceDeclTypes[recursive](decl, ctx, full_indent));
-    });
+    }, method_fwddecls);
 
     return String::concat(subns, indent, "}%n;");
 }
@@ -2352,47 +2351,46 @@ function emitNamespaceDeclTypes(nsdecl: CPPAssembly::NamespaceDecl, ctx: Context
 function emitAssembly(asm: CPPAssembly::Assembly): String {    
     let ctx: Context = Context{ asm, CPPAssembly::NamespaceKey::from('Tmp'), List<CString>{''} }; %% No known namespace yet
 
-    let primitive_typeinfos = asm.typeinfos.reduce<String>("//%n;// Primitive Types%n;//%n;", fn(acc, tk, ti) => {
+    let primitive_typeinfos = asm.typeinfos.reduce<String>(fn(acc, tk, ti) => {
         return if(asm.isPrimtitiveType(tk) && tk.value !== 'CString' && tk.value !== 'String') 
             then String::concat(acc, emitTypeInfo(ti, none, ctx, "")) 
             else acc;
-    }); 
+    }, "//%n;// Primitive Types%n;//%n;"); 
 
     let primitives = asm.primitives
-        .reduce<String>(primitive_typeinfos,
-        fn(acc, tk, petd) => {
+        .reduce<String>(fn(acc, tk, petd) => {
             let def = emitAbstractNominalTypeDecl(petd, tk, ctx, "");
             return String::concat(acc, def);
-        }
+        },
+        primitive_typeinfos
     );
 
     %% Non-value type forward decls
     let fwddecls = asm.nsdecls
-        .reduce<String>(String::concat(primitives, "//%n;// Ref and Tagged Type Forward Declarations (and collections)%n;//%n;"),
-        fn(acc, nsname, nsdecl) => {
+        .reduce<String>(fn(acc, nsname, nsdecl) => {
             return String::concat(acc, emitNamespaceDeclFwdDecls(nsdecl, ctx, ""));
-    });
+    }, String::concat(primitives, "//%n;// Ref and Tagged Type Forward Declarations (and collections)%n;//%n;"));
 
     %% Defintion of Value and Non-value types
-    let types = asm.nsdecls.reduce<String>(fwddecls, fn(acc, nsname, nsdecl) => {
+    let types = asm.nsdecls.reduce<String>(fn(acc, nsname, nsdecl) => {
         return String::concat(acc, emitNamespaceDeclTypes(nsdecl, ctx, ""));
-    });
+    }, fwddecls);
 
     %% Function forward decls
     let funcfwddecls = asm.nsdecls
-        .reduce<String>(String::concat(types, "//%n;// Namespace/Type Function Forward Declarations%n;//%n;"), fn(acc, nsname, nsdecl) => {
+        .reduce<String>(fn(acc, nsname, nsdecl) => {
             let ns = String::concat("", "namespace ", String::fromCString(nsname), " {%n;");
             return String::concat(acc, ns, emitFuncForwardDeclarations(nsdecl, ctx, "    "), "}%n;");
-        });
+        }, String::concat(types, "//%n;// Namespace/Type Function Forward Declarations%n;//%n;"));
 
 
-    let ns_emission = asm.nsdecls.reduce<String>("//%n;// Emitted Functions/Methods%n;//%n;", fn(acc, nsname, nsdecl) => {
+    let ns_emission = asm.nsdecls.reduce<String>(fn(acc, nsname, nsdecl) => {
         return String::concat(acc, emitNamespaceDecl[recursive](nsdecl, ctx, ""));
-    });
+    }, "//%n;// Emitted Functions/Methods%n;//%n;");
 
     %% Various size allocators needed for the GC
     var allocs, allocslist, allocmap = asm.typeinfos
-        .reduce<(|String, List<String>, Map<Nat, String>|)>((|"", List<String>{}, Map<Nat, String>{}|), fn(acc, tk, ti) => {
+        .reduce<(|String, List<String>, Map<Nat, String>|)>(fn(acc, tk, ti) => {
             if(acc.2.has(ti.slotsize) || ti.slotsize == 0n) {
                 return acc;
             }
@@ -2402,7 +2400,7 @@ function emitAssembly(asm: CPPAssembly::Assembly): String {
             let cons = String::concat(decl, "(", natToString(ti.typesize), ", REAL_ENTRY_SIZE(", natToString(ti.typesize), "), collect);%n;");
 
             return String::concat(acc.0, cons), acc.1.pushBack(String::concat("&", name)), acc.2.insert(ti.slotsize, name);
-        });
+        }, (|"", List<String>{}, Map<Nat, String>{}|));
     let nallocslist = String::concat("GCAllocator* allocs[", natToString(allocmap.size()), "] = {", String::joinAll(", ", allocslist), "};%n;%n;");
 
     let gcinfo = String::concat(allocs, nallocslist);

--- a/src/backend/cpp/transformer/cpptransform.bsq
+++ b/src/backend/cpp/transformer/cpptransform.bsq
@@ -176,14 +176,14 @@ namespace TypeInfoGenerator {
         }
         
         let fields = transformer.bsqasm.lookupNominalTypeDeclaration(tk).saturatedBFieldInfo;
-        let primitiveAndBelowThresh = fields.reduce<(|Bool, Nat|)>((|true, 0n|), fn(acc, f) => {
+        let primitiveAndBelowThresh = fields.reduce<(|Bool, Nat|)>(fn(acc, f) => {
             let ftype = f.ftype;
             if(ftype)@<BSQAssembly::EListTypeSignature> {
                 return true, acc.1 + $ftype.entries.size();
             }
 
             return (acc.0 && (transformer.bsqasm.isPrimtitiveType(ftype.tkeystr) || transformer.bsqasm.enums.has(ftype.tkeystr))), acc.1 + 1n;
-        });
+        }, (|true, 0n|));
 
         if(primitiveAndBelowThresh.1 > reftypeThreshold || !primitiveAndBelowThresh.0) {
             return true;
@@ -225,7 +225,7 @@ namespace TypeInfoGenerator {
     %% Explore all subtypes and find largest possible field slot size (generating subtype tinfo when necessary)
     function findLargestSubtypeAndTag(cur: BSQAssembly::AbstractConceptTypeDecl, tic: TypeInfoContext, transformer: CPPTransformer): Nat, CPPAssembly::Tag, TypeInfoContext {
         let basetag = determineTag(some(cur.tkey), none, transformer);
-        return cur.subtypes.reduce<(|Nat, CPPAssembly::Tag, TypeInfoContext|)>((|0n, basetag, tic|), fn(acc, subtk) => {              
+        return cur.subtypes.reduce<(|Nat, CPPAssembly::Tag, TypeInfoContext|)>(fn(acc, subtk) => {              
             let subant = transformer.bsqasm.lookupNominalTypeDeclaration(subtk);
 
             if(subant)@<BSQAssembly::AbstractEntityTypeDecl> {
@@ -251,13 +251,12 @@ namespace TypeInfoGenerator {
             }
 
             return findLargestSubtypeAndTag[recursive](subant@<BSQAssembly::AbstractConceptTypeDecl>, acc.2, transformer);
-        });
+        }, (|0n, basetag, tic|));
     }
 
     recursive function generateEListInfo(elist: BSQAssembly::EListTypeSignature, tic: TypeInfoContext, transformer: CPPTransformer): FieldInfo, TypeInfoContext {
         return elist.entries
-            .reduce<(|FieldInfo, TypeInfoContext|)>((|FieldInfo{ 0n, 0n, '' }, tic|), 
-                fn(acc, f) => {
+            .reduce<(|FieldInfo, TypeInfoContext|)>(fn(acc, f) => {
                     %% If elist contains elist we should explore its entries BEFORE trying to generate field info
                     if(f)@<BSQAssembly::EListTypeSignature> {
                         return generateEListInfo[recursive]($f, acc.1, transformer);
@@ -272,7 +271,8 @@ namespace TypeInfoGenerator {
                     }
 
                     return acc.0.update(finfo.typesize, finfo.slotsize, finfo.ptrmask), ntic;
-                }
+                },
+                (|FieldInfo{ 0n, 0n, '' }, tic|)
             );
     }
 
@@ -298,7 +298,7 @@ namespace TypeInfoGenerator {
 
             let ant = transformer.bsqasm.lookupNominalTypeDeclaration(resolvedtkey);
             return ant.saturatedBFieldInfo
-                .reduce<(|FieldInfo, TypeInfoContext|)>((|FieldInfo{ 0n, 0n, '' }, tic|), fn(acc, finfo) => {
+                .reduce<(|FieldInfo, TypeInfoContext|)>(fn(acc, finfo) => {
                     let ftype = finfo.ftype;
                     if(ftype)@<BSQAssembly::EListTypeSignature> {
                         let e, tic = generateEListInfo($ftype, acc.1, transformer);
@@ -315,7 +315,7 @@ namespace TypeInfoGenerator {
                         return acc.0.update(8n, 1n, '1'), ntic;
                     }
                     return acc.0.update(tinfo.typesize, tinfo.slotsize, tinfo.ptrmask), ntic;
-                });
+                }, (|FieldInfo{ 0n, 0n, '' }, tic|));
     }
 
     recursive function generateTypeInfo(typekey: BSQAssembly::TypeKey, tic: TypeInfoContext, transformer: CPPTransformer): CPPAssembly::TypeInfo, TypeInfoContext { 
@@ -1643,73 +1643,91 @@ entity CPPTransformer {
         let transformer = CPPTransformer{ bsqasm };            
 
         let transformer_nsconsts = bsqasm.nsconsts.reduce<Map<String, CPPAssembly::NamespaceConstDecl>>(
-            Map<String, CPPAssembly::NamespaceConstDecl>{}, fn(acc, cnsd) => {
+            fn(acc, cnsd) => {
                 let cppcnsd = transformer.transformNamespaceConstDeclToCpp(cnsd);
                 return acc.insert(cppcnsd.resolvedname, cppcnsd);
-            });
+            },
+            Map<String, CPPAssembly::NamespaceConstDecl>{}
+        );
 
         let transformer_nsdecls_nsconsts = transformer_nsconsts.reduce<Map<CString, CPPAssembly::NamespaceDecl>>( 
-            Map<CString, CPPAssembly::NamespaceDecl>{}, fn(acc, name, cppcnsd) => {
+            fn(acc, name, cppcnsd) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cppcnsd.fullns, acc,
                     fn(decl) => { 
                         let nnsconsts = decl.nsconsts.pushBack(name);
                         return decl[nsconsts=nnsconsts];
                     });
-        });
+            },
+            Map<CString, CPPAssembly::NamespaceDecl>{}
+        );
 
         let transformer_typeconsts = bsqasm.typeconsts.reduce<Map<String, CPPAssembly::ConstMemberDecl>>(
-            Map<String, CPPAssembly::ConstMemberDecl>{}, fn(acc, cmd) => {
+            fn(acc, cmd) => {
                 let cppcmd = transformer.transformConstMemberDeclToCpp(cmd);
                 return acc.insert(cppcmd.resolvedname, cppcmd);
-            });
+            },
+            Map<String, CPPAssembly::ConstMemberDecl>{}
+        );
 
         let transformer_nsdecls_typeconsts = transformer_typeconsts.reduce<Map<CString, CPPAssembly::NamespaceDecl>>( 
-            transformer_nsdecls_nsconsts, fn(acc, name, cppcmd) => {
+            fn(acc, name, cppcmd) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cppcmd.fullns, acc,
                     fn(decl) => { 
                         let ntypeconsts = decl.typeconsts.pushBack(name);
                         return decl[typeconsts=ntypeconsts];
                     });
-        });
+            },
+            transformer_nsdecls_nsconsts
+        );
 
         let transformer_nsfuncs = bsqasm.nsfuncs.reduce<Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>>(
-            Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>{}, fn(acc, ikey, func) => {
+            fn(acc, ikey, func) => {
                 let cppdecl = transformer.transformNamespaceFunctionDeclToCpp(func);
                 return acc.insert(cppdecl.ikey, cppdecl);
-            });
+            },
+            Map<CPPAssembly::InvokeKey, CPPAssembly::NamespaceFunctionDecl>{}
+        );
 
         let transformer_nsdecls_nsfuncs = transformer_nsfuncs.reduce<Map<CString, CPPAssembly::NamespaceDecl>>( 
-            transformer_nsdecls_typeconsts, fn(acc, cppikey, cppfunc) => {
+            fn(acc, cppikey, cppfunc) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cppfunc.fullns, acc,
                     fn(decl) => { 
                         let nnsfuncs = decl.nsfuncs.pushBack(cppfunc.ikey);
                         return decl[nsfuncs=nnsfuncs];
                     });
-        });
+            },
+            transformer_nsdecls_typeconsts
+        );
 
         let transformer_typefuncs = bsqasm.typefuncs.reduce<Map<CPPAssembly::InvokeKey, CPPAssembly::TypeFunctionDecl>>(
-            Map<CPPAssembly::InvokeKey, CPPAssembly::TypeFunctionDecl>{}, fn(acc, ikey, tf) => {
+            fn(acc, ikey, tf) => {
                 let cpptypefunc = transformer.transformTypeFunctionDeclToCpp(bsqasm.typefuncs.get(ikey));
                 return acc.insert(cpptypefunc.ikey, cpptypefunc);
-            });
+            },
+            Map<CPPAssembly::InvokeKey, CPPAssembly::TypeFunctionDecl>{}
+        );
 
         let transformer_nsdecls_typefuncs = transformer_typefuncs.reduce<Map<CString, CPPAssembly::NamespaceDecl>>( 
-            transformer_nsdecls_nsfuncs, fn(acc, ikey, cppfunc) => {
+            fn(acc, ikey, cppfunc) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cppfunc.fullns, acc,
                     fn(decl) => { 
                         let ntypefuncs = decl.typefuncs.pushBack(ikey);
                         return decl[typefuncs=ntypefuncs];
                     });
-        });
+            },
+            transformer_nsdecls_nsfuncs
+        );
 
         let transformer_entities = bsqasm.entities.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::EntityTypeDecl>>(
-            Map<CPPAssembly::TypeKey, CPPAssembly::EntityTypeDecl>{}, fn(acc, tk, e) => {
+            fn(acc, tk, e) => {
                 let cppentity = transformer.transformEntityDeclToCpp(e);
                 return acc.insert(cppentity.tkey, cppentity);
-            });
+            },
+            Map<CPPAssembly::TypeKey, CPPAssembly::EntityTypeDecl>{}
+        );
 
         let transformer_nsdecls_entities = transformer_entities.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            transformer_nsdecls_typefuncs, fn(acc, cpptk, cppe) => {
+            fn(acc, cpptk, cppe) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cppe.fullns, acc,
                     fn(decl) => {
                         let nentities = decl.entities.pushBack(cpptk);
@@ -1718,16 +1736,20 @@ entity CPPTransformer {
                         
                         return ndecl[entities=nentities, alltypes=nalltypes];
                     });
-        });
+            },
+            transformer_nsdecls_typefuncs
+        );
 
         let transformer_datamembers = bsqasm.datamembers.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::DatatypeMemberEntityTypeDecl>>(
-            Map<CPPAssembly::TypeKey, CPPAssembly::DatatypeMemberEntityTypeDecl>{}, fn(acc, tk, datamember) => {
+            fn(acc, tk, datamember) => {
                 let cppdatamember = transformer.transformDatatypeMemberToCpp(datamember);
                 return acc.insert(cppdatamember.tkey, cppdatamember);
-            });
+            },
+            Map<CPPAssembly::TypeKey, CPPAssembly::DatatypeMemberEntityTypeDecl>{}
+        );
 
         let transformer_nsdecls_datamembers = transformer_datamembers.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            transformer_nsdecls_entities, fn(acc, cpptk, cppdatamember) => {                 
+            fn(acc, cpptk, cppdatamember) => {                 
                 return CPPTransformNameManager::getNamespaceDeclMapping(cppdatamember.fullns, acc,
                     fn(decl) => {
                         let ndatamembers = decl.datamembers.pushBack(cpptk);
@@ -1736,16 +1758,20 @@ entity CPPTransformer {
 
                         return ndecl[datamembers=ndatamembers, alltypes=nalltypes];
                     });                     
-            });
+            },
+            transformer_nsdecls_entities
+        );
 
         let transformer_datatypes = bsqasm.datatypes.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::DatatypeTypeDecl>>(
-            Map<CPPAssembly::TypeKey, CPPAssembly::DatatypeTypeDecl>{}, fn(acc, tk, dtype) => {
+            fn(acc, tk, dtype) => {
                 let cppdatatype = transformer.transformDatatypeToCpp(dtype);
                 return acc.insert(cppdatatype.tkey, cppdatatype);
-            });
+            },
+            Map<CPPAssembly::TypeKey, CPPAssembly::DatatypeTypeDecl>{}
+        );
 
         let transformer_nsdecls_datatypes = transformer_datatypes.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            transformer_nsdecls_datamembers, fn(acc, cpptk, cppdatatype) => {
+            fn(acc, cpptk, cppdatatype) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cppdatatype.fullns, acc,
                     fn(decl) => {
                         let ndatatypes = decl.datatypes.pushBack(cpptk);
@@ -1753,17 +1779,21 @@ entity CPPTransformer {
                         let ndecl = transformer.updateNSMethods(decl, cppdatatype@<CPPAssembly::AbstractNominalTypeDecl>);
                         return ndecl[datatypes=ndatatypes, alltypes=nalltypes];
                     });                     
-            });
+            },
+            transformer_nsdecls_datamembers
+        );
 
         let transformer_pconcepts = bsqasm.pconcepts.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveConceptTypeDecl>>(
-            Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveConceptTypeDecl>{}, fn(acc, tk, pc) => {
+            fn(acc, tk, pc) => {
                 let cpppc = transformer.transformPrimitiveConceptDeclToCpp(pc);
                 return acc.insert(cpppc.tkey, cpppc);
-            });
+            },
+            Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveConceptTypeDecl>{}
+        );
 
         %% I could see name conflicts arising with emitting pconcepts at top of file, so we do in ns to be safe
         let transformer_nsdecls_pconcepts = transformer_pconcepts.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            transformer_nsdecls_datatypes, fn(acc, cpptk, cpppc) => {
+            fn(acc, cpptk, cpppc) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cpppc.fullns, acc,
                     fn(decl) => {
                         let npconcepts = decl.pconcepts.pushBack(cpptk);
@@ -1772,16 +1802,20 @@ entity CPPTransformer {
 
                         return ndecl[pconcepts=npconcepts, alltypes=nalltypes];
                     });                     
-            }); 
+            },
+            transformer_nsdecls_datatypes
+        ); 
 
         let transformer_constructables = bsqasm.constructables.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::ConstructableTypeDecl>> (
-            Map<CPPAssembly::TypeKey, CPPAssembly::ConstructableTypeDecl>{}, fn(acc, tk, ctd) => {
+            fn(acc, tk, ctd) => {
                 let cppctd = transformer.transformConstructableTypeDecl(ctd);
                 return acc.insert(cppctd.tkey, cppctd);
-            });
+            },
+            Map<CPPAssembly::TypeKey, CPPAssembly::ConstructableTypeDecl>{}
+        );
 
         let transformer_nsdecls_constructables = transformer_constructables.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            transformer_nsdecls_pconcepts, fn(acc, cpptk, cppctd) => {
+            fn(acc, cpptk, cppctd) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cppctd.fullns, acc,
                     fn(decl) => {
                         let nconstructables = decl.constructables.pushBack(cpptk);
@@ -1790,16 +1824,20 @@ entity CPPTransformer {
 
                         return ndecl[constructables=nconstructables, alltypes=nalltypes];
                     });                     
-            });
+            },
+            transformer_nsdecls_pconcepts
+        );
 
         let transformer_collections = bsqasm.collections.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::CollectionTypeDecl>>(
-            Map<CPPAssembly::TypeKey, CPPAssembly::CollectionTypeDecl>{}, fn(acc, tk, ctd) => { 
+            fn(acc, tk, ctd) => { 
                 let cppctd = transformer.transformCollectionTypeDecl(ctd);
                 return acc.insert(cppctd.tkey, cppctd);
-            });
+            },
+            Map<CPPAssembly::TypeKey, CPPAssembly::CollectionTypeDecl>{}
+        );
 
         let transformer_nsdecls_collections = transformer_collections.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            transformer_nsdecls_constructables, fn(acc, cpptk, cppctd) => {
+            fn(acc, cpptk, cppctd) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cppctd.fullns, acc,
                     fn(decl) => {
                         let ncollections = decl.collections.pushBack(cpptk);
@@ -1808,7 +1846,9 @@ entity CPPTransformer {
 
                         return ndecl[collections=ncollections, alltypes=nalltypes];
                     });                     
-            });
+            },
+            transformer_nsdecls_constructables
+        );
 
         let transformer_allfuncs = bsqasm.allfuncs.map<CPPAssembly::FunctionDecl>(fn(ikey) => {
             let cppikey = CPPTransformNameManager::convertInvokeKey(ikey);
@@ -1828,61 +1868,75 @@ entity CPPTransformer {
         });
 
         let transformer_enums = bsqasm.enums.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::EnumTypeDecl>>(
-            Map<CPPAssembly::TypeKey, CPPAssembly::EnumTypeDecl>{}, fn(acc, tk, etd) => {
+            fn(acc, tk, etd) => {
                 let base = transformer.transformAbstractNominalTypeDeclBase(bsqasm.enums.get(tk)@<BSQAssembly::AbstractNominalTypeDecl>);
                 return acc.insert(base.2, CPPAssembly::EnumTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9, etd.members });
-        });
+            },
+            Map<CPPAssembly::TypeKey, CPPAssembly::EnumTypeDecl>{}
+        );
 
         let transformer_nsdecls_enums = transformer_enums.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            transformer_nsdecls_collections, fn(acc, cpptk, cppetd) => {
+            fn(acc, cpptk, cppetd) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cppetd.fullns, acc,
                     fn(decl) => {
                         let nenums = decl.enums.pushBack(cpptk);
                         let nalltypes = decl.alltypes.pushBack(cpptk);
                         return decl[enums=nenums, alltypes=nalltypes];
                     });                     
-            }); 
+            },
+            transformer_nsdecls_collections
+        ); 
 
         let transformer_typedecls = bsqasm.typedecls.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::TypedeclTypeDecl>>(
-            Map<CPPAssembly::TypeKey, CPPAssembly::TypedeclTypeDecl>{}, fn(acc, tk, tdtd) => {
+            fn(acc, tk, tdtd) => {
                 let cpptd = transformer.transformTypedeclTypeDecl(tdtd);
                 return acc.insert(cpptd.tkey, cpptd);
-        });
+            },
+            Map<CPPAssembly::TypeKey, CPPAssembly::TypedeclTypeDecl>{}
+        );
 
         let transformer_nsdecls_typedecls = transformer_typedecls.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            transformer_nsdecls_enums, fn(acc, cpptk, cpptdtd) => {
+            fn(acc, cpptk, cpptdtd) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cpptdtd.fullns, acc,
                     fn(decl) => {
                         let ntypedecls = decl.typedecls.pushBack(cpptk);
                         let nalltypes = decl.alltypes.pushBack(cpptk);
                         return decl[typedecls=ntypedecls, alltypes=nalltypes];
                     });                     
-            }); 
+            },
+            transformer_nsdecls_enums
+        ); 
 
         let transformer_stringoftypedecls = bsqasm.stringoftypedecls.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::TypedeclStringOfTypeDecl>>(
-            Map<CPPAssembly::TypeKey, CPPAssembly::TypedeclStringOfTypeDecl>{}, fn(acc, tk, stdtd) => {
+            fn(acc, tk, stdtd) => {
                 let cppstdtd = transformer.transformTypedeclStringOfTypeDecl(stdtd);
                 return acc.insert(cppstdtd.tkey, cppstdtd);
-        });
+            },
+            Map<CPPAssembly::TypeKey, CPPAssembly::TypedeclStringOfTypeDecl>{}
+        );
 
         let transformer_nsdecls_stringoftypedecls = transformer_stringoftypedecls.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            transformer_nsdecls_typedecls, fn(acc, cpptk, cppstdtd) => {
+            fn(acc, cpptk, cppstdtd) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cppstdtd.fullns, acc,
                     fn(decl) => {
                         let nstringoftypedecls = decl.stringoftypedecls.pushBack(cpptk);
                         let nalltypes = decl.alltypes.pushBack(cpptk);
                         return decl[stringoftypedecls=nstringoftypedecls, alltypes=nalltypes];
                     });                     
-            }); 
+            },
+            transformer_nsdecls_typedecls
+        ); 
 
         let transformer_primitives = bsqasm.primtives.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveEntityTypeDecl>>(
-            Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveEntityTypeDecl>{}, fn(acc, tkey, pe) => {
+            fn(acc, tkey, pe) => {
                 let base = transformer.transformAbstractNominalTypeDeclBase(bsqasm.primtives.get(tkey)@<BSQAssembly::AbstractNominalTypeDecl>);
                 return acc.insert(base.2, CPPAssembly::PrimitiveEntityTypeDecl{ base.0, base.1, base.2, base.3, base.4, base.5, base.6, base.7, base.8, base.9 });
-        });
+            },
+            Map<CPPAssembly::TypeKey, CPPAssembly::PrimitiveEntityTypeDecl>{}
+        );
 
         let transformer_nsdecls_primitives = transformer_primitives.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            transformer_nsdecls_stringoftypedecls, fn(acc, cpptk, cppetd) => {
+            fn(acc, cpptk, cppetd) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cppetd.fullns, acc,
                     fn(decl) => {
                         let nalltypes = decl.alltypes.pushBack(cpptk);
@@ -1891,36 +1945,48 @@ entity CPPTransformer {
                         
                         return ndecl[primitives=nprimitives, alltypes=nalltypes];
                     });                     
-            }); 
+            },
+            transformer_nsdecls_stringoftypedecls
+        ); 
 
         let transformer_staticmethods = bsqasm.staticmethods.reduce<Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclStatic>>(
-            Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclStatic>{}, fn(acc, ikey, decl) => {
+            fn(acc, ikey, decl) => {
                 return acc.insert(CPPTransformNameManager::convertInvokeKey(ikey), transformer.transformStaticMethodDecl(decl));
-        });
+            },
+            Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclStatic>{}
+        );
 
         let transformer_virtmethods = bsqasm.virtmethods.reduce<Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclVirtual>>(
-            Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclVirtual>{}, fn(acc, ikey, decl) => {
+            fn(acc, ikey, decl) => {
                 return acc.insert(CPPTransformNameManager::convertInvokeKey(ikey), transformer.transformVirtualMethodDecl(decl));
-        });
+            },
+            Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclVirtual>{}
+        );
 
         let transformer_absmethods = bsqasm.absmethods.reduce<Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclAbstract>>(
-            Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclAbstract>{}, fn(acc, ikey, decl) => {
+            fn(acc, ikey, decl) => {
                 return acc.insert(CPPTransformNameManager::convertInvokeKey(ikey), transformer.transformAbstractMethodDecl(decl));
-        });
+            },
+            Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclAbstract>{}
+        );
 
         let transformer_overmethods = bsqasm.overmethods.reduce<Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclOverride>>(
-            Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclOverride>{}, fn(acc, ikey, decl) => {
+            fn(acc, ikey, decl) => {
                 return acc.insert(CPPTransformNameManager::convertInvokeKey(ikey), transformer.transformOverrideMethodDecl(decl));
-        });
+            },
+            Map<CPPAssembly::InvokeKey, CPPAssembly::MethodDeclOverride>{}
+        );
 
         let transformer_concepts = bsqasm.concepts.reduce<Map<CPPAssembly::TypeKey, CPPAssembly::ConceptTypeDecl>>(
-            Map<CPPAssembly::TypeKey, CPPAssembly::ConceptTypeDecl>{}, fn(acc, tk, ctd) => {
+            fn(acc, tk, ctd) => {
                 let cppctd = transformer.transformConceptTypeDeclToCpp(ctd);
                 return acc.insert(cppctd.tkey, cppctd);
-        });
+            },
+            Map<CPPAssembly::TypeKey, CPPAssembly::ConceptTypeDecl>{}
+        );
 
         let transformer_nsdecls_concepts = transformer_concepts.reduce<Map<CString, CPPAssembly::NamespaceDecl>>(
-            transformer_nsdecls_primitives, fn(acc, cpptk, cppconcept) => {
+            fn(acc, cpptk, cppconcept) => {
                 return CPPTransformNameManager::getNamespaceDeclMapping(cppconcept.fullns, acc,
                     fn(decl) => {
                         let nconcepts = decl.concepts.pushBack(cpptk);
@@ -1929,7 +1995,9 @@ entity CPPTransformer {
 
                         return ndecl[concepts=nconcepts, alltypes=nalltypes];
                     });                     
-            });
+            },
+            transformer_nsdecls_primitives
+        );
 
         let transformer_allmethods = bsqasm.allmethods.map<CPPAssembly::InvokeKey>(fn(ikey) => {
             return CPPTransformNameManager::convertInvokeKey(ikey);
@@ -1937,14 +2005,18 @@ entity CPPTransformer {
 
         let generated_typeinfos_concrete = bsqasm.allconcretetypes
             .reduce<TypeInfoContext>( 
-                TypeInfoContext{ Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>{}, 1n }, fn(acc, tkey) => {
+                fn(acc, tkey) => {
                     return TypeInfoGenerator::generateTypeInfo(tkey, acc, transformer).1;
-            });
+                },
+                TypeInfoContext{ Map<CPPAssembly::TypeKey, CPPAssembly::TypeInfo>{}, 1n }
+            );
 
         let generated_typeinfos_abstract = bsqasm.allabstracttypes
-            .reduce<TypeInfoContext>( generated_typeinfos_concrete, fn(acc, tkey) => {
+            .reduce<TypeInfoContext>(fn(acc, tkey) => {
                 return TypeInfoGenerator::generateTypeInfo(tkey, acc, transformer).1;
-        });
+            },
+            generated_typeinfos_concrete
+        );
 
         return CPPAssembly::Assembly {
             nsdecls = transformer_nsdecls_concepts,

--- a/src/backend/smtcore/transformer/bsqanalyze.bsq
+++ b/src/backend/smtcore/transformer/bsqanalyze.bsq
@@ -51,10 +51,11 @@ entity BSQCCInfo {
             let rcallees = callees.sortKeyUniqueify();
             let calleemap = Map<BSQAssembly::InvokeKey, List<BSQAssembly::InvokeKey>>{current => rcallees};
         
-            let callermap = rcallees.reduce<Map<BSQAssembly::InvokeKey, List<BSQAssembly::InvokeKey>>>(Map<BSQAssembly::InvokeKey, List<BSQAssembly::InvokeKey>>{}, 
-                fn(callermap, callee) => {
+            let callermap = rcallees.reduce<Map<BSQAssembly::InvokeKey, List<BSQAssembly::InvokeKey>>>(fn(callermap, callee) => {
                     return callermap.insert(callee, List<BSQAssembly::InvokeKey>{current});                      
-                });
+                },
+                Map<BSQAssembly::InvokeKey, List<BSQAssembly::InvokeKey>>{}
+            );
         
             return BSQCCInfo{calleemap, callermap};
         }
@@ -837,9 +838,9 @@ entity MayErrorAnalysis {
     function generateInvokeErrorInfo(assembly: BSQAssembly::Assembly, callg: BSQToSMTCallGraph): Map<BSQAssembly::InvokeKey, Bool> {
         let erranalysis = MayErrorAnalysis{assembly, callg};
 
-        let ierrors = callg.invokeinfo.reachable.reduce<Map<BSQAssembly::InvokeKey, Bool>>(Map<BSQAssembly::InvokeKey, Bool>{}, fn(emap, ikey) => {
+        let ierrors = callg.invokeinfo.reachable.reduce<Map<BSQAssembly::InvokeKey, Bool>>(fn(emap, ikey) => {
             return emap.insert(ikey, false);
-        });
+        }, Map<BSQAssembly::InvokeKey, Bool>{});
 
         let ferrors = Algorithm::worklist<Map<BSQAssembly::InvokeKey, Bool>, BSQAssembly::InvokeKey>(ierrors, callg.topoorder, fn(emap, ikey) => {
             let sccerror = callg.sccs.someOf(pred(scc) => scc.contains(ikey));

--- a/src/backend/smtcore/transformer/smtemitter.bsq
+++ b/src/backend/smtcore/transformer/smtemitter.bsq
@@ -711,7 +711,7 @@ function emitAssertExpression(e: SMTAssembly::AssertExpression, eev: SMTEmitterE
 
 function emitAssertSetExpression(e: SMTAssembly::AssertSetExpression, eev: SMTEmitterEnv): CString {
     let exp = emitExpression[recursive](e.inexp, eev);
-    return e.aset.lreduce<CString>(exp, fn(expcc, chk) => {
+    return e.aset.lreduce<CString>(fn(expcc, chk) => {
         var err: CString;
         if(chk.1 == eev.errtrgt) {
             err = emitResultErrTrgtAs(e.etype);
@@ -738,7 +738,7 @@ function emitAssertSetExpression(e: SMTAssembly::AssertSetExpression, eev: SMTEm
 
         let bb = CString::concat('(not ', tt, ') ', errop, ' ', expcc);
         return CString::concat('(ite ', bb, ')');
-    });
+    }, exp);
 }
 
 recursive function emitUnwrapFromResultExpression(e: SMTAssembly::UnwrapFromResultExpression, eev: SMTEmitterEnv): CString {
@@ -771,7 +771,7 @@ recursive function emitLetGeneralExpression(e: SMTAssembly::LetGeneralExpression
 
 recursive function emitLetWErrorsExpression(e: SMTAssembly::LetWErrorsExpression, eev: SMTEmitterEnv): CString {
     let iiexp = emitExpression[recursive](e.inexp, eev);
-    let lbs = e.vvbind.lreduce<CString>(iiexp, fn(acc, vb) => {
+    let lbs = e.vvbind.lreduce<CString>(fn(acc, vb) => {
         let vbind = CString::concat('((', vb.2.value, ' ', emitExpression[recursive](vb.0, eev), '))');
         let chk = CString::concat('(not (is-@Result-ok ', vb.2.value, ')) ');
 
@@ -779,7 +779,7 @@ recursive function emitLetWErrorsExpression(e: SMTAssembly::LetWErrorsExpression
 
         let wcheck = CString::concat('(ite ', chk, errop, ' ', acc, ')');
         return CString::concat('(let ', vbind, ' ', wcheck, ')');
-    });
+    }, iiexp);
 
     return lbs;
 }
@@ -927,24 +927,24 @@ recursive function emitMatchOperation(e: SMTAssembly::MatchOperation, eev: SMTEm
     if(indent)@none {
         let dflt = emitOperation[recursive](e.defaultop, eev, none);
 
-        return e.cases.lreduce[recursive]<CString>(dflt, fn(acc, c) => {
+        return e.cases.lreduce[recursive]<CString>(fn(acc, c) => {
             let ttest = emitMatchTestTestableType(c.0, c.1, tst);
             let cbody = emitOperation[recursive](c.2, eev, none);
 
             let opts = CString::concat(' ', cbody, ' ', acc);
             return CString::concat('(ite ', ttest, opts, ')');
-        });
+        }, dflt);
     }
     else {
         let dflt = emitOperation[recursive](e.defaultop, eev, indent);
 
-        return e.cases.lreduce[recursive]<CString>(dflt, fn(acc, c) => {
+        return e.cases.lreduce[recursive]<CString>(fn(acc, c) => {
             let ttest = emitMatchTestTestableType(c.0, c.1, tst);
             let cbody = emitOperation[recursive](c.2, eev, indent);
 
             let opts = CString::concat('%n;', cbody, '%n;', $indent, acc);
             return CString::concat('(ite ', ttest, opts, ')');
-        });
+        }, dflt);
     }
 }
 
@@ -1081,10 +1081,10 @@ recursive function emitLetsOperation(e: SMTAssembly::LetsOperation, eev: SMTEmit
         inexp = CString::concat('%n;', emitOperation[recursive](e.inop, eev, some(iident)), tident);
     }
     
-    let lbs = e.vvbind.lreduce<CString>(inexp, fn(acc, vb) => {
+    let lbs = e.vvbind.lreduce<CString>(fn(acc, vb) => {
         let vbind = CString::concat('((', vb.2.value, ' ', emitSafeExpression[recursive](vb.0, eev), '))');
         return CString::concat('(let ', vbind, ' ', acc, ')');
-    });
+    }, inexp);
     
     if(indent)@none {
         return lbs;
@@ -1144,7 +1144,7 @@ recursive function emitLetWErrorsOperation(e: SMTAssembly::LetWErrorsOperation, 
         inexp = CString::concat('%n;', emitOperation[recursive](e.inop, eev, some(iident)), tident);
     }
     
-    let lbs = e.vvbind.lreduce<CString>(inexp, fn(acc, vb) => {
+    let lbs = e.vvbind.lreduce<CString>(fn(acc, vb) => {
         let vbind = CString::concat('((', vb.2.value, ' ', emitExpression[recursive](vb.0, eev), '))');
         let chk = CString::concat('(not (is-@Result-ok ', vb.2.value, ')) ');
 
@@ -1152,7 +1152,7 @@ recursive function emitLetWErrorsOperation(e: SMTAssembly::LetWErrorsOperation, 
 
         let wcheck = CString::concat('(ite ', chk, errop, ' ', acc, ')');
         return CString::concat('(let ', vbind, ' ', wcheck, ')');
-    });
+    }, inexp);
     
     if(indent)@none {
         return lbs;

--- a/src/backend/smtcore/transformer/smttransform.bsq
+++ b/src/backend/smtcore/transformer/smttransform.bsq
@@ -101,7 +101,7 @@ entity LambdaGeneratorState {
     }
 
     method mergeLambdaGeneratorInfo(lgeninfo: List<LambdaGeneratorInfo>): LambdaGeneratorState {
-        let nsmap = lgeninfo.reduce<Map<BSQAssembly::InvokeKey, List<LambdaGeneratorInfo>>>(this.smap, fn(mm, lgi) => {
+        let nsmap = lgeninfo.reduce<Map<BSQAssembly::InvokeKey, List<LambdaGeneratorInfo>>>(fn(mm, lgi) => {
             if(!mm.has(lgi.invoke)) {
                 return mm.insert(lgi.invoke, List<LambdaGeneratorInfo>{lgi});
             }
@@ -114,7 +114,7 @@ entity LambdaGeneratorState {
                     return mm.set(lgi.invoke, llist.pushBack(lgi));
                 }
             }
-        });
+        }, this.smap);
 
         return LambdaGeneratorState{nsmap};
     }
@@ -268,7 +268,7 @@ entity SMTTransformer {
     }
 
     recursive method processArgsInOrder(args: List<BSQAssembly::Expression>, ctx: SMTTransformerCtx): List<SMTAssembly::SafeExpression>, SMTTransformerCtx, Option<List<(|SMTAssembly::Expression, SMTAssembly::TypeKey, SMTAssembly::Identifier|)>> {
-        let nctx, subexps = args.transduce<SMTTransformerCtx, SMTExpTransformResult>(ctx, recursive fn(ctx, arg) => this.transformExpressionToSMT[recursive](arg, ctx));
+        let nctx, subexps = args.transduce<SMTTransformerCtx, SMTExpTransformResult>(recursive fn(ctx, arg) => this.transformExpressionToSMT[recursive](arg, ctx), ctx);
 
         return this.unpackExpressionErrors(subexps, nctx);
     }
@@ -313,7 +313,7 @@ entity SMTTransformer {
             return ctx, exp;
         }
         else {
-            let rctx, iichecks = preconds.ltransduce<SMTTransformerCtx, (|SMTAssembly::Expression, Nat|)>(ctx, fn(cctx, iiv) => {
+            let rctx, iichecks = preconds.ltransduce<SMTTransformerCtx, (|SMTAssembly::Expression, Nat|)>(fn(cctx, iiv) => {
                 let smtikey = TransformNameManager::convertInvokeKey(iiv.ikey, ttags);
                 
                 let eeid = cctx.errCtr;
@@ -323,7 +323,7 @@ entity SMTTransformer {
                 else {
                     return cctx.addError(iiv.exp.sinfo), (|SMTAssembly::CallFunctionExpression{smtikey, args}, eeid|);
                 }
-            });
+            }, ctx);
 
             let wwexp = if(exp)@<SMTAssembly::CallFunctionSafeExpression> then SMTAssembly::WrapIntoResultExpression{this.transformStdTypeToSMT(etype), $exp} else exp;
             return rctx, SMTAssembly::AssertSetExpression{this.transformStdTypeToSMT(etype), iichecks, wwexp};
@@ -390,7 +390,7 @@ entity SMTTransformer {
             let chkargs = List<SMTAssembly::SafeExpression>{ larg };
             let createop = SMTAssembly::WrapIntoResultExpression{smttype, SMTAssembly::ConstructorTypeDeclExpression{smttype, larg}};
 
-            let rctx, iichecks = tdecl.allInvariants.ltransduce<SMTTransformerCtx, (|SMTAssembly::Expression, Nat|)>(nctx, fn(cctx, iiv) => {
+            let rctx, iichecks = tdecl.allInvariants.ltransduce<SMTTransformerCtx, (|SMTAssembly::Expression, Nat|)>(fn(cctx, iiv) => {
                 let iitypedecl = this.assembly.lookupNominalTypeDeclaration(iiv.declaredInType.tkeystr);
                 let smtikey = TransformNameManager::convertInvokeKey(iiv.ikey, List<Bool>{});
                 
@@ -401,7 +401,7 @@ entity SMTTransformer {
                 else {
                     return cctx.addError(exp.sinfo), (|SMTAssembly::CallFunctionExpression{smtikey, chkargs}, eeid|);
                 }
-            });
+            }, nctx);
 
             let createexp = SMTAssembly::AssertSetExpression{smttype, iichecks, createop};
             return rctx, this.wrapOperationResultWErr(exp.constype, createexp, obinds);
@@ -451,7 +451,7 @@ entity SMTTransformer {
             let chkargs = List<SMTAssembly::SafeExpression>{ larg };
             let createop = SMTAssembly::WrapIntoResultExpression{this.transformStdTypeToSMT(exp.ctype), SMTAssembly::ConstructorTypeDeclExpression{smttype, larg}};
 
-            let rctx, iichecks = tdecl.allInvariants.ltransduce<SMTTransformerCtx, (|SMTAssembly::Expression, Nat|)>(nctx, fn(cctx, iiv) => {
+            let rctx, iichecks = tdecl.allInvariants.ltransduce<SMTTransformerCtx, (|SMTAssembly::Expression, Nat|)>(fn(cctx, iiv) => {
                 let smtikey = TransformNameManager::convertInvokeKey(iiv.ikey, List<Bool>{});
                 
                 let eeid = cctx.errCtr;
@@ -461,7 +461,7 @@ entity SMTTransformer {
                 else {
                     return cctx.addError(exp.sinfo), (|SMTAssembly::CallFunctionExpression{smtikey, chkargs}, eeid|);
                 }
-            });
+            }, nctx);
 
             let createexp = SMTAssembly::AssertSetExpression{this.transformStdTypeToSMT(exp.ctype), iichecks, createop};
             return rctx, this.wrapOperationResultWErr(exp.ctype, createexp, obinds);
@@ -487,7 +487,7 @@ entity SMTTransformer {
             return xctx, this.wrapOperationResultWErr(exp.ctype, SMTAssembly::AssertExpression{smttype, fmtchk, feid, createop}, obinds);
         }
         else {
-            let rctx, iichecks = tdecl.allInvariants.ltransduce<SMTTransformerCtx, (|SMTAssembly::Expression, Nat|)>(xctx, fn(cctx, iiv) => {
+            let rctx, iichecks = tdecl.allInvariants.ltransduce<SMTTransformerCtx, (|SMTAssembly::Expression, Nat|)>(fn(cctx, iiv) => {
                 let smtikey = TransformNameManager::convertInvokeKey(iiv.ikey, List<Bool>{});
                 
                 let eeid = cctx.errCtr;
@@ -497,7 +497,7 @@ entity SMTTransformer {
                 else {
                     return cctx.addError(exp.sinfo), (|SMTAssembly::CallFunctionExpression{smtikey, chkargs}, eeid|);
                 }
-            });
+            }, xctx);
             
             let xichecks = List<(|SMTAssembly::Expression, Nat|)>::concat(List<(|SMTAssembly::Expression, Nat|)>{(|fmtchk, feid|)}, iichecks);
             let createexp = SMTAssembly::AssertSetExpression{smttype, xichecks, createop};
@@ -518,7 +518,7 @@ entity SMTTransformer {
         else {
             let createop = SMTAssembly::WrapIntoResultExpression{this.transformStdTypeToSMT(e.ctype), SMTAssembly::ConstructorStdExpression{smttype, aargs}};
 
-            let rctx, iichecks = tdecl.allInvariants.ltransduce<SMTTransformerCtx, (|SMTAssembly::Expression, Nat|)>(nctx, fn(cctx, iiv) => {
+            let rctx, iichecks = tdecl.allInvariants.ltransduce<SMTTransformerCtx, (|SMTAssembly::Expression, Nat|)>(fn(cctx, iiv) => {
                 let iitypedecl = this.assembly.lookupNominalTypeDeclaration(iiv.declaredInType.tkeystr);
                 let smtikey = TransformNameManager::convertInvokeKey(iiv.ikey, List<Bool>{});
                 
@@ -530,7 +530,7 @@ entity SMTTransformer {
                 else {
                     return cctx.addError(e.sinfo), (|SMTAssembly::CallFunctionExpression{smtikey, sliceargs}, eeid|);
                 }
-            });
+            }, nctx);
 
             let createexp = SMTAssembly::AssertSetExpression{this.transformStdTypeToSMT(e.ctype), iichecks, createop};
             return rctx, this.wrapOperationResultWErr(e.ctype, createexp, obinds);
@@ -1102,7 +1102,7 @@ entity SMTTransformer {
         let ebase, nctx, obinds = this.processUnaryArg[recursive](exp.rootExp, ctx);
         let eexp = this.wrapOperationResult(exp.rootExp.etype, ebase, obinds);
 
-        let rres = exp.ops.reduce[recursive]<(|SMTTransformerCtx, SMTExpTransformResult|)>((|nctx, eexp|), recursive fn(pstate, op) => {
+        let rres = exp.ops.reduce[recursive]<(|SMTTransformerCtx, SMTExpTransformResult|)>(recursive fn(pstate, op) => {
             match(op)@ {
                 | BSQAssembly::PostfixAccessFromName => { return this.transformPostfixAccessFromName($op, pstate.0, pstate.1); }
                 | BSQAssembly::PostfixProjectFromNames => { abort; }
@@ -1120,7 +1120,7 @@ entity SMTTransformer {
                 | BSQAssembly::PostfixAccessSomeValue => { return this.transformPostfixAccessSomeValue($op, pstate.0, pstate.1); }
                 | BSQAssembly::PostfixLiteralNoneValue => { return this.transformPostfixLiteralNoneValue($op, pstate.0, pstate.1); }
             }
-        });
+        }, (|nctx, eexp|));
 
         return rres;
     }
@@ -1896,7 +1896,7 @@ entity SMTTransformer {
     recursive method transformIfElifElseStatement(stmt: BSQAssembly::IfElifElseStatement, tail: Option<SMTAssembly::Operation>, ctx: SMTTransformerCtx): SMTTransformerCtx, Option<SMTAssembly::Operation> {
         let ectx, elseop = this.transformBlockStatement[recursive](stmt.elseflow, tail, ctx);
 
-        let octx, conds = stmt.condflow.reduce<(|SMTTransformerCtx, SMTAssembly::Operation|)>((|ectx, elseop@some|), recursive fn(acc, flow) => {
+        let octx, conds = stmt.condflow.reduce<(|SMTTransformerCtx, SMTAssembly::Operation|)>(recursive fn(acc, flow) => {
             let ntexp, cctx, cobinds = this.processUnaryArg[recursive](flow.0, acc.0);
             let nctx, nblock = this.transformBlockStatement[recursive](flow.1, tail, cctx);
 
@@ -1907,7 +1907,7 @@ entity SMTTransformer {
             else {
                 return nctx, SMTAssembly::LetWErrorsOperation{$cobinds, ifop};
             }
-        });
+        }, (|ectx, elseop@some|));
 
         let itexp, ictx, iobinds = this.processUnaryArg[recursive](stmt.ifcond, octx);
         let inctx, inblock = this.transformBlockStatement[recursive](stmt.ifflow, tail, ictx);
@@ -1924,7 +1924,7 @@ entity SMTTransformer {
     recursive method transformMatchStatement(stmt: BSQAssembly::MatchStatement, tail: Option<SMTAssembly::Operation>, ctx: SMTTransformerCtx): SMTTransformerCtx, Option<SMTAssembly::Operation> {
         let ntexp, cctx, cobinds = this.processUnaryArg[recursive](stmt.sval, ctx);
         
-        var fctx, ops = stmt.matchflow.reduce<(|SMTTransformerCtx, List<(|Bool, SMTAssembly::TypeKey, SMTAssembly::Operation|)>|)>((|cctx, List<(|Bool, SMTAssembly::TypeKey, SMTAssembly::Operation|)>{}|), recursive fn(acc, op) => {
+        var fctx, ops = stmt.matchflow.reduce<(|SMTTransformerCtx, List<(|Bool, SMTAssembly::TypeKey, SMTAssembly::Operation|)>|)>(recursive fn(acc, op) => {
             let cctx, nblock = this.transformBlockStatement[recursive](op.1, tail, acc.0);
 
             var fblock: SMTAssembly::Operation = nblock@some;
@@ -1936,7 +1936,7 @@ entity SMTTransformer {
 
             let iscct = this.assembly.isTypeConcrete(op.0);
             return cctx, acc.1.pushBack((|!iscct, this.transformStdTypeToSMT(op.0), fblock|));
-        });
+        }, (|cctx, List<(|Bool, SMTAssembly::TypeKey, SMTAssembly::Operation|)>{}|));
 
         var mop: SMTAssembly::MatchOperation;
         if(stmt.mustExhaustive) {
@@ -2023,18 +2023,18 @@ entity SMTTransformer {
     }
 
     recursive method transformBlockStatement(stmt: BSQAssembly::BlockStatement, tail: Option<SMTAssembly::Operation>, ctx: SMTTransformerCtx): SMTTransformerCtx, Option<SMTAssembly::Operation> {
-        return stmt.statements.lreduce[recursive]<(|SMTTransformerCtx, Option<SMTAssembly::Operation>|)>((|ctx, tail|), recursive fn(acc, s) => {
+        return stmt.statements.lreduce[recursive]<(|SMTTransformerCtx, Option<SMTAssembly::Operation>|)>(recursive fn(acc, s) => {
             return this.transformStatement[recursive](s, acc.1, acc.0);
-        });
+        }, (|ctx, tail|));
     }
 
     recursive method transformBinderBlockStatement(stmt: BSQAssembly::BinderBlockStatement, tail: Option<SMTAssembly::Operation>, ctx: SMTTransformerCtx): SMTTransformerCtx, Option<SMTAssembly::Operation> {
         let onarg, cctx, cobinds = this.processUnaryArg[recursive](stmt.bexp, ctx);
         let topt, _ = this.transformITestAsSafeConvertOptions(stmt.bexp.etype, stmt.itest, onarg);
         
-        let octx, ops = stmt.statements.lreduce[recursive]<(|SMTTransformerCtx, Option<SMTAssembly::Operation>|)>((|cctx, tail|), recursive fn(acc, s) => {
+        let octx, ops = stmt.statements.lreduce[recursive]<(|SMTTransformerCtx, Option<SMTAssembly::Operation>|)>(recursive fn(acc, s) => {
             return this.transformStatement[recursive](s, acc.1, acc.0);
-        });
+        }, (|cctx, tail|));
 
         let bindname = SMTAssembly::Identifier::from(TransformNameManager::safeifyName(stmt.binder.srcname.value));
         let bindop = SMTAssembly::LetOperation{bindname, topt, ops@some};
@@ -2064,9 +2064,9 @@ entity SMTTransformer {
                 }
             }
             | BSQAssembly::StandardBodyImplementation => {
-                let rctx, smtop = $impl.statements.lreduce[recursive]<(|SMTTransformerCtx, Option<SMTAssembly::Operation>|)>((|ctx, none|), recursive fn(acc, s) => {
+                let rctx, smtop = $impl.statements.lreduce[recursive]<(|SMTTransformerCtx, Option<SMTAssembly::Operation>|)>(recursive fn(acc, s) => {
                     return this.transformStatement[recursive](s, acc.1, acc.0);
-                });
+                }, (|ctx, none|));
                 
                 return rctx, smtop@some;
             }
@@ -2154,7 +2154,7 @@ entity SMTTransformer {
                 let rtype = this.transformStdTypeToSMT(decl.resultType);
                 let artype = if(mayerr) then SMTAssembly::ErrorResult{ rtype } else SMTAssembly::SafeResult{ rtype };
 
-                let lambdaerr = lgi.largerrors.reduce<Map<BSQAssembly::Identifier, Bool>>(Map<BSQAssembly::Identifier, Bool>{}, fn(lemap, gg) => lemap.insert(gg.0, gg.1));
+                let lambdaerr = lgi.largerrors.reduce<Map<BSQAssembly::Identifier, Bool>>(fn(lemap, gg) => lemap.insert(gg.0, gg.1), Map<BSQAssembly::Identifier, Bool>{});
                 let ctx = SMTTransformerCtx{mayerr, lambdaerr, decl.file, some(decl.ikey), some(ikey), false, 1n, 1n, List<SMTAssembly::ErrorInfo>{}, List<LambdaGeneratorInfo>{lgi}};
                 let rctx, body = this.transformBodyToSMTBody(decl.body, ctx, decl.resultType);
 
@@ -2219,7 +2219,7 @@ entity SMTTransformer {
                 let rtype = this.transformStdTypeToSMT(decl.resultType);
                 let artype = if(mayerr) then SMTAssembly::ErrorResult{ rtype } else SMTAssembly::SafeResult{ rtype };
 
-                let lambdaerr = lgi.largerrors.reduce<Map<BSQAssembly::Identifier, Bool>>(Map<BSQAssembly::Identifier, Bool>{}, fn(lemap, gg) => lemap.insert(gg.0, gg.1));
+                let lambdaerr = lgi.largerrors.reduce<Map<BSQAssembly::Identifier, Bool>>(fn(lemap, gg) => lemap.insert(gg.0, gg.1), Map<BSQAssembly::Identifier, Bool>{});
                 let ctx = SMTTransformerCtx{mayerr, lambdaerr, decl.file, some(decl.ikey), some(ikey), false, 1n, 1n, List<SMTAssembly::ErrorInfo>{}, List<LambdaGeneratorInfo>{lgi}};
                 let rctx, body = this.transformBodyToSMTBody(decl.body, ctx, decl.resultType);
 
@@ -2286,7 +2286,7 @@ entity SMTTransformer {
                 let rtype = this.transformStdTypeToSMT(decl.resultType);
                 let artype = if(mayerr) then SMTAssembly::ErrorResult{ rtype } else SMTAssembly::SafeResult{ rtype };
 
-                let lambdaerr = lgi.largerrors.reduce<Map<BSQAssembly::Identifier, Bool>>(Map<BSQAssembly::Identifier, Bool>{}, fn(lemap, gg) => lemap.insert(gg.0, gg.1));
+                let lambdaerr = lgi.largerrors.reduce<Map<BSQAssembly::Identifier, Bool>>(fn(lemap, gg) => lemap.insert(gg.0, gg.1), Map<BSQAssembly::Identifier, Bool>{});
                 let ctx = SMTTransformerCtx{mayerr, lambdaerr, decl.file, some(decl.ikey), some(ikey), false, 1n, 1n, List<SMTAssembly::ErrorInfo>{}, List<LambdaGeneratorInfo>{lgi}};
                 let rctx, body = this.transformBodyToSMTBody(decl.body, ctx, decl.resultType);
 
@@ -2362,7 +2362,7 @@ entity SMTTransformer {
                 let rtype = this.transformStdTypeToSMT(SMTTransformer::booltype);
                 let artype = if(mayerr) then SMTAssembly::ErrorResult{ rtype } else SMTAssembly::SafeResult{ rtype };
 
-                let lambdaerr = lgi.largerrors.reduce<Map<BSQAssembly::Identifier, Bool>>(Map<BSQAssembly::Identifier, Bool>{}, fn(lemap, gg) => lemap.insert(gg.0, gg.1));
+                let lambdaerr = lgi.largerrors.reduce<Map<BSQAssembly::Identifier, Bool>>(fn(lemap, gg) => lemap.insert(gg.0, gg.1), Map<BSQAssembly::Identifier, Bool>{});
                 let ctx = SMTTransformerCtx{mayerr, lambdaerr, cond.file, some(cond.ikey), some(ikey), false, 1n, 1n, List<SMTAssembly::ErrorInfo>{}, List<LambdaGeneratorInfo>{lgi}};
                 let rctx, smtexp = this.transformExpressionToSMT(cond.exp, ctx);
 
@@ -2950,11 +2950,10 @@ entity SMTTransformer {
             .mergeLambdaGeneratorInfo(List<LambdaGeneratorInfo>::concatAll(ttypeconstsinfo.map<List<LambdaGeneratorInfo>>(fn(tc) => tc.1)));
 
         let tnsfuncs, lgstatef, tnsinvkeys = this.callg.topoorder
-            .lreduce<(|Map<SMTAssembly::InvokeKey, SMTAssembly::FunctionDecl>, LambdaGeneratorState, List<SMTAssembly::InvokeKey>|)>((|Map<SMTAssembly::InvokeKey, SMTAssembly::FunctionDecl>{}, lgstate, List<SMTAssembly::InvokeKey>{}|), 
-                fn(acc, ikey) => {
+            .lreduce<(|Map<SMTAssembly::InvokeKey, SMTAssembly::FunctionDecl>, LambdaGeneratorState, List<SMTAssembly::InvokeKey>|)>(fn(acc, ikey) => {
                     let fdinfo = this.transformInvokeToSMTFunction(ikey, acc.1.getLambdaGeneratorInfo(ikey));
                     if(fdinfo)@some {
-                        let nfm = $fdinfo.0.reduce<Map<SMTAssembly::InvokeKey, SMTAssembly::FunctionDecl>>(acc.0, fn(mm, f) => mm.insert(f.invokeKey, f));
+                        let nfm = $fdinfo.0.reduce<Map<SMTAssembly::InvokeKey, SMTAssembly::FunctionDecl>>(fn(mm, f) => mm.insert(f.invokeKey, f), acc.0);
                         let nlgen = acc.1.mergeLambdaGeneratorInfo($fdinfo.1);
                         let nlsort = acc.2.prepend($fdinfo.0.map<SMTAssembly::InvokeKey>(fn(f) => f.invokeKey));
 
@@ -2963,19 +2962,22 @@ entity SMTTransformer {
                     else {
                         return acc;
                     }
-                });
+                },
+                (|Map<SMTAssembly::InvokeKey, SMTAssembly::FunctionDecl>{}, lgstate, List<SMTAssembly::InvokeKey>{}|)
+            );
 
         let tnsfuncsbuiltin = this.callg.topoorder
-            .lreduce<Map<SMTAssembly::InvokeKey, SMTAssembly::BuiltinFunctionDecl>>(Map<SMTAssembly::InvokeKey, SMTAssembly::BuiltinFunctionDecl>{}, 
-                fn(acc, ikey) => {
+            .lreduce<Map<SMTAssembly::InvokeKey, SMTAssembly::BuiltinFunctionDecl>>(fn(acc, ikey) => {
                     let bidl = this.transformInvokeToSMTBuiltinFunction(ikey, lgstatef.getLambdaGeneratorInfo(ikey));
                     if(bidl)@some {
-                        return $bidl.reduce<Map<SMTAssembly::InvokeKey, SMTAssembly::BuiltinFunctionDecl>>(acc, fn(mm, f) => mm.insert(f.invokeKey, f));
+                        return $bidl.reduce<Map<SMTAssembly::InvokeKey, SMTAssembly::BuiltinFunctionDecl>>(fn(mm, f) => mm.insert(f.invokeKey, f), acc);
                     }
                     else {
                         return acc;
                     }
-                });
+                },
+                Map<SMTAssembly::InvokeKey, SMTAssembly::BuiltinFunctionDecl>{}
+            );
 
         let tenums = this.assembly.allconcretetypes
             .filter(pred(tkey) => this.assembly.enums.has(tkey))

--- a/src/bsqir/simplifier/constsimplify.bsq
+++ b/src/bsqir/simplifier/constsimplify.bsq
@@ -962,7 +962,7 @@ entity ConstantSimplification {
             return nifflow;
         }
         else {
-            return ncondflow.lreduce<Statement>(nelseflow, fn(acc, eb) => {
+            return ncondflow.lreduce<Statement>(fn(acc, eb) => {
                 let cur = eb.0;
                 if(cur)@!<LiteralSimpleExpression> {
                     return s[ifcond=nifcond, ifflow=nifflow, condflow=ncondflow, elseflow=nelseflow];
@@ -975,14 +975,14 @@ entity ConstantSimplification {
                         return acc;
                     }
                 }
-            });
+            }, nelseflow);
         }
     }
 
     recursive method processMatchStatement(s: MatchStatement): Statement {
         let nsv = this.processExpression[recursive](s.sval);
 
-        let nflow = s.matchflow.reduce[recursive]<(|Bool, List<(|TypeSignature, BlockStatement|)>|)>((|true, List<(|TypeSignature, BlockStatement|)>{}|), recursive fn(acc, mb) => {
+        let nflow = s.matchflow.reduce[recursive]<(|Bool, List<(|TypeSignature, BlockStatement|)>|)>(recursive fn(acc, mb) => {
             if(!acc.0) {
                 return acc;
             }
@@ -997,7 +997,7 @@ entity ConstantSimplification {
                     return (|true, acc.1.pushBack((|mb.0, this.processBlockStatement[recursive](mb.1)|))|);
                 }
             }
-        });
+        }, (|true, List<(|TypeSignature, BlockStatement|)>{}|));
 
         if(nflow.1.empty()) {
             return AbortStatement{ s.sinfo };
@@ -1152,7 +1152,7 @@ entity ConstantSimplification {
     }
 
     recursive method processBodyStatementList(stmts: List<Statement>): List<Statement> {
-        let _, nstmts = stmts.reduce[recursive]<(|Bool, List<Statement>|)>((|false, List<Statement>{}|), recursive fn(rvi, stmt) => {
+        let _, nstmts = stmts.reduce[recursive]<(|Bool, List<Statement>|)>(recursive fn(rvi, stmt) => {
             if(rvi.0) {
                 return rvi;
             }
@@ -1162,7 +1162,7 @@ entity ConstantSimplification {
 
                 return (|done, rvi.1.pushBack(pcc)|);
             }
-        });
+        }, (|false, List<Statement>{}|));
 
         return nstmts;
     }

--- a/src/core/algorithms.bsq
+++ b/src/core/algorithms.bsq
@@ -11,9 +11,9 @@ namespace AlgorithmOps {
         var pvmap = vmap.insert(t, false);
         let nexts = next[recursive?](t);
 
-        let nordered, nmap = nexts.reduce[recursive]<(|List<T>, Map<T, Bool>|)>((|ordered, pvmap|), recursive fn(acc, v) => {
+        let nordered, nmap = nexts.reduce[recursive]<(|List<T>, Map<T, Bool>|)>(recursive fn(acc, v) => {
             return AlgorithmOps::s_topologicalSort_single[recursive]<T>(v, acc.0, acc.1, next);
-        });
+        }, (|ordered, pvmap|));
 
         return nordered.pushBack(t), nmap.set(t, true);
     }
@@ -26,9 +26,9 @@ namespace AlgorithmOps {
             var pvmap = vmap.insert(t, false);
             let nexts = next[recursive?](t);
 
-            let tscc, nmap = nexts.reduce[recursive]<(|List<T>, Map<T, Bool>|)>((|scc, pvmap|), recursive fn(acc, v) => {
+            let tscc, nmap = nexts.reduce[recursive]<(|List<T>, Map<T, Bool>|)>(recursive fn(acc, v) => {
                 return AlgorithmOps::s_scc_visit[recursive]<T>(v, acc.0, acc.1, next);
-            });
+            }, (|scc, pvmap|));
 
             return tscc.pushBack(t), nmap.set(t, true);
         }
@@ -56,9 +56,9 @@ namespace Algorithm {
     }
 
     recursive? function topologicalSort<T: keytype>(init: List<T>, next: recursive? fn(T) -> List<T>): List<T> {
-        let ordered, _ = init.reduce[recursive?]<(|List<T>, Map<T, Bool>|)>((|List<T>{}, Map<T, Bool>{}|), recursive? fn(acc, t) => {
+        let ordered, _ = init.reduce[recursive?]<(|List<T>, Map<T, Bool>|)>(recursive? fn(acc, t) => {
             return AlgorithmOps::s_topologicalSort_single[recursive?]<T>(t, acc.0, acc.1, next);
-        });
+        }, (|List<T>{}, Map<T, Bool>{}|));
 
         return ordered;
     }
@@ -66,7 +66,7 @@ namespace Algorithm {
     recursive? function topologicalSortWComponents<T: keytype>(init: List<T>, next: recursive? fn(T) -> List<T>): List<T>, List<List<T>>  {
         let topol = Algorithm::topologicalSort<T>(init, next);
 
-        let sccs, _ = topol.reduce[recursive?]<(|List<List<T>>, Map<T, Bool>|)>((|List<List<T>>{}, Map<T, Bool>{}|), recursive? fn(acc, t) => {
+        let sccs, _ = topol.reduce[recursive?]<(|List<List<T>>, Map<T, Bool>|)>(recursive? fn(acc, t) => {
             if(acc.1.has(t)) {
                 return acc;
             }
@@ -86,7 +86,7 @@ namespace Algorithm {
                     return acc.0, nmap;
                 }
             }
-        });
+        }, (|List<List<T>>{}, Map<T, Bool>{}|));
 
         return topol, sccs;
     }

--- a/src/core/core.bsq
+++ b/src/core/core.bsq
@@ -187,7 +187,7 @@ __internal __typedeclable __keycomparable entity String {
             return "";
         }
         else {
-            return strs.reduce<String>("", fn(acc, s) => StringOps::s_concat2(acc, s));
+            return strs.reduce<String>(fn(acc, s) => StringOps::s_concat2(acc, s), "");
         }
     }
 
@@ -197,7 +197,7 @@ __internal __typedeclable __keycomparable entity String {
             return "";
         }
         else {
-            return strs.reduce<String>("", fn(acc, s) => StringOps::s_concat2(acc, s));
+            return strs.reduce<String>(fn(acc, s) => StringOps::s_concat2(acc, s), "");
         }
     }
 
@@ -207,14 +207,14 @@ __internal __typedeclable __keycomparable entity String {
             return "";
         }
         else {
-            return strs.reduce<String>("", fn(acc, s) => {
+            return strs.reduce<String>(fn(acc, s) => {
                 if(acc.empty()) {
                     return s;
                 }
                 else {
                     return StringOps::s_concat2(StringOps::s_concat2(acc, sep), s);
                 }
-            });
+            }, "");
         }
     }
 
@@ -224,14 +224,14 @@ __internal __typedeclable __keycomparable entity String {
             return "";
         }
         else {
-            return strs.reduce<String>("", fn(acc, s) => {
+            return strs.reduce<String>(fn(acc, s) => {
                 if(acc.empty()) {
                     return s;
                 }
                 else {
                     return StringOps::s_concat2(StringOps::s_concat2(acc, sep), s);
                 }
-            });
+            }, "");
         }
     }
 
@@ -321,7 +321,7 @@ __internal __typedeclable __keycomparable entity CString {
             return '';
         }
         else {
-            return strs.reduce<CString>('', fn(acc, s) => CStringOps::s_concat2(acc, s));
+            return strs.reduce<CString>(fn(acc, s) => CStringOps::s_concat2(acc, s), '');
         }
     }
 
@@ -331,7 +331,7 @@ __internal __typedeclable __keycomparable entity CString {
             return '';
         }
         else {
-            return strs.reduce<CString>('', fn(acc, s) => CStringOps::s_concat2(acc, s));
+            return strs.reduce<CString>(fn(acc, s) => CStringOps::s_concat2(acc, s), '');
         }
     }
 
@@ -341,14 +341,14 @@ __internal __typedeclable __keycomparable entity CString {
             return '';
         }
         else {
-            return strs.reduce<CString>('', fn(acc, s) => {
+            return strs.reduce<CString>(fn(acc, s) => {
                 if(acc.empty()) {
                     return s;
                 }
                 else {
                     return CStringOps::s_concat2(CStringOps::s_concat2(acc, sep), s);
                 }
-            });
+            }, '');
         }
     }
 
@@ -358,14 +358,14 @@ __internal __typedeclable __keycomparable entity CString {
             return '';
         }
         else {
-            return strs.reduce<CString>('', fn(acc, s) => {
+            return strs.reduce<CString>(fn(acc, s) => {
                 if(acc.empty()) {
                     return s;
                 }
                 else {
                     return CStringOps::s_concat2(CStringOps::s_concat2(acc, sep), s);
                 }
-            });
+            }, '');
         }
     }
 

--- a/src/core/list.bsq
+++ b/src/core/list.bsq
@@ -127,7 +127,7 @@ __internal entity List<T> {
                 return ll.single();
             }
             else {
-                return ll.reduce<List<T>>(List<T>{}, fn(acc, l) => ListOps::s_concat2<T>(acc, l));
+                return ll.reduce<List<T>>(fn(acc, l) => ListOps::s_concat2<T>(acc, l), List<T>{});
             }
         }
     }
@@ -141,7 +141,7 @@ __internal entity List<T> {
                 return ll.single();
             }
             else {
-                return ll.reduce<List<T>>(List<T>{}, fn(acc, l) => ListOps::s_concat2<T>(acc, l));
+                return ll.reduce<List<T>>(fn(acc, l) => ListOps::s_concat2<T>(acc, l), List<T>{});
             }
         }
     }
@@ -306,7 +306,7 @@ TODO: this should work (I think)
 
     %% we need to some more flavors here like refduce and reduceIdx
 
-    recursive? method reduce<U>(init: U, f: recursive? fn(U, T) -> U): U {
+    recursive? method reduce<U>(f: recursive? fn(U, T) -> U, init: U): U {
         if(ListOps::s_list_empty<T>(this)) {
             return init;
         }
@@ -315,7 +315,7 @@ TODO: this should work (I think)
         }
     }
 
-    recursive? method lreduce<U>(init: U, f: recursive? fn(U, T) -> U): U {
+    recursive? method lreduce<U>(f: recursive? fn(U, T) -> U, init: U): U {
         if(ListOps::s_list_empty<T>(this)) {
             return init;
         }
@@ -324,7 +324,7 @@ TODO: this should work (I think)
         }
     }
 
-    recursive? method transduce<E, U>(environment: E, f: recursive? fn(E, T) -> (|E, U|)): E, List<U> {
+    recursive? method transduce<E, U>(f: recursive? fn(E, T) -> (|E, U|), environment: E): E, List<U> {
         if(ListOps::s_list_empty<T>(this)) {
             return environment, List<U>{};
         }
@@ -333,7 +333,7 @@ TODO: this should work (I think)
         }
     }
 
-    recursive? method ltransduce<E, U>(environment: E, f: recursive? fn(E, T) -> (|E, U|)): E, List<U> {
+    recursive? method ltransduce<E, U>(f: recursive? fn(E, T) -> (|E, U|), environment: E): E, List<U> {
         if(ListOps::s_list_empty<T>(this)) {
             return environment, List<U>{};
         }

--- a/src/core/map.bsq
+++ b/src/core/map.bsq
@@ -117,7 +117,7 @@ __internal entity Map<K: keytype, V> {
                 return maps.single();
             }
             else {
-                return maps.reduce<Map<K, V>>(Map<K, V>{}, fn(acc, m) => MapOps::s_map_union2<K, V>(acc, m));
+                return maps.reduce<Map<K, V>>(fn(acc, m) => MapOps::s_map_union2<K, V>(acc, m), Map<K, V>{});
             }
         }
     }
@@ -131,7 +131,7 @@ __internal entity Map<K: keytype, V> {
                 return maps.single();
             }
             else {
-                return maps.reduce<Map<K, V>>(Map<K, V>{}, fn(acc, m) => MapOps::s_map_union2<K, V>(acc, m));
+                return maps.reduce<Map<K, V>>(fn(acc, m) => MapOps::s_map_union2<K, V>(acc, m), Map<K, V>{});
             }
         }
     }
@@ -145,7 +145,7 @@ __internal entity Map<K: keytype, V> {
         }
     }
 
-    recursive? method reduce<U>(init: U, f: recursive? fn(U, K, V) -> U): U {
+    recursive? method reduce<U>(f: recursive? fn(U, K, V) -> U, init: U): U {
         if(MapOps::s_map_empty<K, V>(this)) {
             return init;
         }
@@ -163,7 +163,7 @@ __internal entity Map<K: keytype, V> {
                 return maps.single();
             }
             else {
-                return maps.reduce<Map<K, V>>(Map<K, V>{}, fn(acc, m) => MapOps::s_map_mergei2<K, V>(acc, m));
+                return maps.reduce<Map<K, V>>(fn(acc, m) => MapOps::s_map_mergei2<K, V>(acc, m), Map<K, V>{});
             }
         }
     }
@@ -177,7 +177,7 @@ __internal entity Map<K: keytype, V> {
                 return maps.single();
             }
             else {
-                return maps.reduce<Map<K, V>>(Map<K, V>{}, fn(acc, m) => MapOps::s_map_mergei2<K, V>(acc, m));
+                return maps.reduce<Map<K, V>>(fn(acc, m) => MapOps::s_map_mergei2<K, V>(acc, m), Map<K, V>{});
             }
         }
     }
@@ -191,7 +191,7 @@ __internal entity Map<K: keytype, V> {
                 return maps.single();
             }
             else {
-                return maps.reduce<Map<K, V>>(Map<K, V>{}, recursive? fn(acc, m) => MapOps::s_map_mergec2[recursive?]<K, V>(acc, m, merge));
+                return maps.reduce<Map<K, V>>(recursive? fn(acc, m) => MapOps::s_map_mergec2[recursive?]<K, V>(acc, m, merge), Map<K, V>{});
             }
         }
     }

--- a/src/samples/db/db.bsq
+++ b/src/samples/db/db.bsq
@@ -29,13 +29,13 @@ entity Format {
     invariant $vcount == $entries.map<Nat>(fn(ee) => ee.entries.size()).sum();
 
     method formatEntry(entry: Entry): CString {
-        let res, _ = this.entries.reduce<(|CString, List<CString>|)>((|'', entry.items|), fn(acc, fmt) => {
+        let res, _ = this.entries.reduce<(|CString, List<CString>|)>(fn(acc, fmt) => {
             let fargs = acc.1.firstK(fmt.entries.size());
             let rrest = acc.1.shiftK(fmt.entries.size());
 
             let formatted = CString::concat(acc.0, '%n;', fmt.format(fargs));
             return formatted, rrest;
-        });
+        }, (|'', entry.items|));
 
         return res;
     }
@@ -245,10 +245,10 @@ entity Database {
     }
 
     method processDB(ops: List<DatabaseOperation>): CString, Database {
-        let res, tdb = ops.reduce<(|List<CString>, Database|)>((|List<CString>{}, this|), fn(acc, op) => {
+        let res, tdb = ops.reduce<(|List<CString>, Database|)>(fn(acc, op) => {
             let opstr, ndb = acc.1.processDatabaseOperation(op);
             return acc.0.pushBack(opstr), ndb;
-        });
+        }, (|List<CString>{}, this|));
 
         return CString::joinAll('%n;', res), tdb;
     }

--- a/src/samples/raytrace/raytrace.bsq
+++ b/src/samples/raytrace/raytrace.bsq
@@ -38,7 +38,7 @@ entity RayTracer{
     }
 
     method minIntersection(ray: Ray, scene: Scene): Option<ISect> {
-        return scene.things.reduce<Option<ISect>>(none, fn(min, obj) => {
+        return scene.things.reduce<Option<ISect>>(fn(min, obj) => {
             let isect = obj.intersect(ray);
             if(isect)@none {
                 return min;
@@ -56,7 +56,7 @@ entity RayTracer{
                     }
                 }
             }
-        });
+        }, none);
     }
 
     method testRay(ray: Ray, scene: Scene): Float {

--- a/src/samples/tic_tac_toe/tic_tac_toe.bsq
+++ b/src/samples/tic_tac_toe/tic_tac_toe.bsq
@@ -86,7 +86,7 @@ entity Board {
 
 %*
 function main(moves: List<[Nat, Nat, PlayerMark]>): Result<PlayerMark?, String> {
-    let res = moves.reduce<Result<Board, String>>(Result<Board, String>::Ok{Board::createEmpty()}, fn(state: Result<Board, String>, move: [Nat, Nat, PlayerMark]): Result<Board, String> => {
+    let res = moves.reduce<Result<Board, String>>(fn(state: Result<Board, String>, move: [Nat, Nat, PlayerMark]): Result<Board, String> => {
             if err (state) {
                 return state;
             }
@@ -102,7 +102,9 @@ function main(moves: List<[Nat, Nat, PlayerMark]>): Result<PlayerMark?, String> 
                     return ok(bb.setCellMark(move.0, move.1, move.2));
                 }
             }
-        });
+        },
+        Result<Board, String>::Ok{Board::createEmpty()}
+    );
 
     if err (res) {
         return err($);

--- a/test/cppoutput/list/list_reduce.test.js
+++ b/test/cppoutput/list/list_reduce.test.js
@@ -5,19 +5,19 @@ import { describe, it } from "node:test";
 
 describe ("CPP Emit Evaluate List -- reduce simple", () => {
     it("should do simple bool reduce", function () {
-        runMainCode('public function main(): Bool { return List<Int>{}.reduce<Bool>(true, fn(acc, x) => acc && x > 0i); }', "true");
-        runMainCode('public function main(): Bool { return List<Int>{}.reduce<Bool>(false, fn(acc, x) => acc && x > 0i); }', "false");
+        runMainCode('public function main(): Bool { return List<Int>{}.reduce<Bool>(fn(acc, x) => acc && x > 0i, true); }', "true");
+        runMainCode('public function main(): Bool { return List<Int>{}.reduce<Bool>(fn(acc, x) => acc && x > 0i, false); }', "false");
 
-        runMainCode('public function main(): Bool { return List<Int>{1i, 3i}.reduce<Bool>(true, fn(acc, x) => acc && x > 0i); }', "true");
-        runMainCode('public function main(): Bool { return List<Int>{2i, 0i, 3i}.reduce<Bool>(true, fn(acc, x) => acc && x > 0i); }', "false");
+        runMainCode('public function main(): Bool { return List<Int>{1i, 3i}.reduce<Bool>(fn(acc, x) => acc && x > 0i, true); }', "true");
+        runMainCode('public function main(): Bool { return List<Int>{2i, 0i, 3i}.reduce<Bool>(fn(acc, x) => acc && x > 0i, true); }', "false");
     });
 
     it("should do simple int reduce", function () {
-        runMainCode('public function main(): Int { return List<Int>{}.reduce<Int>(0i, fn(acc, x) => acc + x); }', "0_i");
-        runMainCode('public function main(): Int { return List<Int>{}.reduce<Int>(5i, fn(acc, x) => acc + x); }', "5_i");
+        runMainCode('public function main(): Int { return List<Int>{}.reduce<Int>(fn(acc, x) => acc + x, 0i); }', "0_i");
+        runMainCode('public function main(): Int { return List<Int>{}.reduce<Int>(fn(acc, x) => acc + x, 5i); }', "5_i");
 
-        runMainCode('public function main(): Int { return List<Int>{1i, 3i}.reduce<Int>(0i, fn(acc, x) => acc + x); }', "4_i");
-        runMainCode('public function main(): Int { return List<Int>{-2i, 0i, 3i}.reduce<Int>(0i, fn(acc, x) => acc + x); }', "1_i");
+        runMainCode('public function main(): Int { return List<Int>{1i, 3i}.reduce<Int>(fn(acc, x) => acc + x, 0i); }', "4_i");
+        runMainCode('public function main(): Int { return List<Int>{-2i, 0i, 3i}.reduce<Int>(fn(acc, x) => acc + x, 0i); }', "1_i");
     });
 
 /*

--- a/test/cppoutput/map/map_reduce.test.js
+++ b/test/cppoutput/map/map_reduce.test.js
@@ -5,19 +5,19 @@ import { describe, it } from "node:test";
 
 describe ("CPP Emit Evaluate -- Map reduce simple", () => {
     it("should do simple bool reduce", function () {
-        runMainCode('public function main(): Bool { return Map<Int, Int>{}.reduce<Bool>(true, fn(acc, k, v) => acc && k > v); }', "true");
-        runMainCode('public function main(): Bool { return Map<Int, Int>{}.reduce<Bool>(false, fn(acc, k, v) => acc && v > 0i); }', "false");
+        runMainCode('public function main(): Bool { return Map<Int, Int>{}.reduce<Bool>(fn(acc, k, v) => acc && k > v, true); }', "true");
+        runMainCode('public function main(): Bool { return Map<Int, Int>{}.reduce<Bool>(fn(acc, k, v) => acc && v > 0i, false); }', "false");
 
-        runMainCode('public function main(): Bool { return Map<Int, Int>{1i => 2i, 3i => 4i}.reduce<Bool>(true, fn(acc, k, v) => acc && v > 0i); }', "true");
-        runMainCode('public function main(): Bool { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Bool>(true, fn(acc, k, v) => acc && v > 0i); }', "false");
-        runMainCode('public function main(): Bool { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Bool>(true, fn(acc, k, v) => acc && k > 0i); }', "true");
+        runMainCode('public function main(): Bool { return Map<Int, Int>{1i => 2i, 3i => 4i}.reduce<Bool>(fn(acc, k, v) => acc && v > 0i, true); }', "true");
+        runMainCode('public function main(): Bool { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Bool>(fn(acc, k, v) => acc && v > 0i, true); }', "false");
+        runMainCode('public function main(): Bool { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Bool>(fn(acc, k, v) => acc && k > 0i, true); }', "true");
     });
 
     it("should do simple int reduce", function () {
-        runMainCode('public function main(): Int { return Map<Int, Int>{}.reduce<Int>(0i, fn(acc, k, v) => acc + v); }', "0_i");
-        runMainCode('public function main(): Int { return Map<Int, Int>{}.reduce<Int>(5i, fn(acc, k, v) => acc + v); }', "5_i");
+        runMainCode('public function main(): Int { return Map<Int, Int>{}.reduce<Int>(fn(acc, k, v) => acc + v, 0i); }', "0_i");
+        runMainCode('public function main(): Int { return Map<Int, Int>{}.reduce<Int>(fn(acc, k, v) => acc + v, 5i); }', "5_i");
 
-        runMainCode('public function main(): Int { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Int>(0i, fn(acc, k, v) => acc + k); }', "4_i");
-        runMainCode('public function main(): Int { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Int>(0i, fn(acc, k, v) => acc + v); }', "2_i");
+        runMainCode('public function main(): Int { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Int>(fn(acc, k, v) => acc + k, 0i); }', "4_i");
+        runMainCode('public function main(): Int { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Int>(fn(acc, k, v) => acc + v, 0i); }', "2_i");
     });
 });

--- a/test/smtoutput/list/list_reduce.test.js
+++ b/test/smtoutput/list/list_reduce.test.js
@@ -5,27 +5,27 @@ import { describe, it } from "node:test";
 
 describe ("SMT List -- reduce simple", () => {
     it("should do simple bool reduce smt", function () {
-        runishMainCodeUnsat('public function main(): Bool { return List<Int>{}.reduce<Bool>(true, fn(acc, x) => acc && x > 0i); }', "(assert (not Main@main))");
-        runishMainCodeUnsat('public function main(): Bool { return List<Int>{}.reduce<Bool>(false, fn(acc, x) => acc && x > 0i); }', "(assert Main@main)");
+        runishMainCodeUnsat('public function main(): Bool { return List<Int>{}.reduce<Bool>(fn(acc, x) => acc && x > 0i, true); }', "(assert (not Main@main))");
+        runishMainCodeUnsat('public function main(): Bool { return List<Int>{}.reduce<Bool>(fn(acc, x) => acc && x > 0i, false); }', "(assert Main@main)");
 
-        runishMainCodeUnsat('public function main(): Bool { return List<Int>{1i, 3i}.reduce<Bool>(true, fn(acc, x) => acc && x > 0i); }', "(assert (not Main@main))");
-        runishMainCodeUnsat('public function main(): Bool { return List<Int>{2i, 0i, 3i}.reduce<Bool>(true, fn(acc, x) => acc && x > 0i); }', "(assert Main@main)");
+        runishMainCodeUnsat('public function main(): Bool { return List<Int>{1i, 3i}.reduce<Bool>(fn(acc, x) => acc && x > 0i, true); }', "(assert (not Main@main))");
+        runishMainCodeUnsat('public function main(): Bool { return List<Int>{2i, 0i, 3i}.reduce<Bool>(fn(acc, x) => acc && x > 0i, true); }', "(assert Main@main)");
     });
 
     it("should do simple int reduce smt", function () {
-        runishMainCodeUnsat('public function main(): Int { return List<Int>{}.reduce<Int>(0i, fn(acc, x) => acc + x); }', "(assert (not (= 0 Main@main)))");
-        runishMainCodeUnsat('public function main(): Int { return List<Int>{}.reduce<Int>(5i, fn(acc, x) => acc + x); }', "(assert (not (= 5 Main@main)))");
+        runishMainCodeUnsat('public function main(): Int { return List<Int>{}.reduce<Int>(fn(acc, x) => acc + x, 0i); }', "(assert (not (= 0 Main@main)))");
+        runishMainCodeUnsat('public function main(): Int { return List<Int>{}.reduce<Int>(fn(acc, x) => acc + x, 5i); }', "(assert (not (= 5 Main@main)))");
 
-        runishMainCodeUnsat('public function main(): Int { return List<Int>{1i, 3i}.reduce<Int>(0i, fn(acc, x) => acc + x); }', "(assert (not (= 4 Main@main)))");
-        runishMainCodeUnsat('public function main(): Int { return List<Int>{-2i, 0i, 3i}.reduce<Int>(0i, fn(acc, x) => acc + x); }', "(assert (not (= 1 Main@main)))");
+        runishMainCodeUnsat('public function main(): Int { return List<Int>{1i, 3i}.reduce<Int>(fn(acc, x) => acc + x, 0i); }', "(assert (not (= 4 Main@main)))");
+        runishMainCodeUnsat('public function main(): Int { return List<Int>{-2i, 0i, 3i}.reduce<Int>(fn(acc, x) => acc + x, 0i); }', "(assert (not (= 1 Main@main)))");
     });
 
     it("should do simple int reduce smt w/err", function () {
-        runishMainCodeUnsat('public function main(): Bool { return List<Int>{1i, 3i}.reduce<Bool>(true, fn(acc, x) => { assert x != 0i; return acc && x > 0i; }); }', "(assert (not (= (@Result-ok true) Main@main)))");
-        runishMainCodeUnsat('public function main(): Bool { return List<Int>{1i, 0i, 3i}.reduce<Bool>(true, fn(acc, x) => { assert x != 0i; return acc && x > 0i; }); }', "(assert (not (is-@Result-err Main@main)))");
+        runishMainCodeUnsat('public function main(): Bool { return List<Int>{1i, 3i}.reduce<Bool>(fn(acc, x) => { assert x != 0i; return acc && x > 0i; }, true); }', "(assert (not (= (@Result-ok true) Main@main)))");
+        runishMainCodeUnsat('public function main(): Bool { return List<Int>{1i, 0i, 3i}.reduce<Bool>(fn(acc, x) => { assert x != 0i; return acc && x > 0i; }, true); }', "(assert (not (is-@Result-err Main@main)))");
 
-        runishMainCodeUnsat('public function main(): Int { return List<Int>{-2i, 3i}.reduce<Int>(0i, fn(acc, x) => { assert x != 0i; return acc + x; }); }', "(assert (not (= (@Result-ok 1) Main@main)))");
-        runishMainCodeUnsat('public function main(): Int { return List<Int>{-2i, 0i, 3i}.reduce<Int>(0i, fn(acc, x) => { assert x != 0i; return acc + x; }); }', "(assert (not (is-@Result-err Main@main)))");
+        runishMainCodeUnsat('public function main(): Int { return List<Int>{-2i, 3i}.reduce<Int>(fn(acc, x) => { assert x != 0i; return acc + x; }, 0i); }', "(assert (not (= (@Result-ok 1) Main@main)))");
+        runishMainCodeUnsat('public function main(): Int { return List<Int>{-2i, 0i, 3i}.reduce<Int>(fn(acc, x) => { assert x != 0i; return acc + x; }, 0i); }', "(assert (not (is-@Result-err Main@main)))");
     });
 
 /*

--- a/test/stdlib/list/list_reduce.test.js
+++ b/test/stdlib/list/list_reduce.test.js
@@ -5,47 +5,47 @@ import { describe, it } from "node:test";
 
 describe ("List -- reduce simple", () => {
     it("should do simple bool reduce", function () {
-        runMainCode('public function main(): Bool { return List<Int>{}.reduce<Bool>(true, fn(acc, x) => acc && x > 0i); }', "true");
-        runMainCode('public function main(): Bool { return List<Int>{}.reduce<Bool>(false, fn(acc, x) => acc && x > 0i); }', "false");
+        runMainCode('public function main(): Bool { return List<Int>{}.reduce<Bool>(fn(acc, x) => acc && x > 0i, true); }', "true");
+        runMainCode('public function main(): Bool { return List<Int>{}.reduce<Bool>(fn(acc, x) => acc && x > 0i, false); }', "false");
 
-        runMainCode('public function main(): Bool { return List<Int>{1i, 3i}.reduce<Bool>(true, fn(acc, x) => acc && x > 0i); }', "true");
-        runMainCode('public function main(): Bool { return List<Int>{2i, 0i, 3i}.reduce<Bool>(true, fn(acc, x) => acc && x > 0i); }', "false");
+        runMainCode('public function main(): Bool { return List<Int>{1i, 3i}.reduce<Bool>(fn(acc, x) => acc && x > 0i, true); }', "true");
+        runMainCode('public function main(): Bool { return List<Int>{2i, 0i, 3i}.reduce<Bool>(fn(acc, x) => acc && x > 0i, true); }', "false");
     });
 
     it("should do simple int reduce", function () {
-        runMainCode('public function main(): Int { return List<Int>{}.reduce<Int>(0i, fn(acc, x) => acc + x); }', "0i");
-        runMainCode('public function main(): Int { return List<Int>{}.reduce<Int>(5i, fn(acc, x) => acc + x); }', "5i");
+        runMainCode('public function main(): Int { return List<Int>{}.reduce<Int>(fn(acc, x) => acc + x, 0i); }', "0i");
+        runMainCode('public function main(): Int { return List<Int>{}.reduce<Int>(fn(acc, x) => acc + x, 5i); }', "5i");
 
-        runMainCode('public function main(): Int { return List<Int>{1i, 3i}.reduce<Int>(0i, fn(acc, x) => acc + x); }', "4i");
-        runMainCode('public function main(): Int { return List<Int>{-2i, 0i, 3i}.reduce<Int>(0i, fn(acc, x) => acc + x); }', "1i");
+        runMainCode('public function main(): Int { return List<Int>{1i, 3i}.reduce<Int>(fn(acc, x) => acc + x, 0i); }', "4i");
+        runMainCode('public function main(): Int { return List<Int>{-2i, 0i, 3i}.reduce<Int>(fn(acc, x) => acc + x, 0i); }', "1i");
     });
 
     it("should do simple int lreduce", function () {
-        runMainCode('public function main(): Int { return List<Int>{}.lreduce<Int>(0i, fn(acc, x) => acc + x); }', "0i");
-        runMainCode('public function main(): Int { return List<Int>{}.lreduce<Int>(5i, fn(acc, x) => acc + x); }', "5i");
+        runMainCode('public function main(): Int { return List<Int>{}.lreduce<Int>(fn(acc, x) => acc + x, 0i); }', "0i");
+        runMainCode('public function main(): Int { return List<Int>{}.lreduce<Int>(fn(acc, x) => acc + x, 5i); }', "5i");
 
-        runMainCode('public function main(): Int { return List<Int>{1i, 3i}.lreduce<Int>(0i, fn(acc, x) => acc + x); }', "4i");
-        runMainCode('public function main(): Int { return List<Int>{-2i, 0i, 3i}.lreduce<Int>(0i, fn(acc, x) => acc + x); }', "1i");
+        runMainCode('public function main(): Int { return List<Int>{1i, 3i}.lreduce<Int>(fn(acc, x) => acc + x, 0i); }', "4i");
+        runMainCode('public function main(): Int { return List<Int>{-2i, 0i, 3i}.lreduce<Int>(fn(acc, x) => acc + x, 0i); }', "1i");
     });
 });
 
 describe ("List -- transduce simple", () => {
     it("should do simple int transduce", function () {
-        runMainCode('public function main(): Int { return List<Int>{}.transduce<Int, Bool>(0i, fn(e, x) => (|e + 1i, x > 2i|)).0; }', "0i");
-        runMainCode('public function main(): Nat { return List<Int>{}.transduce<Int, Bool>(0i, fn(e, x) => (|e + 1i, x > 2i|)).1.size(); }', "0n");
+        runMainCode('public function main(): Int { return List<Int>{}.transduce<Int, Bool>(fn(e, x) => (|e + 1i, x > 2i|), 0i).0; }', "0i");
+        runMainCode('public function main(): Nat { return List<Int>{}.transduce<Int, Bool>(fn(e, x) => (|e + 1i, x > 2i|), 0i).1.size(); }', "0n");
 
-        runMainCode('public function main(): Int { return List<Int>{1i, 2i, 3i}.transduce<Int, Bool>(0i, fn(e, x) => (|e + 1i, x > 2i|)).0; }', "3i");
-        runMainCode('public function main(): Nat { return List<Int>{1i, 2i, 3i}.transduce<Int, Bool>(0i, fn(e, x) => (|e + 1i, x > 2i|)).1.size(); }', "3n");
-        runMainCode('public function main(): Bool { return List<Int>{1i, 2i, 3i}.transduce<Int, Bool>(0i, fn(e, x) => (|e + 1i, x > 2i|)).1.front(); }', "false");
-        runMainCode('public function main(): Bool { return List<Int>{1i, 2i, 3i}.transduce<Int, Bool>(0i, fn(e, x) => (|e + 1i, x > 2i|)).1.back(); }', "true");
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i, 3i}.transduce<Int, Bool>(fn(e, x) => (|e + 1i, x > 2i|), 0i).0; }', "3i");
+        runMainCode('public function main(): Nat { return List<Int>{1i, 2i, 3i}.transduce<Int, Bool>(fn(e, x) => (|e + 1i, x > 2i|), 0i).1.size(); }', "3n");
+        runMainCode('public function main(): Bool { return List<Int>{1i, 2i, 3i}.transduce<Int, Bool>(fn(e, x) => (|e + 1i, x > 2i|), 0i).1.front(); }', "false");
+        runMainCode('public function main(): Bool { return List<Int>{1i, 2i, 3i}.transduce<Int, Bool>(fn(e, x) => (|e + 1i, x > 2i|), 0i).1.back(); }', "true");
     });
 
     it("should do simple int ltransduce", function () {
-        runMainCode('public function main(): Int { return List<Int>{}.ltransduce<Int, Bool>(0i, fn(e, x) => (|e + 1i, x > 2i|)).0; }', "0i");
-        runMainCode('public function main(): Nat { return List<Int>{}.ltransduce<Int, Bool>(0i, fn(e, x) => (|e + 1i, x > 2i|)).1.size(); }', "0n");
+        runMainCode('public function main(): Int { return List<Int>{}.ltransduce<Int, Bool>(fn(e, x) => (|e + 1i, x > 2i|), 0i).0; }', "0i");
+        runMainCode('public function main(): Nat { return List<Int>{}.ltransduce<Int, Bool>(fn(e, x) => (|e + 1i, x > 2i|), 0i).1.size(); }', "0n");
 
-        runMainCode('public function main(): Int { return List<Int>{1i, 2i, 3i}.ltransduce<Int, Bool>(0i, fn(e, x) => (|e + 1i, x > 2i|)).0; }', "3i");
-        runMainCode('public function main(): Nat { return List<Int>{1i, 2i, 3i}.ltransduce<Int, Bool>(0i, fn(e, x) => (|e + 1i, x > 2i|)).1.size(); }', "3n");
+        runMainCode('public function main(): Int { return List<Int>{1i, 2i, 3i}.ltransduce<Int, Bool>(fn(e, x) => (|e + 1i, x > 2i|), 0i).0; }', "3i");
+        runMainCode('public function main(): Nat { return List<Int>{1i, 2i, 3i}.ltransduce<Int, Bool>(fn(e, x) => (|e + 1i, x > 2i|), 0i).1.size(); }', "3n");
     });
 });
 

--- a/test/stdlib/map/map_reduce.test.js
+++ b/test/stdlib/map/map_reduce.test.js
@@ -5,19 +5,19 @@ import { describe, it } from "node:test";
 
 describe ("Map -- reduce simple", () => {
     it("should do simple bool reduce", function () {
-        runMainCode('public function main(): Bool { return Map<Int, Int>{}.reduce<Bool>(true, fn(acc, k, v) => acc && k > v); }', "true");
-        runMainCode('public function main(): Bool { return Map<Int, Int>{}.reduce<Bool>(false, fn(acc, k, v) => acc && v > 0i); }', "false");
+        runMainCode('public function main(): Bool { return Map<Int, Int>{}.reduce<Bool>(fn(acc, k, v) => acc && k > v, true); }', "true");
+        runMainCode('public function main(): Bool { return Map<Int, Int>{}.reduce<Bool>(fn(acc, k, v) => acc && v > 0i, false); }', "false");
 
-        runMainCode('public function main(): Bool { return Map<Int, Int>{1i => 2i, 3i => 4i}.reduce<Bool>(true, fn(acc, k, v) => acc && v > 0i); }', "true");
-        runMainCode('public function main(): Bool { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Bool>(true, fn(acc, k, v) => acc && v > 0i); }', "false");
-        runMainCode('public function main(): Bool { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Bool>(true, fn(acc, k, v) => acc && k > 0i); }', "true");
+        runMainCode('public function main(): Bool { return Map<Int, Int>{1i => 2i, 3i => 4i}.reduce<Bool>(fn(acc, k, v) => acc && v > 0i, true); }', "true");
+        runMainCode('public function main(): Bool { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Bool>(fn(acc, k, v) => acc && v > 0i, true); }', "false");
+        runMainCode('public function main(): Bool { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Bool>(fn(acc, k, v) => acc && k > 0i, true); }', "true");
     });
 
     it("should do simple int reduce", function () {
-        runMainCode('public function main(): Int { return Map<Int, Int>{}.reduce<Int>(0i, fn(acc, k, v) => acc + v); }', "0i");
-        runMainCode('public function main(): Int { return Map<Int, Int>{}.reduce<Int>(5i, fn(acc, k, v) => acc + v); }', "5i");
+        runMainCode('public function main(): Int { return Map<Int, Int>{}.reduce<Int>(fn(acc, k, v) => acc + v, 0i); }', "0i");
+        runMainCode('public function main(): Int { return Map<Int, Int>{}.reduce<Int>(fn(acc, k, v) => acc + v, 5i); }', "5i");
 
-        runMainCode('public function main(): Int { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Int>(0i, fn(acc, k, v) => acc + k); }', "4i");
-        runMainCode('public function main(): Int { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Int>(0i, fn(acc, k, v) => acc + v); }', "2i");
+        runMainCode('public function main(): Int { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Int>(fn(acc, k, v) => acc + k, 0i); }', "4i");
+        runMainCode('public function main(): Int { return Map<Int, Int>{1i => 2i, 3i => 0i}.reduce<Int>(fn(acc, k, v) => acc + v, 0i); }', "2i");
     });
 });


### PR DESCRIPTION
Move lambda params to first arg in stdlib methods.

Closes #351 
