### PR TITLE
Postree Insertion Balancing and Bug Fix

### DIFF
--- a/build/runcpp/core/list_t.h
+++ b/build/runcpp/core/list_t.h
@@ -363,8 +363,7 @@ namespace ᐸRuntimeᐳ
                         return XList(this->ulist.data.inlinelist.insert(index, value));
                     }
                     else {
-                        auto leaf = ListTTreeContent<T, getPosTreeIDFrom(TYPE_ID_LIST_T)>::fromInlineList(this->ulist.data.inlinelist);
-                        return XList(leaf.insert(index, value));
+                        return XList(ListTTreeContent<T, getPosTreeIDFrom(TYPE_ID_LIST_T)>::fromInlineList(this->ulist.data.inlinelist).insert(index, value));
                     }
                 }
                 else {

--- a/build/runcpp/core/postree.h
+++ b/build/runcpp/core/postree.h
@@ -301,6 +301,24 @@ namespace ᐸRuntimeᐳ
             return mkwnodeRepr(s_nodeallocator->allocate(nl.node->count + nr.node->count, RColor::Black, nl, nr));
         }
 
+        // double red violation on the LR side (PosRBTreeNode{ ..., Red, ..., PosRBTreeNode{ x, Red, ... }})
+        static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_LL(const PosRBTreeRepr<T, K>& cur)
+        {
+            const PosRBTreeRepr<T, K>& l  = cur.node->left;
+            const PosRBTreeRepr<T, K>& lr = r.node->right;
+            if(!validateBlackNode(cur) || !validateRedNode(l) || !validateRedNode(lr)) {
+                return std::nullopt;
+            }
+
+            const PosRBTreeRepr<T, K>& ll  = l.node->left;
+            const PosRBTreeRepr<T, K>& lrl = lr.node->left;
+            const PosRBTreeRepr<T, K>& lrr = lr.node->right;
+            const PosRBTreeRepr<T, K>& r   = cur.node->right;
+            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(ll.node->count + lrl.node->count, RColor::Red, l, lrl);
+            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(lrr.node->count + r.node->count, RColor::Red, lrr, r);
+            return mkwnodeRepr(s_nodeallocator->allocate(nl.node->count + nr.node->count, RColor::Black, nl, nr));
+        }
+
         // double red violation on the RL side (PosRBTreeNode{ ..., Red, PosRBTreeNode{ x, Red, ... }, ... })
         static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_RL(const PosRBTreeRepr<T, K>& cur)
         {

--- a/build/runcpp/core/postree.h
+++ b/build/runcpp/core/postree.h
@@ -249,12 +249,15 @@ namespace ᐸRuntimeᐳ
             }
 
             return checkRBChildColorInvariant(t.data.node->left)
-                && checkRBChildColorInvariant(t.data.node->left);
+                && checkRBChildColorInvariant(t.data.node->right);
         }
 
         static bool checkRBInvariants(const PosRBTree<T, K, TreeID>& tree)
         {
-            return checkRBChildColorInvariant(tree.repr) && checkRBPathLengthInvariant(tree.repr) >= 0;
+            bool rb = checkRBChildColorInvariant(tree.repr);
+            bool height = checkRBPathLengthInvariant(tree.repr) >= 0;
+            return rb && height;
+            //return checkRBChildColorInvariant(tree.repr) && checkRBPathLengthInvariant(tree.repr) >= 0;
         }
 
         static bool validateRedNode(const PosRBTreeRepr<T, K>& cur)
@@ -296,9 +299,9 @@ namespace ᐸRuntimeᐳ
             const PosRBTreeRepr<T, K>& llr = ll.data.node->right;
             const PosRBTreeRepr<T, K>& lr  = l.data.node->right;
             const PosRBTreeRepr<T, K>& r   = cur.data.node->right;
-            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(s_nodeallocator->allocate(lll.data.node->count + llr.data.node->count, RColor::Red, lll, llr));
+            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(s_nodeallocator->allocate(lll.data.node->count + llr.data.node->count, RColor::Black, lll, llr));
             const PosRBTreeRepr<T, K> nr = mkwnodeRepr(s_nodeallocator->allocate(lr.data.node->count + r.data.node->count, RColor::Red, lr, r));
-            return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Black, nl, nr));
+            return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Red, nl, nr));
         }
 
         // double red violation on the LR side (PosRBTreeNode{ ..., Red, ..., PosRBTreeNode{ x, Red, ... }})
@@ -314,9 +317,9 @@ namespace ᐸRuntimeᐳ
             const PosRBTreeRepr<T, K>& lrl = lr.data.node->left;
             const PosRBTreeRepr<T, K>& lrr = lr.data.node->right;
             const PosRBTreeRepr<T, K>& r   = cur.data.node->right;
-            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(s_nodeallocator->allocate(ll.data.node->count + lrl.data.node->count, RColor::Red, l, lrl));
-            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(s_nodeallocator->allocate(lrr.data.node->count + r.data.node->count, RColor::Red, lrr, r));
-            return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Black, nl, nr));
+            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(s_nodeallocator->allocate(ll.data.node->count + lrl.data.node->count, RColor::Black, ll, lrl));
+            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(s_nodeallocator->allocate(lrr.data.node->count + r.data.node->count, RColor::Black, lrr, r));
+            return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Red, nl, nr));
         }
 
         // double red violation on the RL side (PosRBTreeNode{ ..., Red, PosRBTreeNode{ x, Red, ... }, ... })
@@ -332,9 +335,9 @@ namespace ᐸRuntimeᐳ
             const PosRBTreeRepr<T, K>& rll = rl.data.node->left;
             const PosRBTreeRepr<T, K>& rlr = rl.data.node->right;
             const PosRBTreeRepr<T, K>& rr  = r.data.node->right;
