### PR TITLE
numeric range parser

### DIFF
--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -6460,6 +6460,28 @@ class Parser {
         }
     }
 
+    private isLiteralNumericToken(kind?: string): boolean {
+        const tk = kind ?? this.peekTokenKind();
+        return tk === TokenStrings.Nat || tk === TokenStrings.Int
+            || tk === TokenStrings.ChkNat || tk === TokenStrings.ChkInt
+            || tk === TokenStrings.Float || tk === TokenStrings.Decimal
+            || tk === TokenStrings.Rational || tk === TokenStrings.DecimalDegree
+            || tk === TokenStrings.Complex || tk === TokenStrings.NumberinoInt
+            || tk === TokenStrings.NumberinoFloat || tk === TokenStrings.NumberinoRational;
+    }
+
+    private expectedRangeLiteralToken(typeName: string): string | undefined {
+        switch(typeName) {
+            case "Int": return TokenStrings.Int;
+            case "Nat": return TokenStrings.Nat;
+            case "Float": return TokenStrings.Float;
+            case "Decimal": return TokenStrings.Decimal;
+            case "Rational": return TokenStrings.Rational;
+            case "String": return TokenStrings.Nat;
+            default: return undefined;
+        }
+    }
+
     private parseTypeDecl(attributes: DeclarationAttibute[]) {
         const sinfo = this.peekToken().getSourceInfo();
 
@@ -6483,11 +6505,11 @@ class Parser {
 
             this.scanToKWOptsInDeclaration(SYM_lbrace, SYM_semicolon);
             if(!this.testAndConsumeTokenIf(SYM_semicolon)) {
-                if(this.peekTokenKind(1) === TokenStrings.Nat || this.peekTokenKind(1) === SYM_coma) {
+                if(this.isLiteralNumericToken(this.peekTokenKind(1)) || this.peekTokenKind(1) === SYM_coma) {
                     this.consumeToken();
-                    this.ensureAndConsumeTokenIf(TokenStrings.Nat, "type declaration size min");
+                    if(this.isLiteralNumericToken()) { this.consumeToken(); }
                     this.ensureAndConsumeTokenAlways(SYM_coma, "type declaration size range");
-                    this.ensureAndConsumeTokenIf(TokenStrings.Nat, "type declaration size max");
+                    if(this.isLiteralNumericToken()) { this.consumeToken(); }
                     this.ensureAndConsumeTokenAlways(SYM_rbrace, "type declaration size range");
                 }
 
@@ -6501,15 +6523,23 @@ class Parser {
             const ttype = this.parseTypedeclRHSSignature();
             (tdecl as TypedeclTypeDecl).valuetype = ttype;
 
-            if(this.testAndConsumeTokenIf(SYM_lbrace)) {;
+            if(this.testAndConsumeTokenIf(SYM_lbrace)) {
                 let min: string | undefined = undefined;
                 let max: string | undefined = undefined;
 
-                if(this.testToken(TokenStrings.Nat)) {
+                const expectedToken = (ttype instanceof NominalTypeSignature) ? this.expectedRangeLiteralToken(ttype.decl.name) : undefined;
+
+                if(this.isLiteralNumericToken()) {
+                    if(expectedToken !== undefined && this.peekTokenKind() !== expectedToken) {
+                        this.recordErrorGeneral(this.peekToken().getSourceInfo(), `Range bound literal must match type ${(ttype as NominalTypeSignature).decl.name}`);
+                    }
                     min = this.consumeTokenAndGetValue();
                 }
                 this.ensureAndConsumeTokenAlways(SYM_coma, "type declaration size range");
-                if(this.testToken(TokenStrings.Nat)) {
+                if(this.isLiteralNumericToken()) {
+                    if(expectedToken !== undefined && this.peekTokenKind() !== expectedToken) {
+                        this.recordErrorGeneral(this.peekToken().getSourceInfo(), `Range bound literal must match type ${(ttype as NominalTypeSignature).decl.name}`);
+                    }
                     max = this.consumeTokenAndGetValue();
                 }
 

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -6465,19 +6465,20 @@ class Parser {
         return tk === TokenStrings.Nat || tk === TokenStrings.Int
             || tk === TokenStrings.ChkNat || tk === TokenStrings.ChkInt
             || tk === TokenStrings.Float || tk === TokenStrings.Decimal
-            || tk === TokenStrings.Rational || tk === TokenStrings.DecimalDegree
-            || tk === TokenStrings.Complex || tk === TokenStrings.NumberinoInt
-            || tk === TokenStrings.NumberinoFloat || tk === TokenStrings.NumberinoRational;
+            || tk === TokenStrings.Rational;
     }
 
     private expectedRangeLiteralToken(typeName: string): string | undefined {
         switch(typeName) {
             case "Int": return TokenStrings.Int;
             case "Nat": return TokenStrings.Nat;
+            case "ChkInt": return TokenStrings.ChkInt;
+            case "ChkNat": return TokenStrings.ChkNat;
             case "Float": return TokenStrings.Float;
             case "Decimal": return TokenStrings.Decimal;
             case "Rational": return TokenStrings.Rational;
             case "String": return TokenStrings.Nat;
+            case "CString": return TokenStrings.Nat;
             default: return undefined;
         }
     }
@@ -6508,8 +6509,9 @@ class Parser {
                 if(this.isLiteralNumericToken(this.peekTokenKind(1)) || this.peekTokenKind(1) === SYM_coma) {
                     this.consumeToken();
                     if(this.isLiteralNumericToken()) { this.consumeToken(); }
-                    this.ensureAndConsumeTokenAlways(SYM_coma, "type declaration size range");
-                    if(this.isLiteralNumericToken()) { this.consumeToken(); }
+                    if(this.testAndConsumeTokenIf(SYM_coma)) {
+                        if(this.isLiteralNumericToken()) { this.consumeToken(); }
+                    }
                     this.ensureAndConsumeTokenAlways(SYM_rbrace, "type declaration size range");
                 }
 
@@ -6535,12 +6537,16 @@ class Parser {
                     }
                     min = this.consumeTokenAndGetValue();
                 }
-                this.ensureAndConsumeTokenAlways(SYM_coma, "type declaration size range");
-                if(this.isLiteralNumericToken()) {
-                    if(expectedToken !== undefined && this.peekTokenKind() !== expectedToken) {
-                        this.recordErrorGeneral(this.peekToken().getSourceInfo(), `Range bound literal must match type ${(ttype as NominalTypeSignature).decl.name}`);
+                if(this.testAndConsumeTokenIf(SYM_coma)) {
+                    if(this.isLiteralNumericToken()) {
+                        if(expectedToken !== undefined && this.peekTokenKind() !== expectedToken) {
+                            this.recordErrorGeneral(this.peekToken().getSourceInfo(), `Range bound literal must match type ${(ttype as NominalTypeSignature).decl.name}`);
+                        }
+                        max = this.consumeTokenAndGetValue();
                     }
-                    max = this.consumeTokenAndGetValue();
+                }
+                else {
+                    max = min;
                 }
 
                 this.ensureAndConsumeTokenAlways(SYM_rbrace, "type declaration size range");

--- a/test/parser/constructors/type_alias.test.js
+++ b/test/parser/constructors/type_alias.test.js
@@ -20,7 +20,7 @@ describe ("Parser -- Type Alias w/ Invariants Constructor", () => {
 
     it("should fail missing tokens", function () {
         parseTestFunctionInFile('type Foo = Int & { invariant $value > 3i }', 'Expected ";" but got "}" when parsing "invariant"');
-        parseTestFunctionInFile('type Foo = Int  { invariant $value > 3i; }', 'Expected "," but got "invariant" when parsing "type declaration size range"');
+        parseTestFunctionInFile('type Foo = Int  { invariant $value > 3i; }', 'Expected "}" but got "invariant" when parsing "type declaration size range"');
         parseTestFunctionInFile('type Foo = Int &  invariant $value > 3i; }', 'Expected "{" but got "invariant" when parsing "type members"');
     });
 });

--- a/test/parser/type_decls/type_alias_simple.test.js
+++ b/test/parser/type_decls/type_alias_simple.test.js
@@ -32,3 +32,81 @@ describe ("Parser -- type decl with consts", () => {
         parseTestFunctionInFileError('type Foo = Int & { field c: Int; } function main(): Nat { return 4n; }', "Cannot have a field member on this type"); 
     });
 });
+
+describe ("Parser -- type decl with Int range bounds", () => {
+    it("should parse Int with both bounds", function () {
+        parseTestFunctionInFile('type Bounded = Int{-10i, 10i}; [FUNC]', 'function main(): Bounded { return 5i<Bounded>; }');
+    });
+
+    it("should parse Int with min only", function () {
+        parseTestFunctionInFile('type Positive = Int{0i, }; [FUNC]', 'function main(): Positive { return 1i<Positive>; }');
+    });
+
+    it("should parse Int with max only", function () {
+        parseTestFunctionInFile('type Capped = Int{, 100i}; [FUNC]', 'function main(): Capped { return 50i<Capped>; }');
+    });
+
+    it("should parse Int with negative lower bound", function () {
+        parseTestFunctionInFile('type Fahrenheit = Int{-459i, }; [FUNC]', 'function main(): Fahrenheit { return 32i<Fahrenheit>; }');
+    });
+});
+
+describe ("Parser -- type decl with Nat range bounds", () => {
+    it("should parse Nat with both bounds", function () {
+        parseTestFunctionInFile('type Percentage = Nat{0n, 100n}; [FUNC]', 'function main(): Percentage { return 50n<Percentage>; }');
+    });
+
+    it("should parse Nat with min only", function () {
+        parseTestFunctionInFile('type AtLeastOne = Nat{1n, }; [FUNC]', 'function main(): AtLeastOne { return 5n<AtLeastOne>; }');
+    });
+});
+
+describe ("Parser -- type decl with Float range bounds", () => {
+    it("should parse Float with both bounds", function () {
+        parseTestFunctionInFile('type Probability = Float{0.0f, 1.0f}; [FUNC]', 'function main(): Probability { return 0.5f<Probability>; }');
+    });
+
+    it("should parse Float with negative lower bound", function () {
+        parseTestFunctionInFile('type NormFloat = Float{-1.0f, 1.0f}; [FUNC]', 'function main(): NormFloat { return 0.0f<NormFloat>; }');
+    });
+});
+
+describe ("Parser -- type decl with Decimal range bounds", () => {
+    it("should parse Decimal with both bounds", function () {
+        parseTestFunctionInFile('type SmallDec = Decimal{-1.0d, 1.0d}; [FUNC]', 'function main(): SmallDec { return 0.5d<SmallDec>; }');
+    });
+});
+
+describe ("Parser -- type decl numeric range with invariants", () => {
+    it("should parse Int range combined with invariant body", function () {
+        parseTestFunctionInFile('type EvenBounded = Int{0i, 100i} & { invariant $value == 0i; } [FUNC]', 'function main(): EvenBounded { return 0i<EvenBounded>; }');
+    });
+});
+
+describe ("Parser -- type decl range bound type mismatch errors", () => {
+    it("should reject Nat literals in Int range", function () {
+        parseTestFunctionInFileError('type Bad = Int{0n, 100n}; function main(): Int { return 0i; }', "Range bound literal must match type Int");
+    });
+
+    it("should reject Int literals in Nat range", function () {
+        parseTestFunctionInFileError('type Bad = Nat{0i, 100i}; function main(): Nat { return 0n; }', "Range bound literal must match type Nat");
+    });
+
+    it("should reject Nat literals in Float range", function () {
+        parseTestFunctionInFileError('type Bad = Float{0n, 100n}; function main(): Float { return 0.0f; }', "Range bound literal must match type Float");
+    });
+
+    it("should reject Int literals in Decimal range", function () {
+        parseTestFunctionInFileError('type Bad = Decimal{0i, 100i}; function main(): Decimal { return 0.0d; }', "Range bound literal must match type Decimal");
+    });
+});
+
+describe ("Parser -- type decl string range still works", () => {
+    it("should parse string size range with min only", function () {
+        parseTestFunctionInFile('type UserName = String{5n, }; [FUNC]', 'function main(): UserName { return "hello"<UserName>; }');
+    });
+
+    it("should parse string size range with both bounds", function () {
+        parseTestFunctionInFile('type ShortName = String{1n, 20n}; [FUNC]', 'function main(): ShortName { return "bob"<ShortName>; }');
+    });
+});

--- a/test/parser/type_decls/type_alias_simple.test.js
+++ b/test/parser/type_decls/type_alias_simple.test.js
@@ -110,3 +110,43 @@ describe ("Parser -- type decl string range still works", () => {
         parseTestFunctionInFile('type ShortName = String{1n, 20n}; [FUNC]', 'function main(): ShortName { return "bob"<ShortName>; }');
     });
 });
+
+describe ("Parser -- type decl single-value range (exact type)", () => {
+    it("should parse Int with single exact value", function () {
+        parseTestFunctionInFile('type ExactFive = Int{5i}; [FUNC]', 'function main(): ExactFive { return 5i<ExactFive>; }');
+    });
+
+    it("should parse Nat with single exact value", function () {
+        parseTestFunctionInFile('type ExactTen = Nat{10n}; [FUNC]', 'function main(): ExactTen { return 10n<ExactTen>; }');
+    });
+
+    it("should parse Float with single exact value", function () {
+        parseTestFunctionInFile('type ExactHalf = Float{0.5f}; [FUNC]', 'function main(): ExactHalf { return 0.5f<ExactHalf>; }');
+    });
+
+    it("should parse Decimal with single exact value", function () {
+        parseTestFunctionInFile('type ExactDec = Decimal{1.0d}; [FUNC]', 'function main(): ExactDec { return 1.0d<ExactDec>; }');
+    });
+
+    it("should reject wrong literal type in single-value range", function () {
+        parseTestFunctionInFileError('type Bad = Int{5n}; function main(): Int { return 0i; }', "Range bound literal must match type Int");
+    });
+});
+
+describe ("Parser -- type decl with ChkInt and ChkNat range bounds", () => {
+    it("should parse ChkInt with both bounds", function () {
+        parseTestFunctionInFile('type BoundedChk = ChkInt{-100I, 100I}; [FUNC]', 'function main(): BoundedChk { return 0I<BoundedChk>; }');
+    });
+
+    it("should parse ChkNat with both bounds", function () {
+        parseTestFunctionInFile('type SmallChkNat = ChkNat{0N, 1000N}; [FUNC]', 'function main(): SmallChkNat { return 500N<SmallChkNat>; }');
+    });
+
+    it("should parse ChkInt with single exact value", function () {
+        parseTestFunctionInFile('type ExactChk = ChkInt{42I}; [FUNC]', 'function main(): ExactChk { return 42I<ExactChk>; }');
+    });
+
+    it("should reject wrong literal type in ChkInt range", function () {
+        parseTestFunctionInFileError('type Bad = ChkInt{5i}; function main(): Int { return 0i; }', "Range bound literal must match type ChkInt");
+    });
+});


### PR DESCRIPTION
Added parser support for numeric types, now will be able to parse when numeric types have specified ranges.
Also added tests to check 1) does the range bounds on the numeric types get parsed and 2) are the types of the bounds added valid for that type (i.e. ranges for Ints are ONLY Ints and so on).