### PR TITLE
Range bounds on input validate and Float parsing

### DIFF
--- a/build/runcpp/runtime/bsqir/lexer.cpp
+++ b/build/runcpp/runtime/bsqir/lexer.cpp
@@ -9,7 +9,7 @@ namespace ᐸRuntimeᐳ
     static std::regex s_int_re("^(0|[+-]?[1-9][0-9]*)i", std::regex_constants::nosubs | std::regex_constants::optimize);
     static std::regex s_chknat_re("^(ChkNat::npos|((0|[+-]?[1-9][0-9]*)N))", std::regex_constants::nosubs | std::regex_constants::optimize);
     static std::regex s_chkint_re("^(ChkInt::npos|((0|[+-]?[1-9][0-9]*)I))", std::regex_constants::nosubs | std::regex_constants::optimize);
-    static std::regex s_float_re("^(0|[+-]?[1-9][0-9]*)(\\.[0-9]+)([eE][+-]?[0-9]+)?f", std::regex_constants::nosubs | std::regex_constants::optimize);
+    static std::regex s_float_re("^[+-]?(0|[1-9][0-9]*)(\\.[0-9]+)([eE][+-]?[0-9]+)?f", std::regex_constants::nosubs | std::regex_constants::optimize);
 
     constexpr std::array<char, 11> s_symbol_tokens = { '(', ')', '{', '}', '[', ']', '<', '>', ',', '#', '|' };
     constexpr std::array<const char*, 6> s_keyword_tokens = { "none", "true", "false", "some", "ok", "fail" };
@@ -26,12 +26,15 @@ namespace ᐸRuntimeᐳ
         return std::equal(this->begin, this->end, cchars);
     }
         
-    void BSQONToken::extract(char* outchars, size_t maxlen) const
+    bool BSQONToken::extract(char* outchars, size_t maxlen) const
     {
-        assert(maxlen > this->size());
+        if(maxlen <= this->size()) {
+            return false;
+        }
 
         std::copy(this->begin, this->end, outchars);
         outchars[this->size()] = '\0';
+        return true;
     }
 
     void BSQONLexer::initialize(std::list<uint8_t*>&& iobuffs, size_t totalbytes)

--- a/build/runcpp/runtime/bsqir/lexer.cpp
+++ b/build/runcpp/runtime/bsqir/lexer.cpp
@@ -9,6 +9,7 @@ namespace ᐸRuntimeᐳ
     static std::regex s_int_re("^(0|[+-]?[1-9][0-9]*)i", std::regex_constants::nosubs | std::regex_constants::optimize);
     static std::regex s_chknat_re("^(ChkNat::npos|((0|[+-]?[1-9][0-9]*)N))", std::regex_constants::nosubs | std::regex_constants::optimize);
     static std::regex s_chkint_re("^(ChkInt::npos|((0|[+-]?[1-9][0-9]*)I))", std::regex_constants::nosubs | std::regex_constants::optimize);
+    static std::regex s_float_re("^(0|[+-]?[1-9][0-9]*)(\\.[0-9]+)([eE][+-]?[0-9]+)?f", std::regex_constants::nosubs | std::regex_constants::optimize);
 
     constexpr std::array<char, 11> s_symbol_tokens = { '(', ')', '{', '}', '[', ']', '<', '>', ',', '#', '|' };
     constexpr std::array<const char*, 6> s_keyword_tokens = { "none", "true", "false", "some", "ok", "fail" };
@@ -119,6 +120,17 @@ namespace ᐸRuntimeᐳ
         }
 
         this->advanceToken(BSQONTokenType::LiteralChkInt, mm[0].length());
+        return true;
+    }
+
+    bool BSQONLexer::tryLexFloat()
+    {
+        std::match_results<BSQLexBufferIterator> mm;
+        if(!std::regex_search(this->iter, this->iend, mm, s_float_re)) {
+            return false;
+        }
+
+        this->advanceToken(BSQONTokenType::LiteralFloat, mm[0].length());
         return true;
     }
 