-            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(s_nodeallocator->allocate(l.data.node->count + rll.data.node->count, RColor::Red, l, rll));
-            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(s_nodeallocator->allocate(rlr.data.node->count + rr.data.node->count, RColor::Red, rlr, rr));
-            return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Black, nl, nr));
+            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(s_nodeallocator->allocate(l.data.node->count + rll.data.node->count, RColor::Black, l, rll));
+            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(s_nodeallocator->allocate(rlr.data.node->count + rr.data.node->count, RColor::Black, rlr, rr));
+            return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Red, nl, nr));
         }
 
         // double red violation on the RR side (PosRBTreeNode{ ..., Red, ..., PosRBTreeNode{ x, Red, ... } })
@@ -350,9 +353,9 @@ namespace ᐸRuntimeᐳ
             const PosRBTreeRepr<T, K>& rl  = r.data.node->left;
             const PosRBTreeRepr<T, K>& rrl = rr.data.node->left;
             const PosRBTreeRepr<T, K>& rrr = rr.data.node->right;
-            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(s_nodeallocator->allocate(l.data.node->count + rl.data.node->count, RColor::Red, l, rl));
-            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(s_nodeallocator->allocate(rrr.data.node->count + rrr.data.node->count, RColor::Red, rrl, rrr));
-            return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Black, nl, nr));
+            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(s_nodeallocator->allocate(l.data.node->count + rl.data.node->count, RColor::Black, l, rl));
+            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(s_nodeallocator->allocate(rrl.data.node->count + rrr.data.node->count, RColor::Black, rrl, rrr));
+            return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Red, nl, nr));
         }
 
         static PosRBTreeRepr<T, K> balance(const PosRBTreeRepr<T, K>& cur)
@@ -481,7 +484,8 @@ namespace ᐸRuntimeᐳ
         {
             PosRBTree<T, K, TreeID> res(inserthelper(index, value, this->repr));
             if(res.repr.typeinfo == s_nodetypeinfo) {
-                res.repr.data.node->color = RColor::Black;
+                PosRBTreeNode<T, K>* node = res.repr.data.node;
+                res = PosRBTree<T, K, TreeID>(balance(mkwnodeRepr(s_nodeallocator->allocate(node->count, RColor::Black, node->left, node->right))));
             }
 
             assert(checkRBInvariants(res));

--- a/build/runcpp/core/postree.h
+++ b/build/runcpp/core/postree.h
@@ -301,6 +301,24 @@ namespace ᐸRuntimeᐳ
             return mkwnodeRepr(s_nodeallocator->allocate(nl.node->count + nr.node->count, RColor::Black, nl, nr));
         }
 
+        // double red violation on the RR side (PosRBTreeNode{ ..., Red, ..., PosRBTreeNode{ x, Red, ... } })
+        static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_RL(const PosRBTreeRepr<T, K>& cur)
+        {
+            const PosRBTreeRepr<T, K>& r  = cur.node->right;
+            const PosRBTreeRepr<T, K>& rr = r.node->right;
+            if(!validateBlackNode(cur) || !validateRedNode(r) || !validateRedNode(rr)) {
+                return std::nullopt;
+            }
+
+            const PosRBTreeRepr<T, K>& l   = cur.node->left;
+            const PosRBTreeRepr<T, K>& rl  = r.node->left;
+            const PosRBTreeRepr<T, K>& rrl = rr.node->left;
+            const PosRBTreeRepr<T, K>& rrr = rr.node->right;
+            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(l.node->count + rl.node->count, RColor::Red, l, rl);
+            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(rrr.node->count + rrr.node->count, RColor::Red, rrl, rrr);
+            return mkwnodeRepr(s_nodeallocator->allocate(nl.node->count + nr.node->count, RColor::Black, nl, nr));
+        }
+
         static PosRBTreeRepr<T, K> balance(const PosRBTreeRepr<T, K>& cur)
         {
             PosRBTreeRepr<T, K> res;

--- a/build/runcpp/core/postree.h
+++ b/build/runcpp/core/postree.h
@@ -74,11 +74,11 @@ namespace ᐸRuntimeᐳ
             PosRBTreeLeaf nleaf;
             insert_index -= subset_index;
             std::copy(this->data.begin() + subset_index, 
-                this->data.begin() + subset_index + insert_index, 
-                nleaf.data.begin());
+                      this->data.begin() + subset_index + insert_index, 
+                      nleaf.data.begin());
             std::copy(this->data.begin() + subset_index + insert_index, 
-                this->data.begin() + subset_index + length, 
-                nleaf.data.begin() + insert_index + 1);
+                      this->data.begin() + subset_index + length, 
+                      nleaf.data.begin() + insert_index + 1);
             
             nleaf.data[insert_index] = value;
             nleaf.count = length + 1;

--- a/build/runcpp/core/postree.h
+++ b/build/runcpp/core/postree.h
@@ -206,18 +206,18 @@ namespace ᐸRuntimeᐳ
             return PosRBTree<T, K, TreeID>(mkwnodeRepr(node));
         }
 
-        static int64_t checkRBPathLengthInvariant(const PosRBTreeRepr<T, K>& t)
+        static int64_t checkRBPathLengthInvariant(const PosRBTreeRepr<T, K>& cur)
         {
-            if(t.typeinfo == s_leaftypeinfo) {
+            if(cur.typeinfo == s_leaftypeinfo) {
                 return 0;
             }
             
-            const int lc = checkRBPathLengthInvariant(t.data.node->right);
+            const int lc = checkRBPathLengthInvariant(cur.data.node->left);
             if(lc == -1) {
                 return -1;
             }
 
-            const int rc = checkRBPathLengthInvariant(t.data.node->right);
+            const int rc = checkRBPathLengthInvariant(cur.data.node->right);
             if(rc == -1) {
                 return -1;
             }
@@ -226,30 +226,30 @@ namespace ᐸRuntimeᐳ
                 return -1;
             }
 
-            return t.data.node->color == RColor::Black 
+            return cur.data.node->color == RColor::Black 
                 ? lc + 1
                 : lc;
         }
 
