### PR TITLE
Globals Scanning

### DIFF
--- a/src/backend/cpp/gc/src/runtime/memory/allocator.h
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.h
@@ -64,6 +64,7 @@ class GlobalDataStorage
 public:
     void** native_global_storage = nullptr;
     void** native_global_storage_end = nullptr;
+    bool needs_scanning = false;
 
     GlobalDataStorage() noexcept = default;
 
@@ -73,6 +74,8 @@ public:
     {
         this->native_global_storage = data;
         this->native_global_storage_end = (void**)((uint8_t*)data + numbytes);
+
+        this->needs_scanning = true;
     }
 };
 

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -340,16 +340,20 @@ static void checkPotentialPtr(void* addr, BSQMemoryTheadLocalInfo& tinfo) noexce
 
 static void walkStack(BSQMemoryTheadLocalInfo& tinfo) noexcept 
 {
-    // Process global data (TODO -- later have flag to disable this after it is fixed as immortal)
-    if(GlobalDataStorage::g_global_data.native_global_storage != nullptr) {
+    if(GlobalDataStorage::g_global_data.needs_scanning) {
         void** curr = GlobalDataStorage::g_global_data.native_global_storage;
         while(curr < GlobalDataStorage::g_global_data.native_global_storage_end) {
             checkPotentialPtr(*curr, tinfo);
             curr++;
         }
+        GlobalDataStorage::g_global_data.needs_scanning = false;
     }
 
 #ifdef BSQ_GC_CHECK_ENABLED
+    if(tinfo.enable_global_rescan) {
+        GlobalDataStorage::g_global_data.needs_scanning = true;
+    }
+
     if(tinfo.disable_stack_refs_for_tests) {
         return;
     }

--- a/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
+++ b/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
@@ -114,6 +114,7 @@ struct BSQMemoryTheadLocalInfo
 
 #ifdef BSQ_GC_CHECK_ENABLED
     bool disable_stack_refs_for_tests = false;
+    bool enable_global_rescan         = false;
 #endif
 
     BSQMemoryTheadLocalInfo() noexcept : tl_id(0), g_gcallocs(nullptr), native_stack_base(nullptr), native_stack_contents(), native_register_contents(), roots_count(0), roots(nullptr), old_roots_count(0), old_roots(nullptr), forward_table_index(FWD_TABLE_START), forward_table(nullptr), typeptr_high32(0), pending_roots(), visit_stack(), pending_young(), pending_decs(), max_decrement_count(BSQ_INITIAL_MAX_DECREMENT_COUNT), mstats() { }

--- a/test/gc/tree/tree_basic.test.js
+++ b/test/gc/tree/tree_basic.test.js
@@ -4,7 +4,7 @@ import { runMainCodeGC } from "../../../bin/test/gc/gc_nf.js"
 import { describe, it } from "node:test";
 
 // set up global array, disable stack refs
-const base = "__CoreCpp::Bool main() { GlobalDataStorage::g_global_data.initialize(sizeof(garray), (void**)garray); gtl_info.disable_stack_refs_for_tests = true;\n";
+const base = "__CoreCpp::Bool main() { GlobalDataStorage::g_global_data.initialize(sizeof(garray), (void**)garray); gtl_info.disable_stack_refs_for_tests = true; gtl_info.enable_global_rescan = true;\n";
 const end = "\nreturn true;}"
 
 const test_1 = base.concat("basicTreeTest_1();", end);

--- a/test/gc/tree/tree_wide.test.js
+++ b/test/gc/tree/tree_wide.test.js
@@ -4,7 +4,7 @@ import { runMainCodeGC } from "../../../bin/test/gc/gc_nf.js"
 import { describe, it } from "node:test";
 
 // set up global array, disable stack refs
-const base = "__CoreCpp::Bool main() { GlobalDataStorage::g_global_data.initialize(sizeof(garray), (void**)garray); gtl_info.disable_stack_refs_for_tests = true;\n";
+const base = "__CoreCpp::Bool main() { GlobalDataStorage::g_global_data.initialize(sizeof(garray), (void**)garray); gtl_info.disable_stack_refs_for_tests = true; gtl_info.enable_global_rescan = true;\n";
 const end = "\nreturn true;}"
 
 const test_1 = base.concat("wideTreeTest_1();", end);


### PR DESCRIPTION
Prevents globals from being rescanned after initialization as they are immortal now.