### PR TITLE
quick fix: reject empty size range with no bounds

### DIFF
--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -5136,6 +5136,10 @@ class TypeChecker {
         }
 
         if(tdecl.optsizerng !== undefined) {
+            if(tdecl.optsizerng.min === undefined && tdecl.optsizerng.max === undefined) {
+                this.reportError(tdecl.sinfo, `Invalid size range max and min -- at least one must be defined`);
+            }
+
             const typevaluename = (tdecl.valuetype as NominalTypeSignature).decl.name;
             let minParsed: { value: bigint | number, ok: boolean } | undefined = undefined;
             let maxParsed: { value: bigint | number, ok: boolean } | undefined = undefined;


### PR DESCRIPTION
Adds checker error for String{}, Int{}, etc. for min and max undefined case. Parser allows empty form but checker should reject. Needed for the existing "should fail range index types" test in "type_alias_strings.test.js" to pass.