-        static bool checkRBChildColorInvariant(const PosRBTreeRepr<T, K>& t)
+        static bool checkRBChildColorInvariant(const PosRBTreeRepr<T, K>& cur)
         {
-            if(t.typeinfo != s_nodetypeinfo) {
+            if(cur.typeinfo != s_nodetypeinfo) {
                 return true;
             }
 
-            if(t.data.node->color == RColor::Red) {
-                const bool islred = t.data.node->left.typeinfo == s_nodetypeinfo 
-                    ? t.data.node->left.data.node->color == RColor::Red
+            if(cur.data.node->color == RColor::Red) {
+                const bool islred = cur.data.node->left.typeinfo == s_nodetypeinfo 
+                    ? cur.data.node->left.data.node->color == RColor::Red
                     : false;
-                const bool isrred = t.data.node->right.typeinfo == s_nodetypeinfo 
-                    ? t.data.node->right.data.node->color == RColor::Red
+                const bool isrred = cur.data.node->right.typeinfo == s_nodetypeinfo 
+                    ? cur.data.node->right.data.node->color == RColor::Red
                     : false;
 
                 return !(islred || isrred);
             }
 
-            return checkRBChildColorInvariant(t.data.node->left)
-                && checkRBChildColorInvariant(t.data.node->right);
+            return checkRBChildColorInvariant(cur.data.node->left)
+                && checkRBChildColorInvariant(cur.data.node->right);
         }
 
         static bool checkRBInvariants(const PosRBTree<T, K, TreeID>& tree)
@@ -259,7 +259,10 @@ namespace ᐸRuntimeᐳ
 
         static bool validateRedNode(const PosRBTreeRepr<T, K>& cur)
         {
-            if(cur.typeinfo != s_nodetypeinfo || cur.data.node->color != RColor::Red) {
+            if(cur.typeinfo != s_nodetypeinfo) {
+                return false;
+            }
+            if(cur.data.node->color != RColor::Red) {
                 return false;
             }
             
@@ -268,19 +271,30 @@ namespace ᐸRuntimeᐳ
 
         static bool validateBlackNode(const PosRBTreeRepr<T, K>& cur)
         {
-            if(cur.typeinfo != s_nodetypeinfo || cur.data.node->color != RColor::Black) {
+            if(cur.typeinfo != s_nodetypeinfo) {
+                return false;
+            }
+            if(cur.data.node->color != RColor::Black) {
                 return false;
             }
             
             return true;
         }
 
-        // double red violation on the LL side (tleft = Node{Red, _, Node{Red, _ a, b}, c})
+        // double red violation on the LL side (tleft = Node{_, Red, Node{_, Red, a, b}, c})
         static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_LL(const PosRBTreeRepr<T, K>& cur)
         {
+            if(!validateBlackNode(cur)) {
+                return std::nullopt;
+            }
+
             const PosRBTreeRepr<T, K>& l  = cur.data.node->left;
+            if(!validateRedNode(l)) {
+                return std::nullopt;
+            }
+
             const PosRBTreeRepr<T, K>& ll = l.data.node->left;
-            if(!validateBlackNode(cur) || !validateRedNode(l) || !validateRedNode(ll)) {
+            if(!validateRedNode(ll)) {
                 return std::nullopt;
             }
 
@@ -289,16 +303,24 @@ namespace ᐸRuntimeᐳ
             const PosRBTreeRepr<T, K>& lr  = l.data.node->right;
             const PosRBTreeRepr<T, K>& r   = cur.data.node->right;
             const PosRBTreeRepr<T, K> nl = mkwnodeRepr(s_nodeallocator->allocate(lll.data.node->count + llr.data.node->count, RColor::Black, lll, llr));
-            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(s_nodeallocator->allocate(lr.data.node->count + r.data.node->count, RColor::Red, lr, r));
+            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(s_nodeallocator->allocate(lr.data.node->count + r.data.node->count, RColor::Black, lr, r));
             return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Red, nl, nr));
         }
 
-        // double red violation on the LR side (tleft = Node{Red, _, a, Node{Red, _, b, c}})
+        // double red violation on the LR side (tleft = Node{_, Red, a, Node{_, Red, b, c}})
         static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_LR(const PosRBTreeRepr<T, K>& cur)
         {
+            if(!validateBlackNode(cur)) {
+                return std::nullopt;
+            }
+
             const PosRBTreeRepr<T, K>& l  = cur.data.node->left;
+            if(!validateRedNode(l)) {
+                return std::nullopt;
+            }
+
             const PosRBTreeRepr<T, K>& lr = l.data.node->right;
-            if(!validateBlackNode(cur) || !validateRedNode(l) || !validateRedNode(lr)) {
+            if(!validateRedNode(lr)) {
                 return std::nullopt;
             }
 
@@ -311,12 +333,20 @@ namespace ᐸRuntimeᐳ
             return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Red, nl, nr));
         }
 
-        // double red violation on the RL side (tright = Node{Red, _, Node{Red, _, b, c}, d})
+        // double red violation on the RL side (tright = Node{_, Red, Node{_, Red, b, c}, d})
         static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_RL(const PosRBTreeRepr<T, K>& cur)
         {
+            if(!validateBlackNode(cur)) {
+                return std::nullopt;
+            }
+
             const PosRBTreeRepr<T, K>& r  = cur.data.node->right;
+            if(!validateRedNode(r)) {
+                return std::nullopt;
+            }
+
             const PosRBTreeRepr<T, K>& rl = r.data.node->left;
-            if(!validateBlackNode(cur) || !validateRedNode(r) || !validateRedNode(rl)) {
+            if(!validateRedNode(rl)) {
                 return std::nullopt;
             }
 
@@ -332,9 +362,17 @@ namespace ᐸRuntimeᐳ
         // double red violation on the RR side (tright = Node{Red, _, b, Node{Red, _, c, d}})
         static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_RR(const PosRBTreeRepr<T, K>& cur)
         {
+            if(!validateBlackNode(cur)) {
+                return std::nullopt;
+            }
+
             const PosRBTreeRepr<T, K>& r  = cur.data.node->right;
+            if(!validateRedNode(r)) {
+                return std::nullopt;
+            }
+
             const PosRBTreeRepr<T, K>& rr = r.data.node->right;
-            if(!validateBlackNode(cur) || !validateRedNode(r) || !validateRedNode(rr)) {
+            if(!validateRedNode(rr)) {
                 return std::nullopt;
             }
 
@@ -465,17 +503,19 @@ namespace ᐸRuntimeᐳ
                     nr = inserthelper(index - lcount, value, cur.data.node->right); 
                 }
 
-                return balance(mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Red, nl, nr)));
+                return balance(mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, cur.data.node->color, nl, nr)));
             }
         }
 
         PosRBTree<T, K, TreeID> insert(int64_t index, const T& value) const
         {
             PosRBTree<T, K, TreeID> res(inserthelper(index, value, this->repr));
+        
             if(res.repr.typeinfo == s_nodetypeinfo) {  
                 res.repr.data.node->color = RColor::Black;
                 res = PosRBTree<T, K, TreeID>(balance(res.repr));
             }
+            
 
             assert(checkRBInvariants(res));
 

--- a/build/runcpp/core/postree.h
+++ b/build/runcpp/core/postree.h
@@ -262,7 +262,7 @@ namespace ᐸRuntimeᐳ
             if(cur.typeinfo != s_nodetypeinfo) {
                 return false;
             }
-            else if(cur.node->color != RColor::Red) {
+            else if(cur.data.node->color != RColor::Red) {
                 return false;
             }
             else {
@@ -275,7 +275,7 @@ namespace ᐸRuntimeᐳ
             if(cur.typeinfo != s_nodetypeinfo) {
                 return false;
             }
-            else if(cur.node->color != RColor::Black) {
+            else if(cur.data.node->color != RColor::Black) {
                 return false;
             }
             else {
@@ -286,80 +286,88 @@ namespace ᐸRuntimeᐳ
         // double red violation on the LL side (PosRBTreeNode{ ..., Red, PosRBTreeNode{ x, Red, ... }, ... })
         static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_LL(const PosRBTreeRepr<T, K>& cur)
         {
-            const PosRBTreeRepr<T, K>& l  = cur.node->right;
-            const PosRBTreeRepr<T, K>& ll = r.node->left;
-            if(!validateBlackNode(cur) || !validateRedNode(lr) || !validateRedNode(ll)) {
+            const PosRBTreeRepr<T, K>& l  = cur.data.node->left;
+            const PosRBTreeRepr<T, K>& ll = l.data.node->left;
+            if(!validateBlackNode(cur) || !validateRedNode(l) || !validateRedNode(ll)) {
                 return std::nullopt;
             }
 
-            const PosRBTreeRepr<T, K>& lll = ll.node->left;
-            const PosRBTreeRepr<T, K>& llr = ll.node->right;
-            const PosRBTreeRepr<T, K>& lr  = l.node->right;
-            const PosRBTreeRepr<T, K>& r   = cur.node->right;
-            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(lll.node->count + llr.node->count, RColor::Red, lll, llr);
-            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(lr.node->count + r.node->count, RColor::Red, lr, r);
-            return mkwnodeRepr(s_nodeallocator->allocate(nl.node->count + nr.node->count, RColor::Black, nl, nr));
+            const PosRBTreeRepr<T, K>& lll = ll.data.node->left;
+            const PosRBTreeRepr<T, K>& llr = ll.data.node->right;
+            const PosRBTreeRepr<T, K>& lr  = l.data.node->right;
+            const PosRBTreeRepr<T, K>& r   = cur.data.node->right;
+            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(s_nodeallocator->allocate(lll.data.node->count + llr.data.node->count, RColor::Red, lll, llr));
+            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(s_nodeallocator->allocate(lr.data.node->count + r.data.node->count, RColor::Red, lr, r));
+            return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Black, nl, nr));
         }
 
         // double red violation on the LR side (PosRBTreeNode{ ..., Red, ..., PosRBTreeNode{ x, Red, ... }})
-        static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_LL(const PosRBTreeRepr<T, K>& cur)
+        static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_LR(const PosRBTreeRepr<T, K>& cur)
         {
-            const PosRBTreeRepr<T, K>& l  = cur.node->left;
-            const PosRBTreeRepr<T, K>& lr = r.node->right;
+            const PosRBTreeRepr<T, K>& l  = cur.data.node->left;
+            const PosRBTreeRepr<T, K>& lr = l.data.node->right;
             if(!validateBlackNode(cur) || !validateRedNode(l) || !validateRedNode(lr)) {
                 return std::nullopt;
             }
 
-            const PosRBTreeRepr<T, K>& ll  = l.node->left;
-            const PosRBTreeRepr<T, K>& lrl = lr.node->left;
-            const PosRBTreeRepr<T, K>& lrr = lr.node->right;
-            const PosRBTreeRepr<T, K>& r   = cur.node->right;
-            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(ll.node->count + lrl.node->count, RColor::Red, l, lrl);
-            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(lrr.node->count + r.node->count, RColor::Red, lrr, r);
-            return mkwnodeRepr(s_nodeallocator->allocate(nl.node->count + nr.node->count, RColor::Black, nl, nr));
+            const PosRBTreeRepr<T, K>& ll  = l.data.node->left;
+            const PosRBTreeRepr<T, K>& lrl = lr.data.node->left;
+            const PosRBTreeRepr<T, K>& lrr = lr.data.node->right;
+            const PosRBTreeRepr<T, K>& r   = cur.data.node->right;
+            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(s_nodeallocator->allocate(ll.data.node->count + lrl.data.node->count, RColor::Red, l, lrl));
+            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(s_nodeallocator->allocate(lrr.data.node->count + r.data.node->count, RColor::Red, lrr, r));
+            return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Black, nl, nr));
         }
 
         // double red violation on the RL side (PosRBTreeNode{ ..., Red, PosRBTreeNode{ x, Red, ... }, ... })
         static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_RL(const PosRBTreeRepr<T, K>& cur)
         {
-            const PosRBTreeRepr<T, K>& r  = cur.node->right;
-            const PosRBTreeRepr<T, K>& rl = r.node->left;
+            const PosRBTreeRepr<T, K>& r  = cur.data.node->right;
+            const PosRBTreeRepr<T, K>& rl = r.data.node->left;
             if(!validateBlackNode(cur) || !validateRedNode(r) || !validateRedNode(rl)) {
                 return std::nullopt;
             }
 
-            const PosRBTreeRepr<T, K>& l   = cur.node->left;
-            const PosRBTreeRepr<T, K>& rll = rl.node->left;
-            const PosRBTreeRepr<T, K>& rlr = rl.node->right;
-            const PosRBTreeRepr<T, K>& rr  = r.node->right;
-            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(l.node->count + rll.node->count, RColor::Red, l, rll);
-            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(rlr.node->count + rr.node->count, RColor::Red, rlr, rr);
-            return mkwnodeRepr(s_nodeallocator->allocate(nl.node->count + nr.node->count, RColor::Black, nl, nr));
+            const PosRBTreeRepr<T, K>& l   = cur.data.node->left;
+            const PosRBTreeRepr<T, K>& rll = rl.data.node->left;
+            const PosRBTreeRepr<T, K>& rlr = rl.data.node->right;
+            const PosRBTreeRepr<T, K>& rr  = r.data.node->right;
+            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(s_nodeallocator->allocate(l.data.node->count + rll.data.node->count, RColor::Red, l, rll));
+            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(s_nodeallocator->allocate(rlr.data.node->count + rr.data.node->count, RColor::Red, rlr, rr));
+            return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Black, nl, nr));
         }
 
         // double red violation on the RR side (PosRBTreeNode{ ..., Red, ..., PosRBTreeNode{ x, Red, ... } })
