### PR TITLE
Fix Evacuator Starve and Forward Table

### DIFF
--- a/src/backend/cpp/gc/src/runtime/common.h
+++ b/src/backend/cpp/gc/src/runtime/common.h
@@ -213,10 +213,6 @@ static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #define GC_CLEAR_YOUNG_MARK(META)  { GC_IS_YOUNG(META) = false; }
 #define GC_CLEAR_MARKED_MARK(META) { GC_IS_MARKED(META) = false; }
 
-#define GC_SHOULD_FREE_LIST_ADD(META) \
-	(!GC_IS_ALLOCATED(META) \
-		|| (GC_IS_YOUNG(META) && GC_FWD_INDEX(META) == NON_FORWARDED))
-
 #define GC_CHECK_BOOL_BYTES(META) \
 do { \
     int8_t isalloc_byte  = *reinterpret_cast<int8_t*>(&(META)->isalloc); \
@@ -263,13 +259,13 @@ do { \
 #define GC_CLEAR_YOUNG_MARK(META)  { GC_IS_YOUNG(META) = 0; }
 #define GC_CLEAR_MARKED_MARK(META) { GC_IS_MARKED(META) = 0; }
 
-#define GC_SHOULD_FREE_LIST_ADD(META) \
-	(!GC_IS_ALLOCATED(META) \
-		|| (GC_IS_YOUNG(META) && GC_FWD_INDEX(META) == NON_FORWARDED))
-
 #define GC_CHECK_BOOL_BYTES(META)
 
 #endif // VERBOSE_HEADER
+
+#define GC_SHOULD_FREE_LIST_ADD(META) \
+	(!GC_IS_ALLOCATED(META) \
+		|| (GC_IS_YOUNG(META) && GC_FWD_INDEX(META) == NON_FORWARDED && !GC_IS_ROOT(META)))
 
 #define METADATA_DUMP(META) \
 	std::cout << "Meta Data at " << META << ":" << std::endl \

--- a/src/backend/cpp/gc/src/runtime/common.h
+++ b/src/backend/cpp/gc/src/runtime/common.h
@@ -64,14 +64,6 @@
 #define PAGE_MASK ((1ul << BITS_IN_ADDR_FOR_PAGE) - 1ul)
 #define PAGE_ADDR_MASK (~PAGE_MASK)
 
-//
-//worst possible case where every entry has to be inserted into fwd table:
-//BSQ_BLOCK_ALLOCATION_SIZE / 8 = 512 (assumes every entry is exactly 8 bytes with no padding);
-//then BSQ_COLLECTION_THRESHOLD * (BSQ_BLOCK_ALLOCATION_SIZE / 8 ) = 524288, thus max possible
-//entries before triggering a collection 
-//
-#define BSQ_MAX_FWD_TABLE_ENTRIES 524288ul
-
 #define BSQ_MAX_ROOTS 2048ul
 #define BSQ_MAX_ALLOC_SLOTS 1024ul
 

--- a/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/allocator.cpp
@@ -269,8 +269,10 @@ PageInfo* GCAllocator::getFreshPageForAllocator() noexcept
 
 PageInfo* GCAllocator::getFreshPageForEvacuation() noexcept
 {
-
-	PageInfo* page = this->tryGetPendingRebuildPage(HIGH_UTIL_THRESH);
+	PageInfo* page = this->tryGetPendingGCPage(LOW_UTIL_THRESH);
+   	if(page == nullptr) {
+		page = this->tryGetPendingRebuildPage(LOW_UTIL_THRESH);
+    }
    	if(page == nullptr) { 
 		page = this->getLowestHighUtilPage();
 	}	

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -457,24 +457,6 @@ static void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
     MetaData* m = GC_GET_META_DATA_ADDR(*slots);
     GC_CHECK_BOOL_BYTES(m);
 
-	// If we are seeing a young->old pointer we need to either:
-	// - Simply increment the pointed to objects RC
-	// - Look into the forward table (pointed to old memory location) and 
-	//   increment the appropriate RC
-	if(!GC_IS_YOUNG(m)) {
-		INC_REF_COUNT(m);
-		return ;
-	}
-
-	int32_t fwdidx = GC_FWD_INDEX(m);
-	if(fwdidx > NON_FORWARDED) {
-		void* nobj = gtl_info.forward_table.query(fwdidx);	
-		MetaData* nm = GC_GET_META_DATA_ADDR(nobj);
-		INC_REF_COUNT(nm);
-
-		return ;
-	}
-
 	if(GC_SHOULD_VISIT(m)) { 
 		GC_MARK_AS_MARKED(m);
 		tinfo.visit_stack.push_back({*slots, MARK_STACK_NODE_COLOR_GREY});

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -457,15 +457,6 @@ static void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
     MetaData* m = GC_GET_META_DATA_ADDR(*slots);
     GC_CHECK_BOOL_BYTES(m);
 
-	// TODO: This gets triggered!!!!
-	// -- seems we allocate an object pointing to the old location of one 
-	//    already forwarded (and this location was placed on freelist in a 
-	//    prev collection too)
-    if(!GC_IS_ALLOCATED(m) && !GC_IS_YOUNG(m) && GC_REF_COUNT(m) == 0) {
-        METADATA_DUMP(m);
-        assert(false);
-    }
-
 	// If we are seeing a young->old pointer we need to either:
 	// - Simply increment the pointed to objects RC
 	// - Look into the forward table (pointed to old memory location) and 

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -457,6 +457,11 @@ static void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
     MetaData* m = GC_GET_META_DATA_ADDR(*slots);
     GC_CHECK_BOOL_BYTES(m);
 
+	if(!GC_IS_YOUNG(m)) {
+		INC_REF_COUNT(m);
+		return ;
+	}
+
 	// If we are seeing a young->old pointer just update rc of whatever pointer
 	// is in forward table, as it has already been processed in a prev collection
 	int32_t fwdidx = GC_FWD_INDEX(m);

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -242,8 +242,8 @@ static inline void updateRef(void** obj, BSQMemoryTheadLocalInfo& tinfo)
         return ;
     }
 
-    int32_t fwd_index = GC_FWD_INDEX(m);
-    if(fwd_index == NON_FORWARDED ) {
+    uint32_t fwd_index = GC_FWD_INDEX(m);
+    if(fwd_index == NON_FORWARDED) {
         *obj = forward(ptr, tinfo); 
     }
     else {

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -223,8 +223,8 @@ static void* forward(void* ptr, BSQMemoryTheadLocalInfo& tinfo) noexcept
 	xmem_copy(ptr, nptr, p->typeinfo->slot_size);
 
     // Insert into forward table and update object ensuring future objects update
-    RESET_METADATA_FOR_OBJECT(m, tinfo.forward_table_index);
-    tinfo.forward_table[tinfo.forward_table_index++] = nptr;
+    int32_t fwdidx = tinfo.forward_table.insert(nptr);
+    RESET_METADATA_FOR_OBJECT(m, fwdidx);
 
     UPDATE_TOTAL_PROMOTIONS(tinfo.memstats, +=, 1);
 
@@ -247,7 +247,7 @@ static inline void updateRef(void** obj, BSQMemoryTheadLocalInfo& tinfo)
         *obj = forward(ptr, tinfo); 
     }
     else {
-        *obj = tinfo.forward_table[fwd_index]; 
+        *obj = tinfo.forward_table.query(fwd_index); 
     }
 
 	MetaData* nm = GC_GET_META_DATA_ADDR(*obj);	
@@ -312,8 +312,7 @@ static void processMarkedYoungObjects(BSQMemoryTheadLocalInfo& tinfo) noexcept
         int32_t fwdidx = GC_FWD_INDEX(m);
 		void* nobj = obj;
         if(fwdidx > NON_FORWARDED) {
-            GC_INVARIANT_CHECK(fwdidx < gtl_info.forward_table_index);
-            nobj = gtl_info.forward_table[fwdidx];
+            nobj = gtl_info.forward_table.query(fwdidx);
         }
 		
 		MetaData* nm = GC_GET_META_DATA_ADDR(nobj);
@@ -457,7 +456,18 @@ static void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
 {
     MetaData* m = GC_GET_META_DATA_ADDR(*slots);
     GC_CHECK_BOOL_BYTES(m);
-    
+
+	// If we are seeing a young->old pointer just update rc of whatever pointer
+	// is in forward table, as it has already been processed in a prev collection
+	int32_t fwdidx = GC_FWD_INDEX(m);
+	if(fwdidx > NON_FORWARDED) {
+		void* nobj = gtl_info.forward_table.query(fwdidx);	
+		MetaData* nm = GC_GET_META_DATA_ADDR(nobj);
+		INC_REF_COUNT(nm);
+
+		return ;
+	}
+
 	if(GC_SHOULD_VISIT(m)) { 
 		GC_MARK_AS_MARKED(m);
 		tinfo.visit_stack.push_back({*slots, MARK_STACK_NODE_COLOR_GREY});
@@ -606,10 +616,6 @@ void collect() noexcept
 	MEM_STATS_END(Nursery, gtl_info.memstats);
 
     gtl_info.pending_young.clear();
-
-    xmem_zerofill(gtl_info.forward_table, gtl_info.forward_table_index);
-    gtl_info.forward_table_index = FWD_TABLE_START;
-
     gtl_info.decs_batch.initialize();
 
 	// Find dead roots, walk object graph from dead roots updating necessary rcs

--- a/src/backend/cpp/gc/src/runtime/memory/gc.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/gc.cpp
@@ -457,13 +457,24 @@ static void markRef(BSQMemoryTheadLocalInfo& tinfo, void** slots) noexcept
     MetaData* m = GC_GET_META_DATA_ADDR(*slots);
     GC_CHECK_BOOL_BYTES(m);
 
+	// TODO: This gets triggered!!!!
+	// -- seems we allocate an object pointing to the old location of one 
+	//    already forwarded (and this location was placed on freelist in a 
+	//    prev collection too)
+    if(!GC_IS_ALLOCATED(m) && !GC_IS_YOUNG(m) && GC_REF_COUNT(m) == 0) {
+        METADATA_DUMP(m);
+        assert(false);
+    }
+
+	// If we are seeing a young->old pointer we need to either:
+	// - Simply increment the pointed to objects RC
+	// - Look into the forward table (pointed to old memory location) and 
+	//   increment the appropriate RC
 	if(!GC_IS_YOUNG(m)) {
 		INC_REF_COUNT(m);
 		return ;
 	}
 
-	// If we are seeing a young->old pointer just update rc of whatever pointer
-	// is in forward table, as it has already been processed in a prev collection
 	int32_t fwdidx = GC_FWD_INDEX(m);
 	if(fwdidx > NON_FORWARDED) {
 		void* nobj = gtl_info.forward_table.query(fwdidx);	

--- a/src/backend/cpp/gc/src/runtime/memory/threadinfo.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/threadinfo.cpp
@@ -23,9 +23,6 @@ do { \
     native_register_contents.R = NULL;                                        \
     if(PTR_IN_RANGE(R) && PTR_NOT_IN_STACK(BASE, CURR, R)) { native_register_contents.R = R; }
 
-#define MARK_STACK_NODE_COLOR_GREY 0
-#define MARK_STACK_NODE_COLOR_BLACK 1
-
 void BSQMemoryTheadLocalInfo::initialize(size_t ntl_id, void** caller_rbp, 
 	void (*_collectfp)()) noexcept
 {

--- a/src/backend/cpp/gc/src/runtime/memory/threadinfo.cpp
+++ b/src/backend/cpp/gc/src/runtime/memory/threadinfo.cpp
@@ -2,7 +2,6 @@
 
 thread_local void* roots_array[BSQ_MAX_ROOTS];
 thread_local void* old_roots_array[BSQ_MAX_ROOTS];
-thread_local void* forward_table_array[BSQ_MAX_FWD_TABLE_ENTRIES];
 
 thread_local GCAllocator* g_gcallocs_array[BSQ_MAX_ALLOC_SLOTS];
 
@@ -24,6 +23,9 @@ do { \
     native_register_contents.R = NULL;                                        \
     if(PTR_IN_RANGE(R) && PTR_NOT_IN_STACK(BASE, CURR, R)) { native_register_contents.R = R; }
 
+#define MARK_STACK_NODE_COLOR_GREY 0
+#define MARK_STACK_NODE_COLOR_BLACK 1
+
 void BSQMemoryTheadLocalInfo::initialize(size_t ntl_id, void** caller_rbp, 
 	void (*_collectfp)()) noexcept
 {
@@ -42,10 +44,6 @@ void BSQMemoryTheadLocalInfo::initialize(size_t ntl_id, void** caller_rbp,
     this->old_roots = old_roots_array;
     this->old_roots_count = 0;
     xmem_zerofill(this->old_roots, BSQ_MAX_ROOTS);
-
-    this->forward_table = forward_table_array;
-    this->forward_table_index = FWD_TABLE_START;
-    xmem_zerofill(this->forward_table, BSQ_MAX_FWD_TABLE_ENTRIES);
 
     this->g_gcallocs = g_gcallocs_array;
     xmem_zerofill(this->g_gcallocs, BSQ_MAX_ALLOC_SLOTS);

--- a/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
+++ b/src/backend/cpp/gc/src/runtime/memory/threadinfo.h
@@ -3,14 +3,8 @@
 #include "../common.h"
 #include "allocator.h"
 
-#include <chrono>
-
-#define MAX_ALLOC_LOOKUP_TABLE_SIZE 1024
-
 #define MARK_STACK_NODE_COLOR_GREY 0
 #define MARK_STACK_NODE_COLOR_BLACK 1
-
-#define FWD_TABLE_START 1
 
 struct MarkStackEntry
 {
@@ -40,6 +34,45 @@ struct RegisterContents
     void* r15 = nullptr;
 };
 
+class ForwardTable {
+	// TODO: This is arbitrary for now --- need to find upper bound
+	static constexpr size_t MAX_ENTRIES = 1 << 18;
+
+	void* table[ForwardTable::MAX_ENTRIES];
+	int32_t positions[ForwardTable::MAX_ENTRIES];
+	int32_t index;
+
+public:
+	ForwardTable() noexcept : table(), positions(), index(0) 
+	{
+		for(size_t i = 0; i < ForwardTable::MAX_ENTRIES; i++) {
+			this->positions[i] = i;	
+		}
+	}
+
+	int32_t insert(void* addr) noexcept
+	{
+		int32_t idx = this->positions[this->index++];
+		assert(static_cast<size_t>(idx) < ForwardTable::MAX_ENTRIES);		
+		
+		this->table[idx] = addr;
+
+		return idx;
+	}
+
+	void remove(int32_t idx) noexcept
+	{
+		this->positions[--this->index] = idx;
+		assert(this->index >= 0);
+	}
+
+	void* query(int32_t idx) const noexcept
+	{
+		assert(static_cast<size_t>(idx) < ForwardTable::MAX_ENTRIES);
+		return this->table[idx];	
+	}
+};
+
 //All of the data that a thread local allocator needs to run it's operations
 struct BSQMemoryTheadLocalInfo
 {
@@ -62,8 +95,7 @@ struct BSQMemoryTheadLocalInfo
     int32_t old_roots_count;
     void** old_roots;
 
-    int32_t forward_table_index;
-    void** forward_table;
+	ForwardTable forward_table;
 
     ArrayList<void*> decs_batch; // Decrements able to be done without needing decs thread	
     PageList decd_pages; // pages with newly decd (and now dead) objects
@@ -95,7 +127,7 @@ struct BSQMemoryTheadLocalInfo
     BSQMemoryTheadLocalInfo() noexcept : 
         tl_id(0), g_gcallocs(nullptr), collectfp(nullptr), native_stack_base(nullptr), native_stack_contents(), 
         native_register_contents(), roots_count(0), roots(nullptr), old_roots_count(0), 
-        old_roots(nullptr), forward_table_index(FWD_TABLE_START), forward_table(nullptr), 
+        old_roots(nullptr), forward_table(), 
         decs_batch(), decd_pages(), nursery_usage(0.0f), pending_roots(), visit_stack(), 
 		pending_young(), max_decrement_count(BSQ_INITIAL_MAX_DECREMENT_COUNT), 
 		disable_automatic_collections(false) {}
@@ -103,7 +135,7 @@ struct BSQMemoryTheadLocalInfo
     BSQMemoryTheadLocalInfo() noexcept : 
         tl_id(0), g_gcallocs(nullptr), collectfp(nullptr), native_stack_base(nullptr), native_stack_contents(), 
         native_register_contents(), roots_count(0), roots(nullptr), old_roots_count(0), 
-        old_roots(nullptr), forward_table_index(FWD_TABLE_START), forward_table(nullptr), 
+        old_roots(nullptr), forward_table(), 
         decs_batch(), decd_pages(), nursery_usage(0.0f), pending_roots(), visit_stack(), 
 		pending_young(), max_decrement_count(BSQ_INITIAL_MAX_DECREMENT_COUNT), 
 		disable_automatic_collections(false), memstats() {}


### PR DESCRIPTION
- Evacuator can now get a page on the `pendinggc_pages` list when necessary to prevent starvation
- Forward table is now a ring buffer to prevent data being lost between collections. I feel like there should be a better way to handle this, but the ring buffer works for now

With these changes I was able to get db and raytracer running with a 256Kb nursery, although there still seems to be bugs hanging around when running a program like btrees with a super small nursery (I was not able to diagnose whats going on and figured it is not worth the effort right now).

When running db with a 256Kb nursery (using default 8Kb page):
```
Performance:
    Measurement        Mean          σ         Min         Max        50%         95%          99%
     Collection   44.8355us   4.00855us    14.958us   188.532us        46us        50us        52us
        Nursery   36.3382us   3.57391us     1.272us   178.012us        38us        40us        42us
         RC Old   7.96354us   1.17809us     0.361us    30.557us         8us        10us        10us
Statistics:
	Time Collecting   49.6375%
	Total Collections 66.047K
	Total Pages       152 
	Max Live Heap     40.576KB
	Heap Size         1.24518MB
	Alloc Count       325.374M
	Alloc'd Memory    15.8414GB
	Survival Rate     9.4953%
```
```
real	0m5.961s
user	0m5.992s
sys	    0m0.093s
```

And when running raytracer with a 256Kb nursery (using default 8Kb page):
```
Performance:
    Measurement        Mean          σ         Min         Max        50%         95%          99%
     Collection   13.1496us   1.10086us     6.341us    84.977us        14us        14us        16us
        Nursery   12.4498us  0.886741us     3.036us    33.642us        12us        14us        14us
         RC Old   0.38684us  0.133929us      0.04us     2.495us         0us         0us         0us
Statistics:
	Time Collecting   8.08974%
	Total Collections 17.645K
	Total Pages       139 
	Max Live Heap     448B
	Heap Size         1.13869MB
	Alloc Count       109.633M
	Alloc'd Memory    4.58301GB
	Survival Rate     0.330341%
```
```
real	0m2.862s
user	0m2.863s
sys	    0m0.035s
```