@@ -315,7 +327,7 @@ namespace ᐸRuntimeᐳ
             return;
         }
 
-        if(this->tryLexNat() || this->tryLexInt() || this->tryLexChkNat() || this->tryLexChkInt()) {
+        if(this->tryLexNat() || this->tryLexInt() || this->tryLexChkNat() || this->tryLexChkInt() || this->tryLexFloat()) {
             return;
         }
         else if(this->tryLexCString() || this->tryLexString()) {

--- a/build/runcpp/runtime/bsqir/lexer.h
+++ b/build/runcpp/runtime/bsqir/lexer.h
@@ -151,7 +151,7 @@ namespace ᐸRuntimeᐳ
         }
 
         bool matches(const char* cchars) const;
-        void extract(char* outchars, size_t maxlen) const;
+        bool extract(char* outchars, size_t maxlen) const;
 
         template<size_t len>
         bool xmatches(const char (&cchars)[len]) const

--- a/build/runcpp/runtime/bsqir/lexer.h
+++ b/build/runcpp/runtime/bsqir/lexer.h
@@ -119,6 +119,7 @@ namespace ᐸRuntimeᐳ
         LiteralInt,
         LiteralChkNat,
         LiteralChkInt,
+        LiteralFloat,
         LiteralCString,
         LiteralString,
         LiteralSymbol,
@@ -189,6 +190,7 @@ namespace ᐸRuntimeᐳ
         bool tryLexInt();
         bool tryLexChkNat();
         bool tryLexChkInt();
+        bool tryLexFloat();
 
         bool tryLexCString();
         bool tryLexString();

--- a/build/runcpp/runtime/bsqir/parser.cpp
+++ b/build/runcpp/runtime/bsqir/parser.cpp
@@ -215,7 +215,24 @@ namespace ᐸRuntimeᐳ
 
     std::optional<XFloat> BSQONParser::parseFloat()
     {
-        assert(false); // Not Implemented: parsing Float values
+        if(this->lexer.current().tokentype == BSQONTokenType::LiteralFloat) {
+            char outbuff[64] = {0};
+            this->lexer.current().extract(outbuff, 64);
+
+            errno = 0;
+            char* endptr = nullptr;
+            double vv = std::strtod(outbuff, &endptr);
+
+            if(errno != 0 || endptr == outbuff || !std::isfinite(vv)) {
+                return std::nullopt;
+            }
+            else {
+                this->lexer.consume();
+                return std::make_optional(XFloat{vv});
+            }
+        }
+        
+        return std::nullopt;
     }
 
     bool isSimpleChar(uint8_t c)

--- a/build/runcpp/runtime/bsqir/parser.cpp
+++ b/build/runcpp/runtime/bsqir/parser.cpp
@@ -2,6 +2,16 @@
 
 namespace ᐸRuntimeᐳ
 {
+    char* skipPlusSignOpt(char* ptr)
+    {
+        if(*ptr == '+') {
+            return ptr + 1;
+        }
+        else {
+            return ptr;
+        }
+    }
+
     void BSQONParser::initialize(std::list<uint8_t*>&& iobuffs, size_t totalbytes)
     {
         this->lexer.initialize(std::move(iobuffs), totalbytes);
@@ -59,10 +69,10 @@ namespace ᐸRuntimeᐳ
             return false;
         }
 
-        this->lexer.current().extract(outid, maxlen);
+        bool isok = this->lexer.current().extract(outid, maxlen);
         
         this->lexer.consume();
-        return true;
+        return isok;
     }
 
     void BSQONParser::consumeTokenAlways()
@@ -111,13 +121,15 @@ namespace ᐸRuntimeᐳ
     {
         if(this->lexer.current().tokentype == BSQONTokenType::LiteralNat) {
             char outbuff[32] = {0};
-            this->lexer.current().extract(outbuff, 32);
+            bool isok = this->lexer.current().extract(outbuff, sizeof(outbuff));
+            if(!isok) {
+                return std::nullopt;
+            }
 
-            errno = 0;
-            char* endptr = nullptr;
-            int64_t vv = std::strtoll(outbuff, &endptr, 10);
+            int64_t vv = 0;
+            auto [_, ec] = std::from_chars(skipPlusSignOpt(outbuff), outbuff + sizeof(outbuff), vv);
 
-            if(errno != 0 || endptr == outbuff || !XNat::isValidNat(vv)) {
+            if(ec != std::errc() || !XNat::isValidNat(vv)) {
                 return std::nullopt;
             }
             else {
@@ -133,13 +145,15 @@ namespace ᐸRuntimeᐳ
     {
         if(this->lexer.current().tokentype == BSQONTokenType::LiteralInt) {
             char outbuff[32] = {0};
-            this->lexer.current().extract(outbuff, 32);
+            bool isok = this->lexer.current().extract(outbuff, sizeof(outbuff));
+            if(!isok) {
+                return std::nullopt;
+            }
 
-            errno = 0;
-            char* endptr = nullptr;
-            int64_t vv = std::strtoll(outbuff, &endptr, 10);
+            int64_t vv = 0;
+            auto [_, ec] = std::from_chars(skipPlusSignOpt(outbuff), outbuff + sizeof(outbuff), vv);
 
-            if(errno != 0 || endptr == outbuff || !XInt::isValidInt(vv)) {
+            if(ec != std::errc() || !XInt::isValidInt(vv)) {
                 return std::nullopt;
             }
             else {
@@ -155,21 +169,21 @@ namespace ᐸRuntimeᐳ
     {
         if(this->lexer.current().tokentype == BSQONTokenType::LiteralChkNat) {
             char outbuff[64] = {0};
-            this->lexer.current().extract(outbuff, 64);
+            bool isok = this->lexer.current().extract(outbuff, sizeof(outbuff));
+            if(!isok) {
+                return std::nullopt;
+            }
 
             if(std::strcmp(outbuff, "ChkNat::npos") == 0) {
                 this->lexer.consume();
                 return std::make_optional(XChkNat::bliteral());
             }
             else {
-                errno = 0;
-                char* endptr = nullptr;
-                __int128_t vv = std::strtoll(outbuff, &endptr, 10);
 
-                if(errno == ERANGE) {
-                    assert(false); // Not Implemented: parsing very large ChkNat values
-                }
-                else if(endptr == outbuff || !XChkNat::isValidNat(vv)) {
+                __int128_t vv = 0;
+                auto [_, ec] = std::from_chars(skipPlusSignOpt(outbuff), outbuff + sizeof(outbuff), vv);
+
+                if(ec != std::errc() || !XChkNat::isValidNat(vv)) {
                     return std::nullopt;
                 }
                 else {
@@ -186,21 +200,21 @@ namespace ᐸRuntimeᐳ
     {
         if(this->lexer.current().tokentype == BSQONTokenType::LiteralChkInt) {
             char outbuff[64] = {0};
-            this->lexer.current().extract(outbuff, 64);
+            bool isok = this->lexer.current().extract(outbuff, sizeof(outbuff));
+            if(!isok) {
+                return std::nullopt;
+            }
 
             if(std::strcmp(outbuff, "ChkInt::npos") == 0) {
                 this->lexer.consume();
                 return std::make_optional(XChkInt::bliteral());
             }
             else {
-                errno = 0;
-                char* endptr = nullptr;
-                __int128_t vv = std::strtoll(outbuff, &endptr, 10);
 
-                if(errno == ERANGE) {
-                    assert(false); // Not Implemented: parsing very large ChkNat values
-                }
-                else if(endptr == outbuff || !XChkInt::isValidInt(vv)) {
+                __int128_t vv = 0;
+                auto [_, ec] = std::from_chars(skipPlusSignOpt(outbuff), outbuff + sizeof(outbuff), vv);
+
+                if(ec != std::errc() || !XChkInt::isValidInt(vv)) {
                     return std::nullopt;
                 }
                 else {
@@ -217,13 +231,15 @@ namespace ᐸRuntimeᐳ
     {
         if(this->lexer.current().tokentype == BSQONTokenType::LiteralFloat) {
             char outbuff[64] = {0};
-            this->lexer.current().extract(outbuff, 64);
+            bool isok = this->lexer.current().extract(outbuff, sizeof(outbuff));
+            if(!isok) {
+                return std::nullopt;
+            }
 
-            errno = 0;
-            char* endptr = nullptr;
-            double vv = std::strtod(outbuff, &endptr);
+            double vv = 0;
+            auto [_, ec] = std::from_chars(skipPlusSignOpt(outbuff), outbuff + sizeof(outbuff), vv);
 
-            if(errno != 0 || endptr == outbuff || !std::isfinite(vv)) {
+            if(ec != std::errc() || !std::isfinite(vv)) {
                 return std::nullopt;
             }
             else {
@@ -231,7 +247,7 @@ namespace ᐸRuntimeᐳ
                 return std::make_optional(XFloat{vv});
             }
         }
-        
+
         return std::nullopt;
     }
 

--- a/src/backend/asmprocess/flatten.ts
+++ b/src/backend/asmprocess/flatten.ts
@@ -3988,7 +3988,12 @@ class ASMToIRConverter {
             return { containingtype: this.processTypeSignature(val.containingtype), ii: jj };
         });
 
-        return new IRTypedeclTypeDecl(tinst.tkey, invariants, validates, saturatedProvides, allInvariants, allValidates, docstring, this.processMetaDataTags(tdecl.attributes), tdecl.file, this.convertSourceInfo(tdecl.sinfo), this.processTypeSignature(tdecl.valuetype as TypeSignature), (tdecl.valuetype as NominalTypeSignature).decl.isKeyTypeRestricted(), (tdecl.valuetype as NominalTypeSignature).decl.isNumericRestricted());
+        let rngchk: {min: string | undefined, max: string | undefined} | undefined = undefined;
+        if(tdecl.optsizerng !== undefined) {
+            rngchk = {min: tdecl.optsizerng.min, max: tdecl.optsizerng.max};
+        }
+
+        return new IRTypedeclTypeDecl(tinst.tkey, invariants, validates, saturatedProvides, allInvariants, allValidates, docstring, this.processMetaDataTags(tdecl.attributes), tdecl.file, this.convertSourceInfo(tdecl.sinfo), this.processTypeSignature(tdecl.valuetype as TypeSignature), (tdecl.valuetype as NominalTypeSignature).decl.isKeyTypeRestricted(), (tdecl.valuetype as NominalTypeSignature).decl.isNumericRestricted(), rngchk);
     }
 
     private generateTypedeclCStringDecl(tdecl: TypedeclTypeDecl, tinst: TypeInstantiationInfo, irasm: IRAssembly): IRTypedeclCStringDecl {

--- a/src/backend/ircemit/cppemit.ts
+++ b/src/backend/ircemit/cppemit.ts
@@ -1952,6 +1952,23 @@ class CPPEmitter {
         }
     }
 
+    private emitTypeDeclTypeDeclNumericInfo(tdecl: IRTypedeclTypeDecl): [string, string] {
+        const echks: string[] = [];
+        if(tdecl.rngchk !== undefined) {
+            if(tdecl.rngchk.min === undefined) {
+                echks.push(`if(${(tdecl.rngchk.max as string).slice(0, -1)} < vv.value) { return std::nullopt; };`);
+            }
+            else if(tdecl.rngchk.max === undefined) {
+                echks.push(`if(vv.value < ${(tdecl.rngchk.min as string).slice(0, -1)}) { return std::nullopt; };`);
+            }
+            else {
+                echks.push(`if((vv.value < ${(tdecl.rngchk.min as string).slice(0, -1)}) || (${(tdecl.rngchk.max as string).slice(0, -1)} < vv.value)) { return std::nullopt; };`);
+            }
+        }
+
+        return this.emitGeneralTypeDeclInfo(tdecl, echks);
+    }
+
     private emitCStringTypeDeclInfo(tcstr: IRTypedeclCStringDecl): [string, string] {
         let echks: string[] = [];
         if(tcstr.rngchk !== undefined) {
@@ -2562,7 +2579,15 @@ class CPPEmitter {
         
         const enumdd = this.irasm.enums.map((eden) => this.emitEnumTypeDeclInfo(eden));
 
-        const gtddd = this.irasm.typedecls.map((tgtd) =>  this.emitGeneralTypeDeclInfo(tgtd, undefined));
+        const gtddd = this.irasm.typedecls.map((tgtd) => {
+            if(tgtd.rngchk === undefined) {
+                return this.emitGeneralTypeDeclInfo(tgtd, undefined);
+            }
+            else {
+                return this.emitTypeDeclTypeDeclNumericInfo(tgtd);
+            }
+        });
+        
         const cstringdd = this.irasm.cstringoftypedecls.map((tcstr) => this.emitCStringTypeDeclInfo(tcstr));
         const stringdd = this.irasm.stringoftypedecls.map((tstr) => this.emitStringTypeDeclInfo(tstr));
 
@@ -2741,7 +2766,7 @@ class CPPEmitter {
             }).join("\n") + "\n";
 
             const finalizeparse = 
-            '    if(!ᐸRuntimeᐳ::tl_bosque_info.current_task->bsqparser.allInputConsumed()) { printf("Error parsing input -- invaliad data in tail of input\\n"); exit(1); }\n' +
+            '    if(!ᐸRuntimeᐳ::tl_bosque_info.current_task->bsqparser.allInputConsumed()) { printf("Error parsing input -- invalid data in tail of input\\n"); exit(1); }\n' +
             '    ᐸRuntimeᐳ::tl_bosque_info.current_task->bsqparser.release();\n';
 
             return [initforparse, pargs, finalizeparse].join("\n");

--- a/src/backend/irdefs/irassembly.ts
+++ b/src/backend/irdefs/irassembly.ts
@@ -332,12 +332,15 @@ class IRTypedeclTypeDecl extends IRAbstractEntityTypeDecl {
     readonly valuetype: IRTypeSignature;
     readonly iskeytype: boolean;
     readonly isnumerictype: boolean;
-    
-    constructor(tkey: string, invariants: IRInvariantDecl[], validates: IRValidateDecl[], saturatedProvides: IRTypeSignature[], allInvariants: { containingtype: IRNominalTypeSignature, ii: number }[], allValidates: { containingtype: IRNominalTypeSignature, ii: number }[], docstr: IRDeclarationDocString | undefined, metatags: IRDeclarationMetaTag[], file: string, sinfo: IRSourceInfo, valuetype: IRTypeSignature, iskeytype: boolean, isnumerictype: boolean) {
+   
+    readonly rngchk: {min: string | undefined, max: string | undefined} | undefined;
+
+    constructor(tkey: string, invariants: IRInvariantDecl[], validates: IRValidateDecl[], saturatedProvides: IRTypeSignature[], allInvariants: { containingtype: IRNominalTypeSignature, ii: number }[], allValidates: { containingtype: IRNominalTypeSignature, ii: number }[], docstr: IRDeclarationDocString | undefined, metatags: IRDeclarationMetaTag[], file: string, sinfo: IRSourceInfo, valuetype: IRTypeSignature, iskeytype: boolean, isnumerictype: boolean, rngchk: {min: string | undefined, max: string | undefined} | undefined) {
         super(tkey, invariants, validates, [], "std", saturatedProvides, [], allInvariants, allValidates, docstr, metatags, file, sinfo);
         this.valuetype = valuetype;
         this.iskeytype = iskeytype;
         this.isnumerictype = isnumerictype;
+        this.rngchk = rngchk;
     }
 
     getDeclDependencyTypes(alltypes: Map<string, IRAbstractNominalTypeDecl>): IRTypeSignature[] {
@@ -346,23 +349,19 @@ class IRTypedeclTypeDecl extends IRAbstractEntityTypeDecl {
 }
 
 class IRTypedeclCStringDecl extends IRTypedeclTypeDecl {
-    readonly rngchk: {min: string | undefined, max: string | undefined} | undefined;
     readonly rechk: IRLiteralCRegexExpression | undefined;
     
     constructor(tkey: string, invariants: IRInvariantDecl[], validates: IRValidateDecl[], saturatedProvides: IRTypeSignature[], allInvariants: { containingtype: IRNominalTypeSignature, ii: number }[], allValidates: { containingtype: IRNominalTypeSignature, ii: number }[], docstr: IRDeclarationDocString | undefined, metatags: IRDeclarationMetaTag[], file: string, sinfo: IRSourceInfo, rngchk: {min: string | undefined, max: string | undefined} | undefined, rechk: IRLiteralCRegexExpression | undefined) {
-        super(tkey, invariants, validates, saturatedProvides, allInvariants, allValidates, docstr, [], file, sinfo, new IRNominalTypeSignature("CString"), true, false);
-        this.rngchk = rngchk;
+        super(tkey, invariants, validates, saturatedProvides, allInvariants, allValidates, docstr, [], file, sinfo, new IRNominalTypeSignature("CString"), true, false, rngchk);
         this.rechk = rechk;
     }
 }
 
 class IRTypedeclStringDecl extends IRTypedeclTypeDecl {
-    readonly rngchk: {min: string | undefined, max: string | undefined} | undefined;
     readonly rechk: IRLiteralUnicodeRegexExpression | undefined;
     
     constructor(tkey: string, invariants: IRInvariantDecl[], validates: IRValidateDecl[], saturatedProvides: IRTypeSignature[], allInvariants: { containingtype: IRNominalTypeSignature, ii: number }[], allValidates: { containingtype: IRNominalTypeSignature, ii: number }[], docstr: IRDeclarationDocString | undefined, metatags: IRDeclarationMetaTag[], file: string, sinfo: IRSourceInfo, rngchk: {min: string | undefined, max: string | undefined} | undefined, rechk: IRLiteralUnicodeRegexExpression | undefined) {
-        super(tkey, invariants, validates, saturatedProvides, allInvariants, allValidates, docstr, [], file, sinfo, new IRNominalTypeSignature("String"), true, false);
-        this.rngchk = rngchk;
+        super(tkey, invariants, validates, saturatedProvides, allInvariants, allValidates, docstr, [], file, sinfo, new IRNominalTypeSignature("String"), true, false, rngchk);
         this.rechk = rechk;
     }
 }

--- a/src/backend/irdefs/irassembly.ts
+++ b/src/backend/irdefs/irassembly.ts
@@ -352,7 +352,7 @@ class IRTypedeclCStringDecl extends IRTypedeclTypeDecl {
     readonly rechk: IRLiteralCRegexExpression | undefined;
     
     constructor(tkey: string, invariants: IRInvariantDecl[], validates: IRValidateDecl[], saturatedProvides: IRTypeSignature[], allInvariants: { containingtype: IRNominalTypeSignature, ii: number }[], allValidates: { containingtype: IRNominalTypeSignature, ii: number }[], docstr: IRDeclarationDocString | undefined, metatags: IRDeclarationMetaTag[], file: string, sinfo: IRSourceInfo, rngchk: {min: string | undefined, max: string | undefined} | undefined, rechk: IRLiteralCRegexExpression | undefined) {
-        super(tkey, invariants, validates, saturatedProvides, allInvariants, allValidates, docstr, [], file, sinfo, new IRNominalTypeSignature("CString"), true, false, rngchk);
+        super(tkey, invariants, validates, saturatedProvides, allInvariants, allValidates, docstr, metatags, file, sinfo, new IRNominalTypeSignature("CString"), true, false, rngchk);
         this.rechk = rechk;
     }
 }
@@ -361,7 +361,7 @@ class IRTypedeclStringDecl extends IRTypedeclTypeDecl {
     readonly rechk: IRLiteralUnicodeRegexExpression | undefined;
     
     constructor(tkey: string, invariants: IRInvariantDecl[], validates: IRValidateDecl[], saturatedProvides: IRTypeSignature[], allInvariants: { containingtype: IRNominalTypeSignature, ii: number }[], allValidates: { containingtype: IRNominalTypeSignature, ii: number }[], docstr: IRDeclarationDocString | undefined, metatags: IRDeclarationMetaTag[], file: string, sinfo: IRSourceInfo, rngchk: {min: string | undefined, max: string | undefined} | undefined, rechk: IRLiteralUnicodeRegexExpression | undefined) {
-        super(tkey, invariants, validates, saturatedProvides, allInvariants, allValidates, docstr, [], file, sinfo, new IRNominalTypeSignature("String"), true, false, rngchk);
+        super(tkey, invariants, validates, saturatedProvides, allInvariants, allValidates, docstr, metatags, file, sinfo, new IRNominalTypeSignature("String"), true, false, rngchk);
         this.rechk = rechk;
     }
 }

--- a/src/bsqir/irassembly.bsq
+++ b/src/bsqir/irassembly.bsq
@@ -19,7 +19,4 @@ concept IRAbstractNominalTypeDecl {
 
     %%field docstr: IRDeclarationDocString | undefined;
     %%field metatags: IRDeclarationMetaTag[];
-
-    field file: CString;
-    field sinfo: IRSourceInfo;
 }

--- a/src/cmd/bosque.ts
+++ b/src/cmd/bosque.ts
@@ -71,7 +71,7 @@ function emitCommandLineMakefile(optlevel: "testing" | "release"): string {
         '\n' +
         '#testing is default, for another flavor : make BUILD=release or debug\n' +
         `BUILD := ${optlevel}\n\n` + 
-        'CPP_STDFLAGS=-Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wuninitialized -Werror -std=gnu++20 -fno-omit-frame-pointer -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-stack-protector\n' + 
+        'CPP_STDFLAGS=-Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wuninitialized -Werror -std=gnu++23 -fno-omit-frame-pointer -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-stack-protector\n' + 
         'CPPFLAGS_OPT.testing=-O0 -g -ggdb -fsanitize=address --param asan-stack=0\n' +
         'CPPFLAGS_OPT.testingopt=-O1 -g -ggdb -fsanitize=address --param asan-stack=0\n' +
         'CPPFLAGS_OPT.release=-O2 -g -ggdb -flto=auto -ftree-vectorize -march=native -Wno-array-bounds -Wno-stringop-overflow\n' +

--- a/test/cpprun/cpprun_nf.ts
+++ b/test/cpprun/cpprun_nf.ts
@@ -59,7 +59,7 @@ function emitCommandLineMakefile(): string {
         'ALLOC_SRC_DIR=$(RUNTIME_SRC_DIR)allocator/\n' +
         'BSQIR_SRC_DIR=$(RUNTIME_SRC_DIR)bsqir/\n' +
         '\n' +
-        'CPPFLAGS=-O0 -g -ggdb -fsanitize=address --param asan-stack=0 -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wuninitialized -Werror -std=gnu++20 -fno-omit-frame-pointer -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-stack-protector\n' + 
+        'CPPFLAGS=-O0 -g -ggdb -fsanitize=address --param asan-stack=0 -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wuninitialized -Werror -std=gnu++23 -fno-omit-frame-pointer -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-stack-protector\n' + 
         'HEADERS=$(wildcard $(SRC_DIR)*.h) $(wildcard $(CORE_SRC_DIR)*.h) $(wildcard $(RUNTIME_SRC_DIR)*.h) $(wildcard $(ALLOC_SRC_DIR)*.h) $(wildcard $(BSQIR_SRC_DIR)*.h)\n' +
         'CPP=$(wildcard $(SRC_DIR)*.cpp) $(wildcard $(CORE_SRC_DIR)*.cpp) $(wildcard $(RUNTIME_SRC_DIR)*.cpp) $(wildcard $(ALLOC_SRC_DIR)*.cpp) $(wildcard $(BSQIR_SRC_DIR)*.cpp)\n' +
         '\n' +

--- a/test/documentation/docs_nf.ts
+++ b/test/documentation/docs_nf.ts
@@ -62,7 +62,7 @@ function emitCommandLineMakefile(): string {
         'ALLOC_SRC_DIR=$(RUNTIME_SRC_DIR)allocator/\n' +
         'BSQIR_SRC_DIR=$(RUNTIME_SRC_DIR)bsqir/\n' +
         '\n' +
-        'CPPFLAGS=-O0 -g -ggdb -fsanitize=address --param asan-stack=0 -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wuninitialized -Werror -std=gnu++20 -fno-omit-frame-pointer -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-stack-protector\n' + 
+        'CPPFLAGS=-O0 -g -ggdb -fsanitize=address --param asan-stack=0 -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wuninitialized -Werror -std=gnu++23 -fno-omit-frame-pointer -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-stack-protector\n' + 
         'HEADERS=$(wildcard $(SRC_DIR)*.h) $(wildcard $(CORE_SRC_DIR)*.h) $(wildcard $(RUNTIME_SRC_DIR)*.h) $(wildcard $(ALLOC_SRC_DIR)*.h) $(wildcard $(BSQIR_SRC_DIR)*.h)\n' +
         'CPP=$(wildcard $(SRC_DIR)*.cpp) $(wildcard $(CORE_SRC_DIR)*.cpp) $(wildcard $(RUNTIME_SRC_DIR)*.cpp) $(wildcard $(ALLOC_SRC_DIR)*.cpp) $(wildcard $(BSQIR_SRC_DIR)*.cpp)\n' +
         '\n' +

--- a/test/stdlib/stdlib_nf.ts
+++ b/test/stdlib/stdlib_nf.ts
@@ -59,7 +59,7 @@ function emitCommandLineMakefile(): string {
         'ALLOC_SRC_DIR=$(RUNTIME_SRC_DIR)allocator/\n' +
         'BSQIR_SRC_DIR=$(RUNTIME_SRC_DIR)bsqir/\n' +
         '\n' +
-        'CPPFLAGS=-O0 -g -ggdb -fsanitize=address --param asan-stack=0 -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wuninitialized -Werror -std=gnu++20 -fno-omit-frame-pointer -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-stack-protector\n' + 
+        'CPPFLAGS=-O0 -g -ggdb -fsanitize=address --param asan-stack=0 -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wuninitialized -Werror -std=gnu++23 -fno-omit-frame-pointer -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-stack-protector\n' + 
         'HEADERS=$(wildcard $(SRC_DIR)*.h) $(wildcard $(CORE_SRC_DIR)*.h) $(wildcard $(RUNTIME_SRC_DIR)*.h) $(wildcard $(ALLOC_SRC_DIR)*.h) $(wildcard $(BSQIR_SRC_DIR)*.h)\n' +
         'CPP=$(wildcard $(SRC_DIR)*.cpp) $(wildcard $(CORE_SRC_DIR)*.cpp) $(wildcard $(RUNTIME_SRC_DIR)*.cpp) $(wildcard $(ALLOC_SRC_DIR)*.cpp) $(wildcard $(BSQIR_SRC_DIR)*.cpp)\n' +
         '\n' +


### PR DESCRIPTION
- Fix to propagate numeric ranges into IRTypedecl and also in CPP emit on input validation.
- Add support for Float lexing and parsing in CPP BAPI implementation.