-        static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_RL(const PosRBTreeRepr<T, K>& cur)
+        static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_RR(const PosRBTreeRepr<T, K>& cur)
         {
-            const PosRBTreeRepr<T, K>& r  = cur.node->right;
-            const PosRBTreeRepr<T, K>& rr = r.node->right;
+            const PosRBTreeRepr<T, K>& r  = cur.data.node->right;
+            const PosRBTreeRepr<T, K>& rr = r.data.node->right;
             if(!validateBlackNode(cur) || !validateRedNode(r) || !validateRedNode(rr)) {
                 return std::nullopt;
             }
 
-            const PosRBTreeRepr<T, K>& l   = cur.node->left;
-            const PosRBTreeRepr<T, K>& rl  = r.node->left;
-            const PosRBTreeRepr<T, K>& rrl = rr.node->left;
-            const PosRBTreeRepr<T, K>& rrr = rr.node->right;
-            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(l.node->count + rl.node->count, RColor::Red, l, rl);
-            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(rrr.node->count + rrr.node->count, RColor::Red, rrl, rrr);
-            return mkwnodeRepr(s_nodeallocator->allocate(nl.node->count + nr.node->count, RColor::Black, nl, nr));
+            const PosRBTreeRepr<T, K>& l   = cur.data.node->left;
+            const PosRBTreeRepr<T, K>& rl  = r.data.node->left;
+            const PosRBTreeRepr<T, K>& rrl = rr.data.node->left;
+            const PosRBTreeRepr<T, K>& rrr = rr.data.node->right;
+            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(s_nodeallocator->allocate(l.data.node->count + rl.data.node->count, RColor::Red, l, rl));
+            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(s_nodeallocator->allocate(rrr.data.node->count + rrr.data.node->count, RColor::Red, rrl, rrr));
+            return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Black, nl, nr));
         }
 
         static PosRBTreeRepr<T, K> balance(const PosRBTreeRepr<T, K>& cur)
         {
-            PosRBTreeRepr<T, K> res;
-            if(res = balancehelper_RR_RL(cur)) {
-                return res;
+            if(auto res = balancehelper_RR_LL(cur)) {
+                return *res;
+            }
+            else if(auto res = balancehelper_RR_LR(cur)) {
+                return *res;
+            }
+            else if(auto res = balancehelper_RR_RL(cur)) {
+                return *res;
+            }
+            else if(auto res = balancehelper_RR_RR(cur)) {
+                return *res;
             }
             else {
                 return cur;
@@ -454,7 +462,6 @@ namespace ᐸRuntimeᐳ
                 }
             }
             else {
-                // !!!!!! TODO: need balancing !!!!!!!
                 PosRBTreeRepr<T, K> nl, nr;
                 const int64_t lcount = cur.data.node->left.data.node->count;
                 if(index < lcount) {
@@ -466,7 +473,7 @@ namespace ᐸRuntimeᐳ
                     nr = inserthelper(index - lcount, value, cur.data.node->right); 
                 }
 
-                return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Red, nl, nr));
+                return balance(mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Red, nl, nr)));
             }
         }
 

--- a/build/runcpp/core/postree.h
+++ b/build/runcpp/core/postree.h
@@ -206,6 +206,57 @@ namespace ᐸRuntimeᐳ
             return PosRBTree<T, K, TreeID>(mkwnodeRepr(node));
         }
 
+        static int64_t checkRBPathLengthInvariant(const PosRBTreeRepr<T, K>& t)
+        {
+            if(t.typeinfo == s_leaftypeinfo) {
+                return 0;
+            }
+            
+            const int lc = checkRBPathLengthInvariant(t.data.node->right);
+            if(lc == -1) {
+                return -1;
+            }
+
+            const int rc = checkRBPathLengthInvariant(t.data.node->right);
+            if(rc == -1) {
+                return -1;
+            }
+
+            if(lc != rc) { // black height mismatch
+                return -1;
+            }
+
+            return t.data.node->color == RColor::Black 
+                ? lc + 1
+                : lc;
+        }
+
+        static bool checkRBChildColorInvariant(const PosRBTreeRepr<T, K>& t)
+        {
+            if(t.typeinfo != s_nodetypeinfo) {
+                return true;
+            }
+
+            if(t.data.node->color == RColor::Red) {
+                const bool islred = t.typeinfo == s_nodetypeinfo 
+                    ? t.data.node->left.data.node->color == RColor::Red
+                    : false;
+                const bool isrred = t.typeinfo == s_nodetypeinfo 
+                    ? t.data.node->right.data.node->color == RColor::Red
+                    : false;
+
+                return !(islred || isrred);
+            }
+
+            return checkRBChildColorInvariant(t.data.node->left)
+                && checkRBChildColorInvariant(t.data.node->left);
+        }
+
+        static bool checkRBInvariants(const PosRBTreeRepr<T, K>& t)
+        {
+            return checkRBChildColorInvariant(t) && checkRBPathLengthInvariant(t) >= 0;
+        }
+
         constexpr int64_t count() const
         {
             if(this->repr.typeinfo == nullptr) {
@@ -314,7 +365,7 @@ namespace ᐸRuntimeᐳ
         {
             PosRBTree<T, K, TreeID> res(inserthelper(index, value, this->repr));
 
-            // TODO: assert(checkRBInvariants(res));
+            assert(checkRBInvariants(res));
 
             return res;
         }

--- a/build/runcpp/core/postree.h
+++ b/build/runcpp/core/postree.h
@@ -254,39 +254,28 @@ namespace ᐸRuntimeᐳ
 
         static bool checkRBInvariants(const PosRBTree<T, K, TreeID>& tree)
         {
-            bool rb = checkRBChildColorInvariant(tree.repr);
-            bool height = checkRBPathLengthInvariant(tree.repr) >= 0;
-            return rb && height;
-            //return checkRBChildColorInvariant(tree.repr) && checkRBPathLengthInvariant(tree.repr) >= 0;
+            return checkRBChildColorInvariant(tree.repr) && checkRBPathLengthInvariant(tree.repr) >= 0;
         }
 
         static bool validateRedNode(const PosRBTreeRepr<T, K>& cur)
         {
-            if(cur.typeinfo != s_nodetypeinfo) {
+            if(cur.typeinfo != s_nodetypeinfo || cur.data.node->color != RColor::Red) {
                 return false;
             }
-            else if(cur.data.node->color != RColor::Red) {
-                return false;
-            }
-            else {
-                return true;
-            }
+            
+            return true; 
         }
 
         static bool validateBlackNode(const PosRBTreeRepr<T, K>& cur)
         {
-            if(cur.typeinfo != s_nodetypeinfo) {
+            if(cur.typeinfo != s_nodetypeinfo || cur.data.node->color != RColor::Black) {
                 return false;
             }
-            else if(cur.data.node->color != RColor::Black) {
-                return false;
-            }
-            else {
-                return true;
-            }
+            
+            return true;
         }
 
-        // double red violation on the LL side (PosRBTreeNode{ ..., Red, PosRBTreeNode{ x, Red, ... }, ... })
+        // double red violation on the LL side (tleft = Node{Red, _, Node{Red, _ a, b}, c})
         static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_LL(const PosRBTreeRepr<T, K>& cur)
         {
             const PosRBTreeRepr<T, K>& l  = cur.data.node->left;
@@ -304,7 +293,7 @@ namespace ᐸRuntimeᐳ
             return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Red, nl, nr));
         }
 
-        // double red violation on the LR side (PosRBTreeNode{ ..., Red, ..., PosRBTreeNode{ x, Red, ... }})
+        // double red violation on the LR side (tleft = Node{Red, _, a, Node{Red, _, b, c}})
         static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_LR(const PosRBTreeRepr<T, K>& cur)
         {
             const PosRBTreeRepr<T, K>& l  = cur.data.node->left;
@@ -322,7 +311,7 @@ namespace ᐸRuntimeᐳ
             return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Red, nl, nr));
         }
 
-        // double red violation on the RL side (PosRBTreeNode{ ..., Red, PosRBTreeNode{ x, Red, ... }, ... })
+        // double red violation on the RL side (tright = Node{Red, _, Node{Red, _, b, c}, d})
         static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_RL(const PosRBTreeRepr<T, K>& cur)
         {
             const PosRBTreeRepr<T, K>& r  = cur.data.node->right;
@@ -340,7 +329,7 @@ namespace ᐸRuntimeᐳ
             return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Red, nl, nr));
         }
 
-        // double red violation on the RR side (PosRBTreeNode{ ..., Red, ..., PosRBTreeNode{ x, Red, ... } })
+        // double red violation on the RR side (tright = Node{Red, _, b, Node{Red, _, c, d}})
         static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_RR(const PosRBTreeRepr<T, K>& cur)
         {
             const PosRBTreeRepr<T, K>& r  = cur.data.node->right;
@@ -483,9 +472,9 @@ namespace ᐸRuntimeᐳ
         PosRBTree<T, K, TreeID> insert(int64_t index, const T& value) const
         {
             PosRBTree<T, K, TreeID> res(inserthelper(index, value, this->repr));
-            if(res.repr.typeinfo == s_nodetypeinfo) {
-                PosRBTreeNode<T, K>* node = res.repr.data.node;
-                res = PosRBTree<T, K, TreeID>(balance(mkwnodeRepr(s_nodeallocator->allocate(node->count, RColor::Black, node->left, node->right))));
+            if(res.repr.typeinfo == s_nodetypeinfo) {  
+                res.repr.data.node->color = RColor::Black;
+                res = PosRBTree<T, K, TreeID>(balance(res.repr));
             }
 
             assert(checkRBInvariants(res));

--- a/build/runcpp/core/postree.h
+++ b/build/runcpp/core/postree.h
@@ -480,6 +480,9 @@ namespace ᐸRuntimeᐳ
         PosRBTree<T, K, TreeID> insert(int64_t index, const T& value) const
         {
             PosRBTree<T, K, TreeID> res(inserthelper(index, value, this->repr));
+            if(res.repr.typeinfo == s_nodetypeinfo) {
+                res.repr.data.node->color = RColor::Black;
+            }
 
             assert(checkRBInvariants(res));
 

--- a/build/runcpp/core/postree.h
+++ b/build/runcpp/core/postree.h
@@ -66,18 +66,20 @@ namespace ᐸRuntimeᐳ
 
         PosRBTreeLeaf subsetinsert(int64_t subset_index, int64_t insert_index, int64_t length, const T& value) const
         {
-            assert(insert_index < K);
-            assert(subset_index + length < K);
+            assert(insert_index <= K);
+            assert(subset_index + length <= K);
             assert(this->count <= K);
+            assert(insert_index >= subset_index);
 
             PosRBTreeLeaf nleaf;
+            insert_index -= subset_index;
             std::copy(this->data.begin() + subset_index, 
-                      this->data.begin() + subset_index + insert_index, 
-                      nleaf.data.begin());
+                this->data.begin() + subset_index + insert_index, 
+                nleaf.data.begin());
             std::copy(this->data.begin() + subset_index + insert_index, 
-                      this->data.begin() + subset_index + length, 
-                      nleaf.data.begin() + insert_index + 1);
-
+                this->data.begin() + subset_index + length, 
+                nleaf.data.begin() + insert_index + 1);
+            
             nleaf.data[insert_index] = value;
             nleaf.count = length + 1;
 
@@ -359,7 +361,7 @@ namespace ᐸRuntimeᐳ
             return mkwnodeRepr(s_nodeallocator->allocate(nl.data.node->count + nr.data.node->count, RColor::Red, nl, nr));
         }
 
-        // double red violation on the RR side (tright = Node{Red, _, b, Node{Red, _, c, d}})
+        // double red violation on the RR side (tright = Node{_, Red, b, Node{_, Red, c, d}})
         static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_RR(const PosRBTreeRepr<T, K>& cur)
         {
             if(!validateBlackNode(cur)) {
@@ -463,32 +465,20 @@ namespace ᐸRuntimeᐳ
                     return mkwleafRepr(s_leafallocator->allocate(cur.data.leaf->insert(index, value)));
                 }
                 else {
-                    PosRBTreeRepr<T, K> nl, nr;
-                    if(index == 0) {
-                        nl = mkwleafRepr(s_leafallocator->allocate(value));
-                        nr = cur;
-                    }
-                    else if(index >= K - 1) {
-                        nl = cur; 
-                        nr = mkwleafRepr(s_leafallocator->allocate(value));
+                    constexpr int64_t midpt = K / 2;
+                    PosRBTreeLeaf<T, K> nlleaf, nrleaf;
+                    if(index < midpt) {
+                        nlleaf = cur.data.leaf->subsetinsert(0, index, midpt, value);
+                        nrleaf = cur.data.leaf->subset(midpt, K - midpt);
                     }
                     else {
-                        PosRBTreeLeaf<T, K> nlleaf, nrleaf;
-                        const int64_t midpt = cur.data.leaf->count / 2;
-                        if(index < midpt) {
-                            nlleaf = cur.data.leaf->subsetinsert(0, index, midpt, value);
-                            nrleaf = cur.data.leaf->subset(midpt, K - midpt);
-                        }
-                        else {
-                            nlleaf = cur.data.leaf->subset(0, midpt);
-                            nrleaf = cur.data.leaf->subsetinsert(midpt, index, K - midpt, value);
-                        }
-
-                        nl = mkwleafRepr(s_leafallocator->allocate(nlleaf));
-                        nr = mkwleafRepr(s_leafallocator->allocate(nrleaf));
+                        nlleaf = cur.data.leaf->subset(0, midpt);
+                        nrleaf = cur.data.leaf->subsetinsert(midpt, index, K - midpt, value);
                     }
 
-                    return mkwnodeRepr(s_nodeallocator->allocate(cur_count + 1, RColor::Red, nl, nr)); 
+                    return mkwnodeRepr(s_nodeallocator->allocate(cur_count + 1, RColor::Red, 
+                        mkwleafRepr(s_leafallocator->allocate(nlleaf)), 
+                        mkwleafRepr(s_leafallocator->allocate(nrleaf)))); 
                 }
             }
             else {
@@ -509,8 +499,7 @@ namespace ᐸRuntimeᐳ
 
         PosRBTree<T, K, TreeID> insert(int64_t index, const T& value) const
         {
-            PosRBTree<T, K, TreeID> res(inserthelper(index, value, this->repr));
-        
+            PosRBTree<T, K, TreeID> res(inserthelper(index, value, this->repr)); 
             if(res.repr.typeinfo == s_nodetypeinfo) {  
                 res.repr.data.node->color = RColor::Black;
                 res = PosRBTree<T, K, TreeID>(balance(res.repr));

--- a/build/runcpp/core/postree.h
+++ b/build/runcpp/core/postree.h
@@ -283,6 +283,24 @@ namespace ᐸRuntimeᐳ
             }
         }
 
+        // double red violation on the LL side (PosRBTreeNode{ ..., Red, PosRBTreeNode{ x, Red, ... }, ... })
+        static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_LL(const PosRBTreeRepr<T, K>& cur)
+        {
+            const PosRBTreeRepr<T, K>& l  = cur.node->right;
+            const PosRBTreeRepr<T, K>& ll = r.node->left;
+            if(!validateBlackNode(cur) || !validateRedNode(lr) || !validateRedNode(ll)) {
+                return std::nullopt;
+            }
+
+            const PosRBTreeRepr<T, K>& lll = ll.node->left;
+            const PosRBTreeRepr<T, K>& llr = ll.node->right;
+            const PosRBTreeRepr<T, K>& lr  = l.node->right;
+            const PosRBTreeRepr<T, K>& r   = cur.node->right;
+            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(lll.node->count + llr.node->count, RColor::Red, lll, llr);
+            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(lr.node->count + r.node->count, RColor::Red, lr, r);
+            return mkwnodeRepr(s_nodeallocator->allocate(nl.node->count + nr.node->count, RColor::Black, nl, nr));
+        }
+
         // double red violation on the RL side (PosRBTreeNode{ ..., Red, PosRBTreeNode{ x, Red, ... }, ... })
         static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_RL(const PosRBTreeRepr<T, K>& cur)
         {

--- a/build/runcpp/core/postree.h
+++ b/build/runcpp/core/postree.h
@@ -238,10 +238,10 @@ namespace ᐸRuntimeᐳ
             }
 
             if(t.data.node->color == RColor::Red) {
-                const bool islred = t.typeinfo == s_nodetypeinfo 
+                const bool islred = t.data.node->left.typeinfo == s_nodetypeinfo 
                     ? t.data.node->left.data.node->color == RColor::Red
                     : false;
-                const bool isrred = t.typeinfo == s_nodetypeinfo 
+                const bool isrred = t.data.node->right.typeinfo == s_nodetypeinfo 
                     ? t.data.node->right.data.node->color == RColor::Red
                     : false;
 
@@ -252,9 +252,64 @@ namespace ᐸRuntimeᐳ
                 && checkRBChildColorInvariant(t.data.node->left);
         }
 
-        static bool checkRBInvariants(const PosRBTreeRepr<T, K>& t)
+        static bool checkRBInvariants(const PosRBTree<T, K, TreeID>& tree)
         {
-            return checkRBChildColorInvariant(t) && checkRBPathLengthInvariant(t) >= 0;
+            return checkRBChildColorInvariant(tree.repr) && checkRBPathLengthInvariant(tree.repr) >= 0;
+        }
+
+        static bool validateRedNode(const PosRBTreeRepr<T, K>& cur)
+        {
+            if(cur.typeinfo != s_nodetypeinfo) {
+                return false;
+            }
+            else if(cur.node->color != RColor::Red) {
+                return false;
+            }
+            else {
+                return true;
+            }
+        }
+
+        static bool validateBlackNode(const PosRBTreeRepr<T, K>& cur)
+        {
+            if(cur.typeinfo != s_nodetypeinfo) {
+                return false;
+            }
+            else if(cur.node->color != RColor::Black) {
+                return false;
+            }
+            else {
+                return true;
+            }
+        }
+
+        // double red violation on the RL side (PosRBTreeNode{ ..., Red, PosRBTreeNode{ x, Red, ... }, ... })
+        static std::optional<PosRBTreeRepr<T, K>> balancehelper_RR_RL(const PosRBTreeRepr<T, K>& cur)
+        {
+            const PosRBTreeRepr<T, K>& r  = cur.node->right;
+            const PosRBTreeRepr<T, K>& rl = r.node->left;
+            if(!validateBlackNode(cur) || !validateRedNode(r) || !validateRedNode(rl)) {
+                return std::nullopt;
+            }
+
+            const PosRBTreeRepr<T, K>& l   = cur.node->left;
+            const PosRBTreeRepr<T, K>& rll = rl.node->left;
+            const PosRBTreeRepr<T, K>& rlr = rl.node->right;
+            const PosRBTreeRepr<T, K>& rr  = r.node->right;
+            const PosRBTreeRepr<T, K> nl = mkwnodeRepr(l.node->count + rll.node->count, RColor::Red, l, rll);
+            const PosRBTreeRepr<T, K> nr = mkwnodeRepr(rlr.node->count + rr.node->count, RColor::Red, rlr, rr);
+            return mkwnodeRepr(s_nodeallocator->allocate(nl.node->count + nr.node->count, RColor::Black, nl, nr));
+        }
+
+        static PosRBTreeRepr<T, K> balance(const PosRBTreeRepr<T, K>& cur)
+        {
+            PosRBTreeRepr<T, K> res;
+            if(res = balancehelper_RR_RL(cur)) {
+                return res;
+            }
+            else {
+                return cur;
+            }
         }
 
         constexpr int64_t count() const


### PR DESCRIPTION
- added postree balancing in insertion
- rb invariants check
- fixed a bug in `subsetinsert` that could lead to copying data off the end of our array
- simplified `inserthelper` by no longer doing the weird edge cases for `index == 0` and `index >= K-1` (the k-1 case wasn't even correct)