### PR TITLE
More tecton + stdlib

### DIFF
--- a/build/runcpp/core/list_t.h
+++ b/build/runcpp/core/list_t.h
@@ -679,6 +679,25 @@ namespace ᐸRuntimeᐳ
             }
         }
 
+        template<typename U, uint32_t TYPE_ID_LIST_U>
+        XList<U, TYPE_ID_LIST_U> concat(const XList<T, TYPE_ID_LIST_T>& other) const
+        {
+            XList<U, TYPE_ID_LIST_U> curr{};
+
+            for(auto ii = this->begin(); ii != this->end(); ++ii) {
+                if(!ii->empty()) {
+                    if(curr.empty()) {
+                        curr = *ii;
+                    }
+                    else {
+                        curr = curr.append(*ii);
+                    }
+                }
+            }
+
+            return curr;
+        }
+
         template<bool SafeSimplePred, typename Pred>
         XBool allOf(Pred p) const
         {

--- a/build/runcpp/core/list_t.h
+++ b/build/runcpp/core/list_t.h
@@ -680,9 +680,9 @@ namespace ᐸRuntimeᐳ
         }
 
         template<typename U, uint32_t TYPE_ID_LIST_U>
-        XList<U, TYPE_ID_LIST_U> concat(const XList<T, TYPE_ID_LIST_T>& other) const
+        XList<T, TYPE_ID_LIST_T> concat(const XList<U, TYPE_ID_LIST_U>& other) const
         {
-            XList<U, TYPE_ID_LIST_U> curr{};
+            XList<T, TYPE_ID_LIST_T> curr{};
 
             for(auto ii = this->begin(); ii != this->end(); ++ii) {
                 if(!ii->empty()) {

--- a/build/runcpp/core/list_t.h
+++ b/build/runcpp/core/list_t.h
@@ -680,17 +680,19 @@ namespace ᐸRuntimeᐳ
         }
 
         template<typename U, uint32_t TYPE_ID_LIST_U>
-        XList<T, TYPE_ID_LIST_T> concat(const XList<U, TYPE_ID_LIST_U>& other) const
+        static XList<T, TYPE_ID_LIST_T> concat(const XList<U, TYPE_ID_LIST_U>& ll)
         {
             XList<T, TYPE_ID_LIST_T> curr{};
 
-            for(auto ii = this->begin(); ii != this->end(); ++ii) {
-                if(!ii->empty()) {
+            for(auto ii = ll.begin(); ii != ll.end(); ++ii) {
+                auto il = *ii;
+                
+                if(!il.empty()) {
                     if(curr.empty()) {
-                        curr = *ii;
+                        curr = il;
                     }
                     else {
-                        curr = curr.append(*ii);
+                        curr = curr.append(il);
                     }
                 }
             }

--- a/build/runcpp/core/strings.cpp
+++ b/build/runcpp/core/strings.cpp
@@ -32,6 +32,18 @@ namespace ᐸRuntimeᐳ
         }
     }
 
+    XCString XCString::natToCString(int64_t value) {
+        char numbuf[64];
+        int written = std::snprintf(numbuf, sizeof(numbuf), "%lli", value);
+        return XCString::mk(numbuf, static_cast<size_t>(written));
+    }
+
+    XCString XCString::intToCString(int64_t value) {
+        char numbuf[64];
+        int written = std::snprintf(numbuf, sizeof(numbuf), "%lli", value);
+        return XCString::mk(numbuf, static_cast<size_t>(written));
+    }
+
     XCString XCString::append(XCString other)
     {
         assert(!this->ucstr.empty());

--- a/build/runcpp/core/strings.cpp
+++ b/build/runcpp/core/strings.cpp
@@ -34,13 +34,13 @@ namespace ᐸRuntimeᐳ
 
     XCString XCString::natToCString(int64_t value) {
         char numbuf[64];
-        int written = std::snprintf(numbuf, sizeof(numbuf), "%lli", value);
+        int written = std::snprintf(numbuf, sizeof(numbuf), "%lli", (long long int)value);
         return XCString::mk(numbuf, static_cast<size_t>(written));
     }
 
     XCString XCString::intToCString(int64_t value) {
         char numbuf[64];
-        int written = std::snprintf(numbuf, sizeof(numbuf), "%lli", value);
+        int written = std::snprintf(numbuf, sizeof(numbuf), "%lli", (long long int)value);
         return XCString::mk(numbuf, static_cast<size_t>(written));
     }
 

--- a/build/runcpp/core/strings.h
+++ b/build/runcpp/core/strings.h
@@ -445,6 +445,9 @@ namespace ᐸRuntimeᐳ
 
         void diagnosticEmit(std::ostream& out, bool waddr) const;
 
+        static XCString natToCString(int64_t value);
+        static XCString intToCString(int64_t value);
+
         XCString append(XCString other);
     };
 

--- a/src/backend/asmprocess/flatten.ts
+++ b/src/backend/asmprocess/flatten.ts
@@ -1151,7 +1151,61 @@ class ASMToIRConverter {
         }
     }
 
+    private flattenCallTypeFunctionSpecialExpression(exp: CallTypeFunctionExpression): IRExpression {
+        //currently only allowed special call is "T::from" for constructing a typedecl -- just need to emit that (see flattenSpecialTypeDeclConstructor)
+
+        const ctype = this.tproc(exp.getType()) as NominalTypeSignature;
+        const tdecl = ctype.decl as TypedeclTypeDecl;
+
+        const cargt = this.tproc((exp.args.args[0] as StdArgumentValue).exp.getType());
+        let cval = this.makeExpressionSimple(this.flattenExpression((exp.args.args[0] as StdArgumentValue).exp), cargt);
+        
+        if(tdecl.allInvariants.length !== 0 || tdecl.optofexp !== undefined || tdecl.optsizerng !== undefined) {
+            cval = this.makeExpressionImmediate(cval, tdecl.valuetype);
+        }
+
+        if(tdecl.optsizerng !== undefined) {
+            const mmin = tdecl.optsizerng.min !== undefined ? this.makeExpressionImmediate(this.makeExpressionSimple(this.flattenExpression(tdecl.optsizerng.min), tdecl.valuetype), tdecl.valuetype) : undefined;
+            const mmax = tdecl.optsizerng.max !== undefined ? this.makeExpressionImmediate(this.makeExpressionSimple(this.flattenExpression(tdecl.optsizerng.max), tdecl.valuetype), tdecl.valuetype) : undefined;
+
+            if(tdecl.valuetype.tkeystr === "CString") {
+                this.pushStatement(new IRTypeDeclSizeRangeCheckCStringStatement(tdecl.file, this.convertSourceInfo(tdecl.sinfo), this.registerError(tdecl.file, this.convertSourceInfo(tdecl.sinfo), "userspec"), mmin, mmax, cval as IRImmediateExpression));
+            }
+            else if(tdecl.valuetype.tkeystr === "String") {
+                this.pushStatement(new IRTypeDeclSizeRangeCheckUnicodeStringStatement(tdecl.file, this.convertSourceInfo(tdecl.sinfo), this.registerError(tdecl.file, this.convertSourceInfo(tdecl.sinfo), "userspec"), mmin, mmax, cval as IRImmediateExpression));
+            }
+            else {
+                this.pushStatement(new IRTypeDeclNumericRangeCheckStatement(tdecl.file, this.convertSourceInfo(tdecl.sinfo), this.registerError(tdecl.file, this.convertSourceInfo(tdecl.sinfo), "userspec"), mmin, mmax, cval as IRImmediateExpression));
+            }
+        }
+
+        if(tdecl.optofexp !== undefined) {
+            if(tdecl.valuetype.tkeystr === "CString") {
+                const regex = this.flattenExpression(tdecl.optofexp) as IRLiteralCRegexExpression;
+                this.pushStatement(new IRTypeDeclFormatCheckCStringStatement(tdecl.file, this.convertSourceInfo(tdecl.sinfo), this.registerError(tdecl.file, this.convertSourceInfo(tdecl.sinfo), "userspec"), regex, cval as IRImmediateExpression));
+            }
+            else {
+                const regex = this.flattenExpression(tdecl.optofexp) as IRLiteralUnicodeRegexExpression;
+                this.pushStatement(new IRTypeDeclFormatCheckUnicodeStringStatement(tdecl.file, this.convertSourceInfo(tdecl.sinfo), this.registerError(tdecl.file, this.convertSourceInfo(tdecl.sinfo), "userspec"), regex, cval as IRImmediateExpression));
+            }
+        }
+
+        if(tdecl.allInvariants.length !== 0) {
+            const invchecks = tdecl.allInvariants.map<IRTypeDeclInvariantCheckStatement>((invdecl) => {
+                return new IRTypeDeclInvariantCheckStatement(invdecl.file, this.convertSourceInfo(invdecl.sinfo), invdecl.tag, this.registerError(invdecl.file, this.convertSourceInfo(invdecl.sinfo), "userspec"), this.processTypeSignature(invdecl.containingtype).tkeystr, invdecl.ii, cval);
+            });
+                
+            this.pushStatements(invchecks);
+        }
+
+        return new IRConstructSafeTypeDeclExpression(this.processTypeSignature(ctype), cval);
+    }
+
     private flattenCallTypeFunctionExpression(exp: CallTypeFunctionExpression): IRExpression {
+        if(exp.isSpecialCall) {
+            return this.flattenCallTypeFunctionSpecialExpression(exp);
+        }
+
         const fdecl = exp.resolvedFunction as TypeFunctionDecl;
 
         const haspreconds = fdecl.preconditions.length > 0;

--- a/src/backend/asmprocess/flatten.ts
+++ b/src/backend/asmprocess/flatten.ts
@@ -424,8 +424,8 @@ class ASMToIRConverter {
             return exp;
         }
         else {
-            assert(ftype instanceof NominalTypeSignature, "ASMToIRConverter::makeCoercionExplicitAsNeeded - fromtype not nominal");
-            assert(ttype instanceof NominalTypeSignature, "ASMToIRConverter::makeCoercionExplicitAsNeeded - totype not nominal");
+            assert(ftype instanceof NominalTypeSignature, `ASMToIRConverter::makeCoercionExplicitAsNeeded - fromtype (${ftype.tkeystr}) not nominal`);
+            assert(ttype instanceof NominalTypeSignature, `ASMToIRConverter::makeCoercionExplicitAsNeeded - totype (${ttype.tkeystr}) not nominal`);
 
             if(ftype.decl instanceof AbstractConceptTypeDecl) {
                 return new IRConvertConceptRepresentationExpression(this.processTypeSignature(ftype), this.processTypeSignature(ttype), exp);

--- a/src/backend/ircemit/cppemit.ts
+++ b/src/backend/ircemit/cppemit.ts
@@ -1286,7 +1286,13 @@ class CPPEmitter {
         let prestr = "";
         let bstr: string;
 
-        if(body.builtin === "nat_pow") {
+        if(body.builtin === "nat_to_cstring") {
+            bstr = `ᐸRuntimeᐳ::XCString::natToCString(n.value)`;
+        }
+        else if(body.builtin === "int_to_cstring") {
+            bstr = `ᐸRuntimeᐳ::XCString::intToCString(i.value)`;
+        }
+        else if(body.builtin === "nat_pow") {
             bstr = `ᐸRuntimeᐳ::integerPower<ᐸRuntimeᐳ::XNat, int64_t>(x, y)`;
         }
         else if(body.builtin === "int_pow") {
@@ -1379,6 +1385,9 @@ class CPPEmitter {
         }
         else if(body.builtin === "list_append") {
             bstr = "l1.append(l2)";
+        }
+        else if(body.builtin === "list_concat") {
+            bstr = "XXXX::concat(l)";
         }
         else if(body.builtin === "list_allof") {
             const [fn, isSimple, params, args] = this.getParamInforForLambda(invk, "p");

--- a/src/backend/ircemit/cppemit.ts
+++ b/src/backend/ircemit/cppemit.ts
@@ -1194,7 +1194,7 @@ class CPPEmitter {
         const ops = mstmt.matchflow.map((mf, ii) => {
             let chk: string;
             if(mf.mtype === undefined || ii === mstmt.matchflow.length - 1) {
-                chk = 'else {';
+                chk = 'else';
             }
             else {
                 const mftinfo = this.irasm.alltypes.get(mf.mtype.tkeystr) as IRAbstractNominalTypeDecl;
@@ -1208,7 +1208,7 @@ class CPPEmitter {
                     cop = `${RUNTIME_NAMESPACE}::isSubtypeOf(${typeidextract}, &${ttmgr})`;
                 }
 
-                chk = `if${ii !== 0 ? " else" : ""}(${cop}) {`;
+                chk = `${ii !== 0 ? "else " : ""}if(${cop})`;
             }
             
             const body = this.emitStatementList(mf.value.statements, undefined, undefined, bindent);

--- a/src/backend/ircemit/cppemit.ts
+++ b/src/backend/ircemit/cppemit.ts
@@ -1387,7 +1387,7 @@ class CPPEmitter {
             bstr = "l1.append(l2)";
         }
         else if(body.builtin === "list_concat") {
-            bstr = "XXXX::concat(l)";
+            bstr = `${TransformCPPNameManager.convertTypeKey(invk.resultType.tkeystr)}::concat(l)`;
         }
         else if(body.builtin === "list_allof") {
             const [fn, isSimple, params, args] = this.getParamInforForLambda(invk, "p");

--- a/src/backend/irdefs/irassembly.ts
+++ b/src/backend/irdefs/irassembly.ts
@@ -1702,6 +1702,7 @@ class IRAssembly {
             //this.agents.map((ag) => ag.toBAPI()).join(","),
             //this.tasks.map((t) => t.toBAPI()).join(",")
 
+            ('Map<Assembly::TypeKey, Assembly::TypeSignature>{\n        ' + this.typedeporder.map((tt) => `${emitTypeKey(tt.tkeystr)} => ${tt.toBAPI()}`).join(",\n        ") + '\n    }'),
             ('Map<Assembly::TypeKey, Assembly::AbstractNominalTypeDecl>{\n        ' + Array.from(this.alltypes.entries()).map(([k, v]) => `${emitTypeKey(k)} => ${v.toBAPI()}`).join(",\n        ") + '\n    }'),
             //readonly allinvokes: Map<string, IRInvokeMetaDecl> = new Map<string, IRInvokeMetaDecl>();
             //readonly alllambdas: Map<string, IRLambdaParameterPackDecl> = new Map<string, IRLambdaParameterPackDecl>();
@@ -1751,6 +1752,14 @@ class IRAssembly {
 
         lexer.ensureAndConsumeSymbol("List<Assembly::StringTypeDecl>");
         irasm.stringoftypedecls.push(...parseListOf<IRTypedeclStringDecl>(lexer, '{', '}', ',', IRTypedeclStringDecl.parseBAPIAsIRTypedeclStringDecl));
+
+        lexer.ensureAndConsumeSymbol("Map<Assembly::TypeKey, Assembly::TypeSignature>");
+        parseListOf<[string, IRTypeSignature]>(lexer, '{', '}', ',', (lexer) => {
+            const key = parseTypeKey(lexer);
+            lexer.ensureAndConsumeSymbol('=>');
+            const value = IRTypeSignature.parseBAPI(lexer);
+            return [key, value];
+        });
 
         lexer.ensureAndConsumeSymbol("Map<Assembly::TypeKey, Assembly::AbstractNominalTypeDecl>");
         const entrylist = parseListOf<[string, IRAbstractNominalTypeDecl]>(lexer, '{', '}', ',', (lexer) => {

--- a/src/backend/irdefs/irassembly.ts
+++ b/src/backend/irdefs/irassembly.ts
@@ -1741,16 +1741,16 @@ class IRAssembly {
         lexer.ensureAndConsumeSymbol("List<Assembly::EnumTypeDecl>");
         irasm.enums.push(...parseListOf<IREnumTypeDecl>(lexer, '{', '}', ',', IREnumTypeDecl.parseBAPIAsIREnumTypeDecl));
 
-        lexer.ensureAndConsumeSymbol("List<Assembly::SimpleTypeDecl>");
+        lexer.ensureAndConsumeSymbol("List<Assembly::TypedeclSimpleTypeDecl>");
         irasm.typedecls.push(...parseListOf<IRTypedeclTypeDecl>(lexer, '{', '}', ',', IRTypedeclTypeDecl.parseBAPIAsIRTypedeclTypeDecl));
 
-        lexer.ensureAndConsumeSymbol("List<Assembly::BoundedTypeDecl>");
+        lexer.ensureAndConsumeSymbol("List<Assembly::TypedeclBoundedTypeDecl>");
         irasm.typedecls.push(...parseListOf<IRTypedeclTypeDecl>(lexer, '{', '}', ',', IRTypedeclTypeDecl.parseBAPIAsIRTypedeclTypeDecl));
 
-        lexer.ensureAndConsumeSymbol("List<Assembly::CStringTypeDecl>");
+        lexer.ensureAndConsumeSymbol("List<Assembly::TypedeclCStringTypeDecl>");
         irasm.cstringoftypedecls.push(...parseListOf<IRTypedeclCStringDecl>(lexer, '{', '}', ',', IRTypedeclCStringDecl.parseBAPIAsIRTypedeclCStringDecl));
 
-        lexer.ensureAndConsumeSymbol("List<Assembly::StringTypeDecl>");
+        lexer.ensureAndConsumeSymbol("List<Assembly::TypedeclStringTypeDecl>");
         irasm.stringoftypedecls.push(...parseListOf<IRTypedeclStringDecl>(lexer, '{', '}', ',', IRTypedeclStringDecl.parseBAPIAsIRTypedeclStringDecl));
 
         lexer.ensureAndConsumeSymbol("Map<Assembly::TypeKey, Assembly::TypeSignature>");

--- a/src/backend/irdefs/irassembly.ts
+++ b/src/backend/irdefs/irassembly.ts
@@ -320,10 +320,10 @@ abstract class IRAbstractNominalTypeDecl {
         else if(ttypekey === 'Assembly::TypedeclBoundedTypeDecl') {
             return IRTypedeclTypeDecl.parseBAPIAsIRTypedeclTypeDecl(lexer);
         }
-        else if(ttypekey === 'Assembly::TypedeclCStringDecl') {
+        else if(ttypekey === 'Assembly::TypedeclCStringTypeDecl') {
             return IRTypedeclCStringDecl.parseBAPIAsIRTypedeclCStringDecl(lexer);
         }
-        else if(ttypekey === 'Assembly::TypedeclStringDecl') {
+        else if(ttypekey === 'Assembly::TypedeclStringTypeDecl') {
             return IRTypedeclStringDecl.parseBAPIAsIRTypedeclStringDecl(lexer);
         }
         else if(ttypekey === 'Assembly::PrimitiveEntityTypeDecl') {
@@ -517,7 +517,7 @@ class IRTypedeclCStringDecl extends IRTypedeclTypeDecl {
         const rngchkstr = this.rngchk !== undefined ? this.toBAPI_RNGCheck() : 'none';
         const rechkstr = this.rechk !== undefined ? `some(${this.rechk.toBAPI()})` : 'none';
 
-        return `Assembly::TypedeclCStringDecl{${this.toBAPI_IRAbstractEntityTypeDecl()}, ${this.iskeytype}, ${this.isnumerictype}, ${rngchkstr}, ${rechkstr}}`;
+        return `Assembly::TypedeclCStringTypeDecl{${this.toBAPI_IRAbstractEntityTypeDecl()}, ${this.iskeytype}, ${this.isnumerictype}, ${rngchkstr}, ${rechkstr}}`;
     }
 
     static parseBAPIAsIRTypedeclCStringDecl(lexer: BAPILexer): IRTypedeclCStringDecl {
@@ -567,7 +567,7 @@ class IRTypedeclStringDecl extends IRTypedeclTypeDecl {
         const rngchkstr = this.rngchk !== undefined ? this.toBAPI_RNGCheck() : 'none';
         const rechkstr = this.rechk !== undefined ? `some(${this.rechk.toBAPI()})` : 'none';
         
-        return `Assembly::TypedeclStringDecl{${this.toBAPI_IRAbstractEntityTypeDecl()}, ${this.iskeytype}, ${this.isnumerictype}, ${rngchkstr}, ${rechkstr}}`;
+        return `Assembly::TypedeclStringTypeDecl{${this.toBAPI_IRAbstractEntityTypeDecl()}, ${this.iskeytype}, ${this.isnumerictype}, ${rngchkstr}, ${rechkstr}}`;
     }
 
     static parseBAPIAsIRTypedeclStringDecl(lexer: BAPILexer): IRTypedeclStringDecl {
@@ -1687,10 +1687,10 @@ class IRAssembly {
 
             ('List<Assembly::EnumTypeDecl>{\n        ' + this.enums.map((e) => e.toBAPI()).join(",\n        ") + '\n    }'),
             
-            ('List<Assembly::SimpleTypeDecl>{\n        ' + this.typedecls.filter((td) => td.rngchk === undefined).map((td) => td.toBAPI()).join(",\n        ") + '\n    }'),
-            ('List<Assembly::BoundedTypeDecl>{\n        ' + this.typedecls.filter((td) => td.rngchk !== undefined).map((td) => td.toBAPI()).join(",\n        ") + '\n    }'),
-            ('List<Assembly::CStringTypeDecl>{\n        ' + this.cstringoftypedecls.map((td) => td.toBAPI()).join(",\n        ") + '\n    }'),
-            ('List<Assembly::StringTypeDecl>{\n        ' + this.stringoftypedecls.map((td) => td.toBAPI()).join(",\n        ") + '\n    }'),
+            ('List<Assembly::TypedeclSimpleTypeDecl>{\n        ' + this.typedecls.filter((td) => td.rngchk === undefined).map((td) => td.toBAPI()).join(",\n        ") + '\n    }'),
+            ('List<Assembly::TypedeclBoundedTypeDecl>{\n        ' + this.typedecls.filter((td) => td.rngchk !== undefined).map((td) => td.toBAPI()).join(",\n        ") + '\n    }'),
+            ('List<Assembly::TypedeclCStringTypeDecl>{\n        ' + this.cstringoftypedecls.map((td) => td.toBAPI()).join(",\n        ") + '\n    }'),
+            ('List<Assembly::TypedeclStringTypeDecl>{\n        ' + this.stringoftypedecls.map((td) => td.toBAPI()).join(",\n        ") + '\n    }'),
             
             //this.entities.map((e) => e.toBAPI()).join(","),
             //this.datamembers.map((dm) => dm.toBAPI()).join(","),

--- a/src/backend/irdefs/irbody.ts
+++ b/src/backend/irdefs/irbody.ts
@@ -676,7 +676,7 @@ class IRLiteralNatExpression extends IRLiteralIntegralNumberExpression {
     }
 
     override toBAPI(): string {
-        return `Assembly::LiteralNatExpression{${this.value}}`;
+        return `Assembly::LiteralNatExpression{${this.value}n}`;
     }
     
     static parseBAPIAsIRLiteralNatExpression(lexer: BAPILexer): IRLiteralNatExpression {
@@ -685,7 +685,7 @@ class IRLiteralNatExpression extends IRLiteralIntegralNumberExpression {
         const value = lexer.ensureAndConsumeToken(BAPITokenKind.NatLiteral);
         lexer.ensureAndConsumeSymbol("}");
 
-        return new IRLiteralNatExpression(value);
+        return new IRLiteralNatExpression(value.slice(0, -1)); //remove the trailing 'n' from the literal
     }
 }
 
@@ -695,7 +695,7 @@ class IRLiteralIntExpression extends IRLiteralIntegralNumberExpression {
     }
 
     override toBAPI(): string {
-        return `Assembly::LiteralIntExpression{${this.value}}`;
+        return `Assembly::LiteralIntExpression{${this.value}i}`;
     }
     
     static parseBAPIAsIRLiteralIntExpression(lexer: BAPILexer): IRLiteralIntExpression {
@@ -704,7 +704,7 @@ class IRLiteralIntExpression extends IRLiteralIntegralNumberExpression {
         const value = lexer.ensureAndConsumeToken(BAPITokenKind.IntLiteral);
         lexer.ensureAndConsumeSymbol("}");
 
-        return new IRLiteralIntExpression(value);
+        return new IRLiteralIntExpression(value.slice(0, -1)); //remove the trailing 'i' from the literal
     }
 }
 
@@ -714,7 +714,7 @@ class IRLiteralChkNatExpression extends IRLiteralIntegralNumberExpression {
     }
 
     override toBAPI(): string {
-        return `Assembly::LiteralChkNatExpression{${this.value}}`;
+        return `Assembly::LiteralChkNatExpression{${this.value}N}`;
     }
 
     static parseBAPIAsIRLiteralChkNatExpression(lexer: BAPILexer): IRLiteralChkNatExpression {
@@ -723,7 +723,7 @@ class IRLiteralChkNatExpression extends IRLiteralIntegralNumberExpression {
         const value = lexer.ensureAndConsumeToken(BAPITokenKind.ChkNatLiteral);
         lexer.ensureAndConsumeSymbol("}");
         
-        return new IRLiteralChkNatExpression(value);
+        return new IRLiteralChkNatExpression(value.slice(0, -1)); //remove the trailing 'N' from the literal
     }
 }
 
@@ -733,7 +733,7 @@ class IRLiteralChkIntExpression extends IRLiteralIntegralNumberExpression {
     }
 
     override toBAPI(): string {
-        return `Assembly::LiteralChkIntExpression{${this.value}}`;
+        return `Assembly::LiteralChkIntExpression{${this.value}I}`;
     }
 
     static parseBAPIAsIRLiteralChkIntExpression(lexer: BAPILexer): IRLiteralChkIntExpression {
@@ -742,7 +742,7 @@ class IRLiteralChkIntExpression extends IRLiteralIntegralNumberExpression {
         const value = lexer.ensureAndConsumeToken(BAPITokenKind.ChkIntLiteral);
         lexer.ensureAndConsumeSymbol("}");
 
-        return new IRLiteralChkIntExpression(value);
+        return new IRLiteralChkIntExpression(value.slice(0, -1)); //remove the trailing 'I' from the literal
     }
 }
 
@@ -797,7 +797,7 @@ class IRLiteralFloatExpression extends IRLiteralFloatingPointExpression {
     }
 
     override toBAPI(): string {
-        return `Assembly::LiteralFloatExpression{${this.value}}`;
+        return `Assembly::LiteralFloatExpression{${this.value}f}`;
     }
 
     static parseBAPIAsIRLiteralFloatExpression(lexer: BAPILexer): IRLiteralFloatExpression {
@@ -806,7 +806,7 @@ class IRLiteralFloatExpression extends IRLiteralFloatingPointExpression {
         const value = lexer.ensureAndConsumeToken(BAPITokenKind.FloatLiteral);
         lexer.ensureAndConsumeSymbol("}");
 
-        return new IRLiteralFloatExpression(value);
+        return new IRLiteralFloatExpression(value.slice(0, -1)); //remove the trailing 'f' from the literal
     }
 }
 
@@ -816,12 +816,12 @@ class IRLiteralDecimalExpression extends IRLiteralFloatingPointExpression {
     }
 
     override toBAPI(): string {
-        return `Assembly::LiteralDecimalExpression{${this.value}}`;
+        return `Assembly::LiteralDecimalExpression{${this.value}d}`;
     }
 
     static parseBAPIAsIRLiteralDecimalExpression(lexer: BAPILexer): IRLiteralDecimalExpression {
         const value = lexer.ensureAndConsumeToken(BAPITokenKind.DecimalLiteral);
-        return new IRLiteralDecimalExpression(value);
+        return new IRLiteralDecimalExpression(value.slice(0, -1)); //remove the trailing 'd' from the literal
     }
 }
 

--- a/src/backend/irdefs/irbody.ts
+++ b/src/backend/irdefs/irbody.ts
@@ -820,7 +820,11 @@ class IRLiteralDecimalExpression extends IRLiteralFloatingPointExpression {
     }
 
     static parseBAPIAsIRLiteralDecimalExpression(lexer: BAPILexer): IRLiteralDecimalExpression {
+        lexer.ensureAndConsumeToken(BAPITokenKind.TypeIdentifier);
+        lexer.ensureAndConsumeSymbol("{");
         const value = lexer.ensureAndConsumeToken(BAPITokenKind.DecimalLiteral);
+        lexer.ensureAndConsumeSymbol("}");
+        
         return new IRLiteralDecimalExpression(value.slice(0, -1)); //remove the trailing 'd' from the literal
     }
 }

--- a/src/backend/irdefs/irtype.ts
+++ b/src/backend/irdefs/irtype.ts
@@ -20,34 +20,34 @@ abstract class IRTypeSignature {
             throw new Error(`Expected TypeIdentifier token but got ${tok.kind}`);
         }
 
-        if(tok.value === "Assembly::IRTypeSignatureVoid") {
+        if(tok.value === "Assembly::VoidTypeSignature") {
             return IRVoidTypeSignature.parseBAPIAsIRVoidTypeSignature(lexer);
         }
-        else if(tok.value === "Assembly::IRTypeSignatureNominal") {
+        else if(tok.value === "Assembly::NominalTypeSignature") {
             return IRNominalTypeSignature.parseBAPIAsIRNominalTypeSignature(lexer);
         }
-        else if(tok.value === "Assembly::IRTypeSignatureEList") {
+        else if(tok.value === "Assembly::EListTypeSignature") {
             return IREListTypeSignature.parseBAPIAsIREListTypeSignature(lexer);
         }
-        else if(tok.value === "Assembly::IRTypeSignatureDashResult") {
+        else if(tok.value === "Assembly::DashResultTypeSignature") {
             return IRDashResultTypeSignature.parseBAPIAsIRDashResultTypeSignature(lexer);
         }
-        else if(tok.value === "Assembly::IRFormatCStringTypeSignature") {
+        else if(tok.value === "Assembly::FormatCStringTypeSignature") {
             return IRFormatCStringTypeSignature.parseBAPIAsIRFormatCStringTypeSignature(lexer);
         }
-        else if(tok.value === "Assembly::IRFormatStringTypeSignature") {
+        else if(tok.value === "Assembly::FormatStringTypeSignature") {
             return IRFormatStringTypeSignature.parseBAPIAsIRFormatStringTypeSignature(lexer);
         }
-        else if(tok.value === "Assembly::IRFormatPathTypeSignature") {
+        else if(tok.value === "Assembly::FormatPathTypeSignature") {
             return IRFormatPathTypeSignature.parseBAPIAsIRFormatPathTypeSignature(lexer);
         }
-        else if(tok.value === "Assembly::IRFormatPathFragmentTypeSignature") {
+        else if(tok.value === "Assembly::FormatPathFragmentTypeSignature") {
             return IRFormatPathFragmentTypeSignature.parseBAPIAsIRFormatPathFragmentTypeSignature(lexer);
         }
-        else if(tok.value === "Assembly::IRFormatPathGlobTypeSignature") {
+        else if(tok.value === "Assembly::FormatPathGlobTypeSignature") {
             return IRFormatPathGlobTypeSignature.parseBAPIAsIRFormatPathGlobTypeSignature(lexer);
         }
-        else if(tok.value === "Assembly::IRLambdaParameterPackTypeSignature") {
+        else if(tok.value === "Assembly::LambdaParameterPackTypeSignature") {
             return IRLambdaParameterPackTypeSignature.parseBAPIAsIRLambdaParameterPackTypeSignature(lexer);
         }
         else {
@@ -66,7 +66,7 @@ class IRVoidTypeSignature extends IRTypeSignature {
     }
 
     override toBAPI(): string {
-        return `Assembly::IRTypeSignatureVoid{${emitTypeKey(this.tkeystr)}}`;
+        return `Assembly::VoidTypeSignature{${emitTypeKey(this.tkeystr)}}`;
     }
 
     static parseBAPIAsIRVoidTypeSignature(lexer: BAPILexer): IRVoidTypeSignature {
@@ -89,7 +89,7 @@ class IRNominalTypeSignature extends IRTypeSignature {
     }
 
     override toBAPI(): string {
-        return `Assembly::IRTypeSignatureNominal{${emitTypeKey(this.tkeystr)}}`;
+        return `Assembly::NominalTypeSignature{${emitTypeKey(this.tkeystr)}}`;
     }
 
     static parseBAPIAsIRNominalTypeSignature(lexer: BAPILexer): IRNominalTypeSignature {
@@ -115,7 +115,7 @@ class IREListTypeSignature extends IRTypeSignature {
     }
 
     override toBAPI(): string {
-        return `Assembly::IRTypeSignatureEList{${emitTypeKey(this.tkeystr)}, List<Assembly::IRTypeSignature>{${this.entries.map(e => e.toBAPI()).join(", ")}}}`;
+        return `Assembly::EListTypeSignature{${emitTypeKey(this.tkeystr)}, List<Assembly::IRTypeSignature>{${this.entries.map(e => e.toBAPI()).join(", ")}}}`;
     }
 
     static parseBAPIAsIREListTypeSignature(lexer: BAPILexer): IREListTypeSignature {
@@ -144,7 +144,7 @@ class IRDashResultTypeSignature extends IRTypeSignature {
     }
 
     override toBAPI(): string {
-        return `Assembly::IRTypeSignatureDashResult{'${this.tkeystr}'<Assembly::TypeKey>, List<Assembly::IRTypeSignature>{${this.entries.map(e => e.toBAPI()).join(", ")}}}`;
+        return `Assembly::DashResultTypeSignature{'${this.tkeystr}'<Assembly::TypeKey>, List<Assembly::IRTypeSignature>{${this.entries.map(e => e.toBAPI()).join(", ")}}}`;
     }
 
     static parseBAPIAsIRDashResultTypeSignature(lexer: BAPILexer): IRDashResultTypeSignature {
@@ -207,7 +207,7 @@ class IRFormatCStringTypeSignature extends IRFormatTypeSignature {
     }
 
     override toBAPI(): string {
-        return `Assembly::IRFormatCStringTypeSignature{${emitTypeKey(this.tkeystr)}, ${this.toBAPI_IRFormatTypeSignature()}}`;
+        return `Assembly::FormatCStringTypeSignature{${emitTypeKey(this.tkeystr)}, ${this.toBAPI_IRFormatTypeSignature()}}`;
     }
 
     static parseBAPIAsIRFormatCStringTypeSignature(lexer: BAPILexer): IRFormatCStringTypeSignature {
@@ -228,7 +228,7 @@ class IRFormatStringTypeSignature extends IRFormatTypeSignature {
     }
 
     override toBAPI(): string {
-        return `Assembly::IRFormatStringTypeSignature{${emitTypeKey(this.tkeystr)}, ${this.toBAPI_IRFormatTypeSignature()}}`;
+        return `Assembly::FormatStringTypeSignature{${emitTypeKey(this.tkeystr)}, ${this.toBAPI_IRFormatTypeSignature()}}`;
     }
 
     static parseBAPIAsIRFormatStringTypeSignature(lexer: BAPILexer): IRFormatStringTypeSignature {
@@ -295,7 +295,7 @@ class IRLambdaParameterPackTypeSignature extends IRTypeSignature {
     }
 
     override toBAPI(): string {
-        return `Assembly::IRLambdaParameterPackTypeSignature{${emitTypeKey(this.tkeystr)}}`;
+        return `Assembly::LambdaParameterPackTypeSignature{${emitTypeKey(this.tkeystr)}}`;
     }
 
     static parseBAPIAsIRLambdaParameterPackTypeSignature(lexer: BAPILexer): IRLambdaParameterPackTypeSignature {

--- a/src/backend/irdefs/irtype.ts
+++ b/src/backend/irdefs/irtype.ts
@@ -115,7 +115,7 @@ class IREListTypeSignature extends IRTypeSignature {
     }
 
     override toBAPI(): string {
-        return `Assembly::EListTypeSignature{${emitTypeKey(this.tkeystr)}, List<Assembly::IRTypeSignature>{${this.entries.map(e => e.toBAPI()).join(", ")}}}`;
+        return `Assembly::EListTypeSignature{${emitTypeKey(this.tkeystr)}, List<Assembly::TypeSignature>{${this.entries.map(e => e.toBAPI()).join(", ")}}}`;
     }
 
     static parseBAPIAsIREListTypeSignature(lexer: BAPILexer): IREListTypeSignature {
@@ -144,7 +144,7 @@ class IRDashResultTypeSignature extends IRTypeSignature {
     }
 
     override toBAPI(): string {
-        return `Assembly::DashResultTypeSignature{'${this.tkeystr}'<Assembly::TypeKey>, List<Assembly::IRTypeSignature>{${this.entries.map(e => e.toBAPI()).join(", ")}}}`;
+        return `Assembly::DashResultTypeSignature{'${this.tkeystr}'<Assembly::TypeKey>, List<Assembly::TypeSignature>{${this.entries.map(e => e.toBAPI()).join(", ")}}}`;
     }
 
     static parseBAPIAsIRDashResultTypeSignature(lexer: BAPILexer): IRDashResultTypeSignature {

--- a/src/bsqir/irassembly.bsq
+++ b/src/bsqir/irassembly.bsq
@@ -103,6 +103,7 @@ entity BapiAssembly {
     %%readonly agents: IRAgentDecl[] = [];
     %%readonly tasks: IRTaskDecl[] = [];
 
+    field alltypesigs: Map<TypeKey, TypeSignature>;
     field alltypes: Map<TypeKey, AbstractNominalTypeDecl>;
     %%readonly allinvokes: Map<string, IRInvokeMetaDecl> = new Map<string, IRInvokeMetaDecl>();
     %%readonly alllambdas: Map<string, IRLambdaParameterPackDecl> = new Map<string, IRLambdaParameterPackDecl>();

--- a/src/bsqir/irassembly.bsq
+++ b/src/bsqir/irassembly.bsq
@@ -60,8 +60,8 @@ datatype TypedeclTypeDecl provides AbstractEntityTypeDecl using {
 of
     TypedeclSimpleTypeDecl { }
     TypedeclBoundedTypeDecl { field rngchk: TypedeclRangeCheck; }
-    TypedeclCStringDecl { field rechk: Option<CString> = none; field rngchk: Option<TypedeclRangeCheck> = none; }
-    TypedeclStringDecl { field rechk: Option<String> = none; field rngchk: Option<TypedeclRangeCheck> = none; }
+    TypedeclCStringTypeDecl { field rechk: Option<CString> = none; field rngchk: Option<TypedeclRangeCheck> = none; }
+    TypedeclStringTypeDecl { field rechk: Option<String> = none; field rngchk: Option<TypedeclRangeCheck> = none; }
 ;
 
 %** This is the abstract type for internal entity type declarations **%
@@ -89,8 +89,8 @@ entity BapiAssembly {
     field enums: List<EnumTypeDecl>;
     field simpletypedecls: List<TypedeclSimpleTypeDecl>;
     field boundedtypedecls: List<TypedeclBoundedTypeDecl>;
-    field cstringoftypedecls: List<TypedeclCStringDecl>;
-    field stringoftypedecls: List<TypedeclStringDecl>;
+    field cstringoftypedecls: List<TypedeclCStringTypeDecl>;
+    field stringoftypedecls: List<TypedeclStringTypeDecl>;
 
     %%readonly entities: IREntityTypeDecl[] = [];
     %%readonly datamembers: IRDatatypeMemberEntityTypeDecl[] = [];
@@ -120,6 +120,4 @@ entity BapiAssembly {
 
     %%readonly typedeporder: IRTypeSignature[] = [];
     %%readonly typedepcycles: IRTypeSignature[][] = [];
-
-    field maxerrorid: Nat;
 }

--- a/src/bsqir/ittype.bsq
+++ b/src/bsqir/ittype.bsq
@@ -16,7 +16,7 @@ of
     FormatCStringTypeSignature { field rtype: TypeSignature; field terms: List<FormatTypeSignatureTerm>; }
     FormatStringTypeSignature { field rtype: TypeSignature; field terms: List<FormatTypeSignatureTerm>; }
     %% More Here -- see below
-    LambdaTypeSignature { }
+    LambdaParameterPackTypeSignature { }
 ;
 
 %*

--- a/src/core/core.bsq
+++ b/src/core/core.bsq
@@ -30,6 +30,10 @@ __internal __typedeclable __keycomparable __numeric entity Nat {
     const zero: Nat = 0n;
     const one: Nat = 1n;
 
+    function toCString(n: Nat): CString {
+        return NumericOps::s_natToCString(n);
+    }
+
     function square(x: Nat): Nat {
         return x * x;
     }
@@ -46,6 +50,10 @@ __internal __typedeclable __keycomparable __numeric entity Int {
 #else
     const zero: Int = 0i;
     const one: Int = 1i;
+
+    function toCString(i: Int): CString {
+        return NumericOps::s_intToCString(i);
+    }
 
     function square(x: Int): Int {
         return x * x;

--- a/src/core/list.bsq
+++ b/src/core/list.bsq
@@ -149,7 +149,7 @@ __internal entity List<T> {
             return ListOps::s_list_concat<T>(lists);
         }
     }
-%*
+
     method {when T: List<U>} flatten<U>(): List<U> {
         if(ListOps::s_list_empty<T>(this)) {
             return List<U>{};
@@ -158,7 +158,7 @@ __internal entity List<T> {
             return ListOps::s_list_concat<U>(this);
         }
     }
-*%
+
     recursive? method allOf(p: recursive? pred(T) -> Bool): Bool {
         if(ListOps::s_list_empty<T>(this)) {
             return true;

--- a/src/core/list.bsq
+++ b/src/core/list.bsq
@@ -132,6 +132,33 @@ __internal entity List<T> {
         }
     }
 
+    function concat(...lists: List<List<T>>): List<T> {
+        if(ListOps::s_list_empty<List<T>>(lists)) {
+            return List<T>{};
+        }
+        else {
+            return ListOps::s_list_concat<T>(lists);
+        }
+    }
+
+    function concatAll(lists: List<List<T>>): List<T> {
+        if(ListOps::s_list_empty<List<T>>(lists)) {
+            return List<T>{};
+        }
+        else {
+            return ListOps::s_list_concat<T>(lists);
+        }
+    }
+
+    method {when T: List<U>} flatten<U>(): List<U> {
+        if(ListOps::s_list_empty<T>(this)) {
+            return List<U>{};
+        }
+        else {
+            return ListOps::s_list_concat<T>(this);
+        }
+    }
+
     recursive? method allOf(p: recursive? pred(T) -> Bool): Bool {
         if(ListOps::s_list_empty<T>(this)) {
             return true;

--- a/src/core/list.bsq
+++ b/src/core/list.bsq
@@ -149,16 +149,16 @@ __internal entity List<T> {
             return ListOps::s_list_concat<T>(lists);
         }
     }
-
+%*
     method {when T: List<U>} flatten<U>(): List<U> {
         if(ListOps::s_list_empty<T>(this)) {
             return List<U>{};
         }
         else {
-            return ListOps::s_list_concat<T>(this);
+            return ListOps::s_list_concat<U>(this);
         }
     }
-
+*%
     recursive? method allOf(p: recursive? pred(T) -> Bool): Bool {
         if(ListOps::s_list_empty<T>(this)) {
             return true;

--- a/src/core/list.bsq
+++ b/src/core/list.bsq
@@ -202,7 +202,27 @@ __internal entity List<T> {
         else {
             return ListOps::s_list_mapidx[recursive?]<T, U>(this, f);
         }
-    }    
+    }
+
+    recursive? method flatmap<U>(f: recursive? fn(T) -> List<U>): List<U> {
+        if(ListOps::s_list_empty<T>(this)) {
+            return List<U>{};
+        }
+        else {
+            let ll = ListOps::s_list_map[recursive?]<T, List<U>>(this, f);
+            return ListOps::s_list_concat<U>(ll);
+        }
+    }
+
+    recursive? method flatmapIdx<U>(f: recursive? fn(T, Nat) -> List<U>): List<U> {
+        if(ListOps::s_list_empty<T>(this)) {
+            return List<U>{};
+        }
+        else {
+            let ll = ListOps::s_list_mapidx[recursive?]<T, List<U>>(this, f);
+            return ListOps::s_list_concat<U>(ll);
+        }
+    }
 
     method convert<U>(): List<U> {
         if(ListOps::s_list_empty<T>(this)) {

--- a/src/core/xcore_list_exec.bsq
+++ b/src/core/xcore_list_exec.bsq
@@ -25,6 +25,7 @@ namespace ListOps {
     function s_list_deleteback<T>(l: List<T>): List<T> = @list_deleteback;
 
     function s_list_append<T>(l1: List<T>, l2: List<T>): List<T> = @list_append;
+    function s_list_concat<T>(l: List<List<T>>): List<T> = @list_concat;
 
     recursive? function s_list_allof<T>(l: List<T>, p: recursive? pred(T) -> Bool): Bool = @list_allof;
     recursive? function s_list_noneof<T>(l: List<T>, p: recursive? pred(T) -> Bool): Bool = @list_noneof;

--- a/src/core/xcore_numeric_exec.bsq
+++ b/src/core/xcore_numeric_exec.bsq
@@ -4,8 +4,10 @@ namespace Core;
 #else
 #if EXEC_LIBS
 namespace NumericOps {
-    __may_fail function s_natPow(x: Nat, y: Nat): Nat = @nat_pow;
+    function s_natToCString(n: Nat): CString = @nat_to_cstring;
+    function s_intToCString(i: Int): CString = @int_to_cstring;
 
+    __may_fail function s_natPow(x: Nat, y: Nat): Nat = @nat_pow;
     __may_fail function s_intPow(x: Int, y: Int): Int = @int_pow;
 
     function s_safeConvertFloatInto<T: numeric>(f: Float): T = @float_safe_convert_into;

--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -2874,6 +2874,7 @@ class TypeChecker {
         exp.monoinvid = this.invidCtr++;
 
         const fullmapper = TemplateNameMapper.merge(mresolve.typeinfo.mapping, imapper);
+        this.checkTemplateBindingsOnInvokeConstraints(exp.sinfo, fullmapper, mresolve.member);
         const arginfo = this.checkArgumentList(exp.sinfo, env, refallowed, exp.args.args, mresolve.member.params, fullmapper);
 
         exp.iimapper = fullmapper;
@@ -3741,6 +3742,7 @@ class TypeChecker {
         exp.monoinvid = this.invidCtr++;
 
         const fullmapper = TemplateNameMapper.merge(mresolve.typeinfo.mapping, imapper);
+        this.checkTemplateBindingsOnInvokeConstraints(exp.sinfo, fullmapper, mresolve.member);
         const arginfo = this.checkArgumentList(exp.sinfo, env, false, exp.args.args, mresolve.member.params, fullmapper);
 
         exp.iimapper = fullmapper;

--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -823,11 +823,6 @@ class TypeChecker {
                 let cc = decl.termRestriction.clauses[i];
                 let trefine = tmap.resolveTemplateMapping(cc.t);
 
-                ////
-                //this.relations.isSubtypeOf(trefine, cc.subtype.remapTemplateBindings(tmap), this.constraints)
-                ////
-
-
                 if(cc.subtype !== undefined && !this.relations.areSameTypes(trefine, cc.subtype.remapTemplateBindings(tmap), this.constraints)) {
                     this.reportError(sinfo, `Template argument ${decl.terms[i].name} is not a subtype of subtype restriction`);
                     return undefined;

--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -823,7 +823,7 @@ class TypeChecker {
                 let cc = decl.termRestriction.clauses[i];
                 let trefine = tmap.resolveTemplateMapping(cc.t);
 
-                if(cc.subtype !== undefined && !this.relations.areSameTypes(trefine, cc.subtype.remapTemplateBindings(tmap), this.constraints)) {
+                if(cc.subtype !== undefined && !this.relations.isSubtypeOf(trefine, cc.subtype.remapTemplateBindings(tmap), this.constraints)) {
                     this.reportError(sinfo, `Template argument ${decl.terms[i].name} is not a subtype of subtype restriction`);
                     return undefined;
                 }

--- a/src/frontend/checker.ts
+++ b/src/frontend/checker.ts
@@ -772,7 +772,7 @@ class TypeChecker {
                     return ["err", new ErrorTypeSignature(rhsexp.sinfo, undefined)];
                 }
                 else {
-                    return this.relations.areSameTypes(rhs, lhs.alltermargs[0]) ? ["rhskeyeqoption", rhs] : ["err", new ErrorTypeSignature(rhsexp.sinfo, undefined)];
+                    return this.relations.areSameTypes(rhs, lhs.alltermargs[0], this.constraints) ? ["rhskeyeqoption", rhs] : ["err", new ErrorTypeSignature(rhsexp.sinfo, undefined)];
                 }
             }
         }
@@ -785,7 +785,7 @@ class TypeChecker {
                     return ["err", new ErrorTypeSignature(lhsexp.sinfo, undefined)];
                 }
                 else {
-                    return this.relations.areSameTypes(lhs, rhs.alltermargs[0]) ? ["lhskeyeqoption", lhs] : ["err", new ErrorTypeSignature(lhsexp.sinfo, undefined)];
+                    return this.relations.areSameTypes(lhs, rhs.alltermargs[0], this.constraints) ? ["lhskeyeqoption", lhs] : ["err", new ErrorTypeSignature(lhsexp.sinfo, undefined)];
                 }
             }
         }
@@ -794,7 +794,7 @@ class TypeChecker {
                 return ["err", new ErrorTypeSignature(rhsexp.sinfo, undefined)];
             }
             else {
-                return this.relations.areSameTypes(rhs, lhs.alltermargs[0]) ? ["rhskeyeqsome", rhs] : ["err", new ErrorTypeSignature(rhsexp.sinfo, undefined)];
+                return this.relations.areSameTypes(rhs, lhs.alltermargs[0], this.constraints) ? ["rhskeyeqsome", rhs] : ["err", new ErrorTypeSignature(rhsexp.sinfo, undefined)];
             }
         }
         else if(rhs.decl instanceof SomeTypeDecl) {
@@ -802,7 +802,7 @@ class TypeChecker {
                 return ["err", new ErrorTypeSignature(lhsexp.sinfo, undefined)];
             }
             else {
-                return this.relations.areSameTypes(lhs, rhs.alltermargs[0]) ? ["lhskeyeqsome", lhs] : ["err", new ErrorTypeSignature(lhsexp.sinfo, undefined)];
+                return this.relations.areSameTypes(lhs, rhs.alltermargs[0], this.constraints) ? ["lhskeyeqsome", lhs] : ["err", new ErrorTypeSignature(lhsexp.sinfo, undefined)];
             }
         }
         else {
@@ -810,7 +810,7 @@ class TypeChecker {
                 return ["err", new ErrorTypeSignature(lhsexp.sinfo, undefined)];
             }
 
-            return this.relations.areSameTypes(lhs, rhs) ? ["stricteq", lhs] : ["err", new ErrorTypeSignature(lhsexp.sinfo, undefined)];
+            return this.relations.areSameTypes(lhs, rhs, this.constraints) ? ["stricteq", lhs] : ["err", new ErrorTypeSignature(lhsexp.sinfo, undefined)];
 
         }
     }
@@ -823,7 +823,12 @@ class TypeChecker {
                 let cc = decl.termRestriction.clauses[i];
                 let trefine = tmap.resolveTemplateMapping(cc.t);
 
-                if(cc.subtype !== undefined && !this.relations.isSubtypeOf(trefine, cc.subtype.remapTemplateBindings(tmap), this.constraints)) {
+                ////
+                //this.relations.isSubtypeOf(trefine, cc.subtype.remapTemplateBindings(tmap), this.constraints)
+                ////
+
+
+                if(cc.subtype !== undefined && !this.relations.areSameTypes(trefine, cc.subtype.remapTemplateBindings(tmap), this.constraints)) {
                     this.reportError(sinfo, `Template argument ${decl.terms[i].name} is not a subtype of subtype restriction`);
                     return undefined;
                 }
@@ -978,7 +983,7 @@ class TypeChecker {
                 }
                 else {
                     const vtype = vinfo.decltype.remapTemplateBindings(imapper);
-                    this.checkError(arg.exp.sinfo, vinfo !== undefined && !this.relations.areSameTypes(vtype, ptype), `Variable ${vname} is not declared`);
+                    this.checkError(arg.exp.sinfo, vinfo !== undefined && !this.relations.areSameTypes(vtype, ptype, this.constraints), `Variable ${vname} is not declared`);
 
                     if(pkind === "out?") {
                         const badvkind = vinfo.vkind === "let" || vinfo.vkind === "ref";
@@ -1041,7 +1046,7 @@ class TypeChecker {
                 rtypes.push([true, argtype]);
 
                 const argetype = this.relations.getExpandoableOfType(argtype);
-                this.checkError(arg.exp.sinfo, argetype === undefined || !this.relations.areSameTypes(argetype, etype), `Rest argument ${i} expected to be container of type ${etype.emit()}`);
+                this.checkError(arg.exp.sinfo, argetype === undefined || !this.relations.areSameTypes(argetype, etype, this.constraints), `Rest argument ${i} expected to be container of type ${etype.emit()}`);
             }
         }
 
@@ -1618,7 +1623,7 @@ class TypeChecker {
                 uniquefmttypes.push(fmttypes[i]);
             }
             else {
-                this.checkError(sinfo, !this.relations.areSameTypes(mmtype.argtype, fmttypes[i].argtype), `Multiple format string arguments with name ${fmttypes[i].argname} must have the same type`);
+                this.checkError(sinfo, !this.relations.areSameTypes(mmtype.argtype, fmttypes[i].argtype, this.constraints), `Multiple format string arguments with name ${fmttypes[i].argname} must have the same type`);
             }
         }
 
@@ -1698,7 +1703,7 @@ class TypeChecker {
 
         const btype = this.relations.getTypeDeclValueType(exp.constype);
         const bvalue = this.checkExpression(env, exp.value, btype !== undefined ? new SimpleTypeInferContext(btype) : undefined);
-        this.checkError(exp.sinfo, !(bvalue instanceof ErrorTypeSignature) && btype !== undefined && !this.relations.areSameTypes(bvalue, btype), `Literal value is not the same type (${bvalue.emit()}) as the value type (${TypeChecker.safeTypePrint(btype)})`);
+        this.checkError(exp.sinfo, !(bvalue instanceof ErrorTypeSignature) && btype !== undefined && !this.relations.areSameTypes(bvalue, btype, this.constraints), `Literal value is not the same type (${bvalue.emit()}) as the value type (${TypeChecker.safeTypePrint(btype)})`);
 
         const tdecl = exp.constype.decl as TypedeclTypeDecl;
         if(tdecl.optsizerng !== undefined && exp.value instanceof LiteralSimpleExpression) {
@@ -1729,7 +1734,7 @@ class TypeChecker {
         }
 
         const btype = this.relations.getTypeDeclValueType(exp.constype);
-        if(btype === undefined || !this.relations.areSameTypes(btype, this.getWellKnownType("String"))) {
+        if(btype === undefined || !this.relations.areSameTypes(btype, this.getWellKnownType("String"), this.constraints)) {
             this.reportError(exp.sinfo, `Typed string literal type must have base type String -- ${exp.constype.emit()}`);
             return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
         }
@@ -1753,7 +1758,7 @@ class TypeChecker {
         }
 
         const btype = this.relations.getTypeDeclValueType(exp.constype);
-        if(btype === undefined || !this.relations.areSameTypes(btype, this.getWellKnownType("CString"))) {
+        if(btype === undefined || !this.relations.areSameTypes(btype, this.getWellKnownType("CString"), this.constraints)) {
             this.reportError(exp.sinfo, `Typed cstring literal type must have base type CString -- ${exp.constype.emit()}`);
             return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
         }
@@ -1777,7 +1782,7 @@ class TypeChecker {
         }
 
         const btype = this.relations.getTypeDeclValueType(exp.constype);
-        if(!this.relations.areSameTypes(exp.constype, this.getWellKnownType("String")) && (btype === undefined || !this.relations.areSameTypes(btype, this.getWellKnownType("String")))) {
+        if(!this.relations.areSameTypes(exp.constype, this.getWellKnownType("String"), this.constraints) && (btype === undefined || !this.relations.areSameTypes(btype, this.getWellKnownType("String"), this.constraints))) {
             this.reportError(exp.sinfo, `Typed format string type must have base type String -- ${exp.constype.emit()}`);
             return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
         }
@@ -1798,7 +1803,7 @@ class TypeChecker {
         }
 
         const btype = this.relations.getTypeDeclValueType(exp.constype);
-        if(!this.relations.areSameTypes(exp.constype, this.getWellKnownType("CString")) && (btype === undefined || !this.relations.areSameTypes(btype, this.getWellKnownType("CString")))) {
+        if(!this.relations.areSameTypes(exp.constype, this.getWellKnownType("CString"), this.constraints) && (btype === undefined || !this.relations.areSameTypes(btype, this.getWellKnownType("CString"), this.constraints))) {
             this.reportError(exp.sinfo, `Typed format cstring type must have base type CString -- ${exp.constype.emit()}`);
             return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
         }
@@ -1967,7 +1972,7 @@ class TypeChecker {
             else {
                 const argtype = this.checkExpression(env, arg.exp, undefined);
                 const argetype = this.relations.getExpandoableOfType(argtype);
-                this.checkError(arg.exp.sinfo, argetype === undefined || !this.relations.areSameTypes(argetype, etype), `Spread argument ${i} expected to be container of type ${etype.emit()}`);
+                this.checkError(arg.exp.sinfo, argetype === undefined || !this.relations.areSameTypes(argetype, etype, this.constraints), `Spread argument ${i} expected to be container of type ${etype.emit()}`);
             }
         }
 
@@ -2095,7 +2100,7 @@ class TypeChecker {
             const vtype = this.relations.getTypeDeclValueType(ctype);
             if(vtype !== undefined) {
                 const etype = this.checkExpression(env, exp.args.args[0].exp, new SimpleTypeInferContext(vtype));
-                this.checkError(exp.sinfo, (etype instanceof ErrorTypeSignature) || !(this.relations.areSameTypes(etype, vtype)), `${etype.emit()} constructor argument is not compatible with ${vtype.emit()}`);
+                this.checkError(exp.sinfo, (etype instanceof ErrorTypeSignature) || !(this.relations.areSameTypes(etype, vtype, this.constraints)), `${etype.emit()} constructor argument is not compatible with ${vtype.emit()}`);
             }
         }
         
@@ -2529,10 +2534,10 @@ class TypeChecker {
 
             if(etype instanceof NominalTypeSignature) {
                 if(etype.decl instanceof PrimitiveEntityTypeDecl) {
-                    this.checkError(exp.sinfo, !this.relations.areSameTypes((fdecl.typeinfo.tsig.decl as TypedeclTypeDecl).valuetype, etype), `Invalid arg type for conversion from ${etype.emit()} -- converting to ${fdecl.typeinfo.tsig.emit()}`);
+                    this.checkError(exp.sinfo, !this.relations.areSameTypes((fdecl.typeinfo.tsig.decl as TypedeclTypeDecl).valuetype, etype, this.constraints), `Invalid arg type for conversion from ${etype.emit()} -- converting to ${fdecl.typeinfo.tsig.emit()}`);
                 }
                 else if(etype.decl instanceof TypedeclTypeDecl) {
-                    this.checkError(exp.sinfo, !this.relations.areSameTypes((fdecl.typeinfo.tsig.decl as TypedeclTypeDecl).valuetype, (etype.decl as TypedeclTypeDecl).valuetype), `Invalid arg type for conversion from ${etype.emit()} -- converting to ${fdecl.typeinfo.tsig.emit()}`);
+                    this.checkError(exp.sinfo, !this.relations.areSameTypes((fdecl.typeinfo.tsig.decl as TypedeclTypeDecl).valuetype, (etype.decl as TypedeclTypeDecl).valuetype, this.constraints), `Invalid arg type for conversion from ${etype.emit()} -- converting to ${fdecl.typeinfo.tsig.emit()}`);
                 }
                 else {
                     this.reportError(exp.sinfo, `Invalid arg type for conversion from ${etype.emit()} -- converting to ${fdecl.typeinfo.tsig.emit()}`);
@@ -3121,7 +3126,7 @@ class TypeChecker {
             return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
         }
         
-        if(this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs), "Addition operator requires 2 arguments of the same type")) {
+        if(this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs, this.constraints), "Addition operator requires 2 arguments of the same type")) {
             return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
         }
 
@@ -3135,7 +3140,7 @@ class TypeChecker {
             return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
         }
 
-        if(this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs), "Subtraction operator requires 2 arguments of the same type")) {
+        if(this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs, this.constraints), "Subtraction operator requires 2 arguments of the same type")) {
             return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
         }
 
@@ -3151,21 +3156,21 @@ class TypeChecker {
 
         let res: TypeSignature;
         if(this.relations.isPrimitiveType(tlhs) && this.relations.isPrimitiveType(trhs)) {
-            if(this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs), "Multiplication operator requires 2 arguments of the same type")) {
+            if(this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs, this.constraints), "Multiplication operator requires 2 arguments of the same type")) {
                 return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
             }
             res = tlhs;
         }
         else if(this.relations.isTypeDeclType(tlhs) && this.relations.isPrimitiveType(trhs)) {
             const baselhs = this.relations.getTypeDeclValueType(tlhs);
-            if(this.checkError(exp.sinfo, baselhs === undefined || !this.relations.areSameTypes(baselhs, trhs), "Multiplication operator requires a unit-less argument that matches underlying unit type")) {
+            if(this.checkError(exp.sinfo, baselhs === undefined || !this.relations.areSameTypes(baselhs, trhs, this.constraints), "Multiplication operator requires a unit-less argument that matches underlying unit type")) {
                 return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
             }
             res = tlhs
         }
         else if(this.relations.isPrimitiveType(tlhs) && this.relations.isTypeDeclType(trhs)) {
             const baserhs = this.relations.getTypeDeclValueType(trhs);
-            if(this.checkError(exp.sinfo, baserhs === undefined || !this.relations.areSameTypes(tlhs, baserhs), "Multiplication operator requires a unit-less argument that matches underlying unit type")) {
+            if(this.checkError(exp.sinfo, baserhs === undefined || !this.relations.areSameTypes(tlhs, baserhs, this.constraints), "Multiplication operator requires a unit-less argument that matches underlying unit type")) {
                 return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
             }
             res = trhs;
@@ -3187,20 +3192,20 @@ class TypeChecker {
 
         let res: TypeSignature;
         if(this.relations.isPrimitiveType(tlhs) && this.relations.isPrimitiveType(trhs)) {
-            if(this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs), "Division operator requires 2 arguments of the same type")) {
+            if(this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs, this.constraints), "Division operator requires 2 arguments of the same type")) {
                 return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
             }
             res = tlhs;
         }
         else if(this.relations.isTypeDeclType(tlhs) && this.relations.isPrimitiveType(trhs)) {
             const baselhs = this.relations.getTypeDeclValueType(tlhs);
-            if(this.checkError(exp.sinfo, baselhs === undefined || !this.relations.areSameTypes(baselhs, trhs), "Division operator requires a unit-less divisor argument that matches the underlying unit type")) {
+            if(this.checkError(exp.sinfo, baselhs === undefined || !this.relations.areSameTypes(baselhs, trhs, this.constraints), "Division operator requires a unit-less divisor argument that matches the underlying unit type")) {
                 return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
             }
             res = tlhs
         }
         else if(this.relations.isTypeDeclType(tlhs) && this.relations.isTypeDeclType(trhs)) {
-            if(this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs), "Division operator requires 2 arguments of the same type")) {
+            if(this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs, this.constraints), "Division operator requires 2 arguments of the same type")) {
                 return exp.setType(new ErrorTypeSignature(exp.sinfo, undefined));
             }
             const basetype = this.relations.getTypeDeclValueType(trhs);
@@ -3265,8 +3270,8 @@ class TypeChecker {
         const trhs = this.checkExpression(env, exp.rhs, ktypeok ? exp.ktype : undefined);
 
         if(ktypeok) {
-            this.checkError(exp.sinfo, !this.relations.isKeyType(tlhs, this.constraints) || !this.relations.areSameTypes(tlhs, exp.ktype), `Type ${tlhs.emit()} is not a (keytype) of ${exp.ktype.emit()}`);
-            this.checkError(exp.sinfo, !this.relations.isKeyType(trhs, this.constraints) || !this.relations.areSameTypes(trhs, exp.ktype), `Type ${trhs.emit()} is not a (keytype) of ${exp.ktype.emit()}`);
+            this.checkError(exp.sinfo, !this.relations.isKeyType(tlhs, this.constraints) || !this.relations.areSameTypes(tlhs, exp.ktype, this.constraints), `Type ${tlhs.emit()} is not a (keytype) of ${exp.ktype.emit()}`);
+            this.checkError(exp.sinfo, !this.relations.isKeyType(trhs, this.constraints) || !this.relations.areSameTypes(trhs, exp.ktype, this.constraints), `Type ${trhs.emit()} is not a (keytype) of ${exp.ktype.emit()}`);
         
             exp.optype = this.resolveUnderlyingType(exp.ktype);
         }
@@ -3281,8 +3286,8 @@ class TypeChecker {
         const trhs = this.checkExpression(env, exp.rhs, ktypeok ? exp.ktype : undefined);
 
         if(ktypeok) {
-            this.checkError(exp.sinfo, !this.relations.isKeyType(tlhs, this.constraints) || !this.relations.areSameTypes(tlhs, exp.ktype), `Type ${tlhs.emit()} is not a (keytype) of ${exp.ktype.emit()}`);
-            this.checkError(exp.sinfo, !this.relations.isKeyType(trhs, this.constraints) || !this.relations.areSameTypes(trhs, exp.ktype), `Type ${trhs.emit()} is not a (keytype) of ${exp.ktype.emit()}`);
+            this.checkError(exp.sinfo, !this.relations.isKeyType(tlhs, this.constraints) || !this.relations.areSameTypes(tlhs, exp.ktype, this.constraints), `Type ${tlhs.emit()} is not a (keytype) of ${exp.ktype.emit()}`);
+            this.checkError(exp.sinfo, !this.relations.isKeyType(trhs, this.constraints) || !this.relations.areSameTypes(trhs, exp.ktype, this.constraints), `Type ${trhs.emit()} is not a (keytype) of ${exp.ktype.emit()}`);
 
             exp.optype = this.resolveUnderlyingType(exp.ktype);
         }
@@ -3296,7 +3301,7 @@ class TypeChecker {
             return exp.setType(this.getWellKnownType("Bool"));
         }
 
-        this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs), "Operator == requires 2 arguments of the same type");
+        this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs, this.constraints), "Operator == requires 2 arguments of the same type");
         
         exp.opertype = this.resolveUnderlyingType(tlhs);
         return exp.setType(this.getWellKnownType("Bool"));
@@ -3308,7 +3313,7 @@ class TypeChecker {
             return exp.setType(this.getWellKnownType("Bool"));
         }
 
-        this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs), "Operator != requires 2 arguments of the same type");
+        this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs, this.constraints), "Operator != requires 2 arguments of the same type");
         
         exp.opertype = this.resolveUnderlyingType(tlhs);
         return exp.setType(this.getWellKnownType("Bool"));
@@ -3320,7 +3325,7 @@ class TypeChecker {
             return exp.setType(this.getWellKnownType("Bool"));
         }
 
-        this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs), "Operator < requires 2 arguments of the same type");
+        this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs, this.constraints), "Operator < requires 2 arguments of the same type");
         
         exp.opertype = this.resolveUnderlyingType(tlhs);
         return exp.setType(this.getWellKnownType("Bool"));
@@ -3332,7 +3337,7 @@ class TypeChecker {
             return exp.setType(this.getWellKnownType("Bool"));
         }
 
-        this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs), "Operator <= requires 2 arguments of the same type");
+        this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs, this.constraints), "Operator <= requires 2 arguments of the same type");
         
         exp.opertype = this.resolveUnderlyingType(tlhs);
         return exp.setType(this.getWellKnownType("Bool"));
@@ -3344,7 +3349,7 @@ class TypeChecker {
             return exp.setType(this.getWellKnownType("Bool"));
         }
 
-        this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs), "Operator > requires 2 arguments of the same type");
+        this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs, this.constraints), "Operator > requires 2 arguments of the same type");
         
         exp.opertype = this.resolveUnderlyingType(tlhs);
         return exp.setType(this.getWellKnownType("Bool"));
@@ -3356,7 +3361,7 @@ class TypeChecker {
             return exp.setType(this.getWellKnownType("Bool"));
         }
 
-        this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs), "Operator >= requires 2 arguments of the same type");
+        this.checkError(exp.sinfo, !this.relations.areSameTypes(tlhs, trhs, this.constraints), "Operator >= requires 2 arguments of the same type");
         
         exp.opertype = this.resolveUnderlyingType(tlhs);
         return exp.setType(this.getWellKnownType("Bool"));
@@ -3767,7 +3772,7 @@ class TypeChecker {
             }
         }
 
-        this.checkError(exp.sinfo, !this.relations.areSameTypes(exp.resolvedDeclType, rcvrtype), `Receiver type ${rcvrtype.emit()} does not match method declaration receiver type ${exp.resolvedDeclType.emit()}`);
+        this.checkError(exp.sinfo, !this.relations.areSameTypes(exp.resolvedDeclType, rcvrtype, this.constraints), `Receiver type ${rcvrtype.emit()} does not match method declaration receiver type ${exp.resolvedDeclType.emit()}`);
 
         exp.shuffleinfo = arginfo.shuffleinfo;
         exp.resttype = arginfo.resttype;

--- a/src/frontend/checker_relations.ts
+++ b/src/frontend/checker_relations.ts
@@ -128,10 +128,11 @@ class TypeCheckerRelations {
 
     private isUniqueForSameTypesWithTemplateResolve(t: TypeSignature): boolean {
         if(t instanceof NominalTypeSignature) {
-            //Atomic types are unique and datatypes are closed on extensibility so subtyping is ok for disjointness there too
-            return (t.decl instanceof AbstractEntityTypeDecl) || (t.decl instanceof DatatypeTypeDecl);
+            //Entity types are unique and not subtypeable so they are ok for same type checks
+            return (t.decl instanceof AbstractEntityTypeDecl);
         }
         else {
+            //Other types are also not subtypeable so they are ok for same type checks
             return true;
         }
     }
@@ -152,7 +153,20 @@ class TypeCheckerRelations {
             res = true;
         }
         else if(t1 instanceof TemplateTypeSignature && t2 instanceof TemplateTypeSignature) {
-            res = (t1.name === t2.name);
+            if(t1.name === t2.name) {
+                res = true;
+            }
+            else {
+                const const1 = tconstrain.resolveConstraint(t1.name);
+                const const2 = tconstrain.resolveConstraint(t2.name);
+
+                if(const1 !== undefined && const1.tconstraint !== undefined && const2 !== undefined && const2.tconstraint !== undefined) {
+                    res = this.isUniqueForSameTypesWithTemplateResolve(const1.tconstraint) && this.isUniqueForSameTypesWithTemplateResolve(const2.tconstraint) && this.areSameTypes(const1.tconstraint, const2.tconstraint, tconstrain);
+                } 
+                else {
+                    ; //for all other cases res stays false
+                }
+            }
         }
         else if(t1 instanceof NominalTypeSignature && t2 instanceof NominalTypeSignature) {
             res = (t1.decl === t2.decl) && this.areSameTypeSignatureLists(t1.alltermargs, t2.alltermargs, tconstrain);
@@ -183,11 +197,11 @@ class TypeCheckerRelations {
         else {
             if(t1 instanceof TemplateTypeSignature) {
                 const cons = tconstrain.resolveConstraint(t1.name);
-                return cons !== undefined && cons.tconstraint !== undefined && this.isUniqueForSameTypesWithTemplateResolve(cons.tconstraint) && this.areSameTypes(cons.tconstraint, t2, tconstrain); 
+                res = cons !== undefined && cons.tconstraint !== undefined && this.isUniqueForSameTypesWithTemplateResolve(cons.tconstraint) && this.areSameTypes(cons.tconstraint, t2, tconstrain); 
             }
             else if (t2 instanceof TemplateTypeSignature) {
                 const cons = tconstrain.resolveConstraint(t2.name);
-                return cons !== undefined && cons.tconstraint !== undefined && this.isUniqueForSameTypesWithTemplateResolve(cons.tconstraint) && this.areSameTypes(t1, cons.tconstraint, tconstrain);
+                res = cons !== undefined && cons.tconstraint !== undefined && this.isUniqueForSameTypesWithTemplateResolve(cons.tconstraint) && this.areSameTypes(t1, cons.tconstraint, tconstrain);
             }
             else {
                 ; //for all other cases res stays false

--- a/src/frontend/checker_relations.ts
+++ b/src/frontend/checker_relations.ts
@@ -77,13 +77,13 @@ class TypeCheckerRelations {
         return pdecls;
     }
 
-    private areSameTypeSignatureLists(tl1: TypeSignature[], tl2: TypeSignature[]): boolean {
+    private areSameTypeSignatureLists(tl1: TypeSignature[], tl2: TypeSignature[], tconstrain: TemplateConstraintScope): boolean {
         if(tl1.length !== tl2.length) {
             return false;
         }
 
         for(let i = 0; i < tl1.length; ++i) {
-            if(!this.areSameTypes(tl1[i], tl2[i])) {
+            if(!this.areSameTypes(tl1[i], tl2[i], tconstrain)) {
                 return false;
             }
         }
@@ -91,7 +91,7 @@ class TypeCheckerRelations {
         return true;
     }
 
-    private areSameFunctionParamLists(tl1: LambdaParameterSignature[], tl2: LambdaParameterSignature[]): boolean {
+    private areSameFunctionParamLists(tl1: LambdaParameterSignature[], tl2: LambdaParameterSignature[], tconstrain: TemplateConstraintScope): boolean {
         if(tl1.length !== tl2.length) {
             return false;
         }
@@ -101,7 +101,7 @@ class TypeCheckerRelations {
                 return false;
             }
             
-            if(!this.areSameTypes(tl1[i].type, tl2[i].type)) {
+            if(!this.areSameTypes(tl1[i].type, tl2[i].type, tconstrain)) {
                 return false;
             }
         }
@@ -109,7 +109,7 @@ class TypeCheckerRelations {
         return true;
     }
 
-    private areSameFunctionFormatLists(tl1: {argname: string, argtype: TypeSignature}[], tl2: {argname: string, argtype: TypeSignature}[]): boolean {
+    private areSameFunctionFormatLists(tl1: {argname: string, argtype: TypeSignature}[], tl2: {argname: string, argtype: TypeSignature}[], tconstrain: TemplateConstraintScope): boolean {
         if(tl1.length !== tl2.length) {
             return false;
         }
@@ -118,7 +118,7 @@ class TypeCheckerRelations {
             const a1 = tl1[i];
             const a2 = tl2.find((a) => a.argname === a1.argname);
 
-            if(a2 === undefined || !this.areSameTypes(a1.argtype, a2.argtype)) {
+            if(a2 === undefined || !this.areSameTypes(a1.argtype, a2.argtype, tconstrain)) {
                 return false;
             }
         }
@@ -126,8 +126,18 @@ class TypeCheckerRelations {
         return true;
     }
 
+    private isUniqueForSameTypesWithTemplateResolve(t: TypeSignature): boolean {
+        if(t instanceof NominalTypeSignature) {
+            //Atomic types are unique and datatypes are closed on extensibility so subtyping is ok for disjointness there too
+            return (t.decl instanceof AbstractEntityTypeDecl) || (t.decl instanceof DatatypeTypeDecl);
+        }
+        else {
+            return true;
+        }
+    }
+
     //Check if t1 and t2 are the same type -- template types are not expanded in this check
-    areSameTypes(t1: TypeSignature, t2: TypeSignature): boolean {
+    areSameTypes(t1: TypeSignature, t2: TypeSignature, tconstrain: TemplateConstraintScope): boolean {
         assert(!(t1 instanceof ErrorTypeSignature) && !(t2 instanceof ErrorTypeSignature), "Checking type same on errors");
         assert(!(t1 instanceof AutoTypeSignature) && !(t2 instanceof AutoTypeSignature), "Checking type same on auto");
 
@@ -145,34 +155,39 @@ class TypeCheckerRelations {
             res = (t1.name === t2.name);
         }
         else if(t1 instanceof NominalTypeSignature && t2 instanceof NominalTypeSignature) {
-            res = (t1.decl === t2.decl) && this.areSameTypeSignatureLists(t1.alltermargs, t2.alltermargs);
+            res = (t1.decl === t2.decl) && this.areSameTypeSignatureLists(t1.alltermargs, t2.alltermargs, tconstrain);
         }
         else if(t1 instanceof EListTypeSignature && t2 instanceof EListTypeSignature) {
-            res = this.areSameTypeSignatureLists(t1.entries, t2.entries);
+            res = this.areSameTypeSignatureLists(t1.entries, t2.entries, tconstrain);
         }
         else if(t1 instanceof DashResultTypeSignature && t2 instanceof DashResultTypeSignature) {
-            res = this.areSameTypeSignatureLists(t1.entries, t2.entries);
+            res = this.areSameTypeSignatureLists(t1.entries, t2.entries, tconstrain);
         }
         else if(t1 instanceof FormatStringTypeSignature && t2 instanceof FormatStringTypeSignature) {
-            res = (t1.oftype === t2.oftype) && this.areSameTypes(t1.rtype, t2.rtype) && this.areSameFunctionFormatLists(t1.terms, t2.terms);
+            res = (t1.oftype === t2.oftype) && this.areSameTypes(t1.rtype, t2.rtype, tconstrain) && this.areSameFunctionFormatLists(t1.terms, t2.terms, tconstrain);
         }
         else if(t1 instanceof FormatPathTypeSignature && t2 instanceof FormatPathTypeSignature) {
-            res = (t1.oftype === t2.oftype) && this.areSameTypes(t1.rtype, t2.rtype) && this.areSameFunctionFormatLists(t1.terms, t2.terms);
+            res = (t1.oftype === t2.oftype) && this.areSameTypes(t1.rtype, t2.rtype, tconstrain) && this.areSameFunctionFormatLists(t1.terms, t2.terms, tconstrain);
         }
         else if(t1 instanceof LambdaTypeSignature && t2 instanceof LambdaTypeSignature) {
             if(t1.name !== t2.name) {
                 res = false;
             }
             else {
-                const okargs = this.areSameFunctionParamLists(t1.params, t2.params);
-                const okres = this.areSameTypes(t1.resultType, t2.resultType);
+                const okargs = this.areSameFunctionParamLists(t1.params, t2.params, tconstrain);
+                const okres = this.areSameTypes(t1.resultType, t2.resultType, tconstrain);
 
                 res = okargs && okres;
             }
         }
         else {
-            if(t1 instanceof TemplateTypeSignature || t2 instanceof TemplateTypeSignature) {
-                ;
+            if(t1 instanceof TemplateTypeSignature) {
+                const cons = tconstrain.resolveConstraint(t1.name);
+                return cons !== undefined && cons.tconstraint !== undefined && this.isUniqueForSameTypesWithTemplateResolve(cons.tconstraint) && this.areSameTypes(cons.tconstraint, t2, tconstrain); 
+            }
+            else if (t2 instanceof TemplateTypeSignature) {
+                const cons = tconstrain.resolveConstraint(t2.name);
+                return cons !== undefined && cons.tconstraint !== undefined && this.isUniqueForSameTypesWithTemplateResolve(cons.tconstraint) && this.areSameTypes(t1, cons.tconstraint, tconstrain);
             }
             else {
                 ; //for all other cases res stays false
@@ -214,7 +229,7 @@ class TypeCheckerRelations {
         }
 
         let res = false;
-        if(this.areSameTypes(t1, t2)) {
+        if(this.areSameTypes(t1, t2, tconstrain)) {
             res = true;
         }
         else {
@@ -273,7 +288,7 @@ class TypeCheckerRelations {
             //check for special case of Ok+Err -> Result
             const okopt = ptl.find((t) => t.decl instanceof OkTypeDecl);
             const erropt = ptl.find((t) => t.decl instanceof FailTypeDecl);
-            if(okopt && erropt && this.areSameTypeSignatureLists(okopt.alltermargs, erropt.alltermargs)) {
+            if(okopt && erropt && this.areSameTypeSignatureLists(okopt.alltermargs, erropt.alltermargs, tconstrain)) {
                 return new NominalTypeSignature(sinfo, undefined, corens.typedecls.find((tdecl) => tdecl.name === "Result") as ResultTypeDecl, okopt.alltermargs);
             }
         }
@@ -601,7 +616,7 @@ class TypeCheckerRelations {
             if((t.decl instanceof SomeTypeDecl) || (t.decl instanceof OptionTypeDecl)) {
                 const topt = t.alltermargs[0];
 
-                if(someT !== undefined && !this.areSameTypes(someT, topt)) {
+                if(someT !== undefined && !this.areSameTypes(someT, topt, tconstrain)) {
                     return undefined;
                 }
                 someT = topt;
@@ -637,7 +652,7 @@ class TypeCheckerRelations {
             if((t.decl instanceof SomeTypeDecl) || (t.decl instanceof OptionTypeDecl)) {
                 const topt = t.alltermargs[0];
 
-                if(someT !== undefined && !this.areSameTypes(someT, topt)) {
+                if(someT !== undefined && !this.areSameTypes(someT, topt, tconstrain)) {
                     return undefined;
                 }
                 someT = topt;
@@ -673,12 +688,12 @@ class TypeCheckerRelations {
             const topt = t.alltermargs[0];
             const eopt = t.alltermargs[1];
 
-            if(typeT !== undefined && !this.areSameTypes(typeT, topt)) {
+            if(typeT !== undefined && !this.areSameTypes(typeT, topt, tconstrain)) {
                 return undefined;
             }
             typeT = topt;
 
-            if(typeE !== undefined && !this.areSameTypes(typeE, eopt)) {
+            if(typeE !== undefined && !this.areSameTypes(typeE, eopt, tconstrain)) {
                 return undefined;
             }
             typeE = eopt;
@@ -724,12 +739,12 @@ class TypeCheckerRelations {
             const topt = t.alltermargs[0];
             const eopt = t.alltermargs[1];
 
-            if(typeT !== undefined && !this.areSameTypes(typeT, topt)) {
+            if(typeT !== undefined && !this.areSameTypes(typeT, topt, tconstrain)) {
                 return undefined;
             }
             typeT = topt;
 
-            if(typeE !== undefined && !this.areSameTypes(typeE, eopt)) {
+            if(typeE !== undefined && !this.areSameTypes(typeE, eopt, tconstrain)) {
                 return undefined;
             }
             typeE = eopt;

--- a/src/frontend/checker_relations.ts
+++ b/src/frontend/checker_relations.ts
@@ -171,10 +171,18 @@ class TypeCheckerRelations {
             }
         }
         else {
-            ; //for all other cases res stays false
+            if(t1 instanceof TemplateTypeSignature || t2 instanceof TemplateTypeSignature) {
+                ;
+            }
+            else {
+                ; //for all other cases res stays false
+            }
         }
 
-        this.memoizedTypeEqualRelation.set(kstr, res);
+        if(!t1.hasTemplateBindings() && !t2.hasTemplateBindings()) {
+            this.memoizedTypeEqualRelation.set(kstr, res);
+        }
+
         return res;
     }
 
@@ -221,7 +229,10 @@ class TypeCheckerRelations {
             }
         }
 
-        this.memoizedTypeSubtypeRelation.set(kstr, res);
+        if(!t1.hasTemplateBindings() && !t2.hasTemplateBindings()) {
+            this.memoizedTypeSubtypeRelation.set(kstr, res);
+        }
+
         return res;
     }
 

--- a/src/frontend/type.ts
+++ b/src/frontend/type.ts
@@ -442,7 +442,7 @@ class LambdaTypeSignature extends TypeSignature {
     readonly resultType: TypeSignature;
 
     constructor(sinfo: SourceInfo, recursive: RecursiveAnnotation, name: "fn" | "pred", params: LambdaParameterSignature[], resultType: TypeSignature) {
-        super(sinfo, `${recursive === "yes" ? "rec " : ""}${name}(${params.map((pp) => pp.emit()).join(", ")}): ${resultType.tkeystr}`);
+        super(sinfo, `${name}(${params.map((pp) => pp.emit()).join(", ")}): ${resultType.tkeystr}`);
         this.recursive = recursive;
         this.name = name;
         this.params = params;

--- a/src/frontend/type.ts
+++ b/src/frontend/type.ts
@@ -194,6 +194,7 @@ abstract class TypeSignature {
         this.tkeystr = tkeystr;
     }
 
+    abstract hasTemplateBindings(): boolean;
     abstract remapTemplateBindings(mapper: TemplateNameMapper): TypeSignature;
     abstract gatherTemplateBindings(tnames: Set<string>): void;
 
@@ -207,6 +208,10 @@ class ErrorTypeSignature extends TypeSignature {
         super(sinfo, "^error^");
 
         this.completionNamespace = completionNamespace;
+    }
+
+    hasTemplateBindings(): boolean {
+        return false;
     }
 
     remapTemplateBindings(mapper: TemplateNameMapper): TypeSignature {
@@ -227,6 +232,10 @@ class VoidTypeSignature extends TypeSignature {
         super(sinfo, "Void");
     }
 
+    hasTemplateBindings(): boolean {
+        return false;
+    }
+
     remapTemplateBindings(mapper: TemplateNameMapper): TypeSignature {
         return this;
     }
@@ -243,6 +252,10 @@ class VoidTypeSignature extends TypeSignature {
 class AutoTypeSignature extends TypeSignature {
     constructor(sinfo: SourceInfo) {
         super(sinfo, "^auto^");
+    }
+
+    hasTemplateBindings(): boolean {
+        return false;
     }
 
     remapTemplateBindings(mapper: TemplateNameMapper): TypeSignature {
@@ -264,6 +277,10 @@ class TemplateTypeSignature extends TypeSignature {
     constructor(sinfo: SourceInfo, name: string) {
         super(sinfo, name);
         this.name = name;
+    }
+
+    hasTemplateBindings(): boolean {
+        return true;
     }
 
     remapTemplateBindings(mapper: TemplateNameMapper): TypeSignature {
@@ -312,6 +329,10 @@ class NominalTypeSignature extends TypeSignature {
         this.altns = altns;
     }
 
+    hasTemplateBindings(): boolean {
+        return this.alltermargs.some((tt) => tt.hasTemplateBindings());
+    }
+
     remapTemplateBindings(mapper: TemplateNameMapper): TypeSignature {
         const rtall = this.alltermargs.map((tt) => tt.remapTemplateBindings(mapper));
 
@@ -352,6 +373,10 @@ class EListTypeSignature extends TypeSignature {
         this.entries = entries;
     }
 
+    hasTemplateBindings(): boolean {
+        return this.entries.some((tt) => tt.hasTemplateBindings());
+    }
+
     remapTemplateBindings(mapper: TemplateNameMapper): TypeSignature {
         return new EListTypeSignature(this.sinfo, this.entries.map((tt) => tt.remapTemplateBindings(mapper)));
     }
@@ -371,6 +396,10 @@ class DashResultTypeSignature extends TypeSignature {
     constructor(sinfo: SourceInfo, entries: TypeSignature[]) {
         super(sinfo, "DashResult<" + entries.map((tt) => tt.tkeystr).join(", ") + ">");
         this.entries = entries;
+    }
+
+    hasTemplateBindings(): boolean {
+        return this.entries.some((tt) => tt.hasTemplateBindings());
     }
 
     remapTemplateBindings(mapper: TemplateNameMapper): TypeSignature {
@@ -418,6 +447,10 @@ class LambdaTypeSignature extends TypeSignature {
         this.name = name;
         this.params = params;
         this.resultType = resultType;
+    }
+
+    hasTemplateBindings(): boolean {
+        return this.params.some((pp) => pp.type.hasTemplateBindings()) || this.resultType.hasTemplateBindings();
     }
 
     remapTemplateBindings(mapper: TemplateNameMapper): TypeSignature {
@@ -472,6 +505,10 @@ class FormatStringTypeSignature extends TypeSignature {
         this.terms = terms;
     }
 
+    hasTemplateBindings(): boolean {
+        return this.terms.some((tt) => tt.argtype.hasTemplateBindings()) || this.rtype.hasTemplateBindings();
+    }
+
     remapTemplateBindings(mapper: TemplateNameMapper): TypeSignature {
         const ttrmp = this.terms.map((tt) => { return {argname: tt.argname, argtype: tt.argtype.remapTemplateBindings(mapper)}; });
         return new FormatStringTypeSignature(this.sinfo, this.oftype, this.rtype.remapTemplateBindings(mapper), ttrmp);
@@ -513,6 +550,10 @@ class FormatPathTypeSignature extends TypeSignature {
         this.oftype = oftype;
         this.rtype = rtype;
         this.terms = terms;
+    }
+
+    hasTemplateBindings(): boolean {
+        return this.terms.some((tt) => tt.argtype.hasTemplateBindings()) || this.rtype.hasTemplateBindings();
     }
 
     remapTemplateBindings(mapper: TemplateNameMapper): TypeSignature {

--- a/src/samples/binary_tree/binary_tree.bsq
+++ b/src/samples/binary_tree/binary_tree.bsq
@@ -9,27 +9,24 @@ public function main(n: Nat): CString
     let stretchDepth: Nat = n + 1n;
     let check: Nat = TreeNode.create(stretchDepth).check();
         
-    ref output = List<CString>{};
-    output.pushBack(interpolate::cstring("stretch tree of depth " + (stretchDepth) + "\t check: " + check));
+    let infomsg = Interpolate::cstring($'stretch tree of depth ${0}%t; check: ${1}', Nat::toString(stretchDepth), Nat::toString(check));
 
     const longLivedTree = TreeNode::create(maxDepth);
     const tdepths = List::rangeOfNat(minDepth, maxDepth, 2n, true); //inclusive of end value
         
-    tdepths.map(fn(depth) => {
+    let msgs = tdepths.flatmap(fn(depth) => {
         let iterations = Nat::pow(2n, (maxDepth - depth) + minDepth);
         let iterrng = List::rangeOfNat(1n, iterations, inclusive=true); //inclusive of end value
 
-        check = 0;
+        let checkvals = iterrng.map(fn(i) => (TreeNode.create(depth)).check());
+        let checksums = checkvals.sumPrefix();
 
-           for (int i = 1; i <= iterations; i++)
-           {
-                check += (TreeNode.create(depth)).check();
-           }
-           System.out.println(iterations + "\t trees of depth " + depth + "\t check: " + check);
-        });
-
-        System.out.println("long lived tree of depth " + n + "\t check: " + longLivedTree.check());
+        return zipmap<Nat, Nat, CString>(checkvals, checksums, fn(c, s) => Interpolate::cstring($'${0}%t; check: ${1}', Nat::toString(c), Nat::toString(s)));
     });
+
+    let llmsg = Interpolate::cstring($'long lived tree of depth ${0}%t; check: ${1}', Nat::toString(maxDepth), Nat::toString(longLivedTree.check()));
+
+    return msgs.pushFront(infomsg).pushBack(llmsg);
 }
 
 entity TreeNode {

--- a/src/samples/binary_tree/binary_tree.bsq
+++ b/src/samples/binary_tree/binary_tree.bsq
@@ -2,31 +2,32 @@ declare namespace Main;
 
 const minDepth: Nat = 4n;
 
-public function main(n: Nat): CString 
+public function main(n: Nat): List<CString>
     requires n >= minDepth + 2n;
 {
     let maxDepth = n;
     let stretchDepth: Nat = n + 1n;
     let check: Nat = TreeNode.create(stretchDepth).check();
         
-    let infomsg = Interpolate::cstring($'stretch tree of depth ${0}%t; check: ${1}', Nat::toString(stretchDepth), Nat::toString(check));
+    ref msgs = List<CString>{};
+    ref msgs.pushBack(Interpolate::cstring($'stretch tree of depth ${0}%t; check: ${1}', Nat::toString(stretchDepth), Nat::toString(check)));
 
     const longLivedTree = TreeNode::create(maxDepth);
     const tdepths = List::rangeOfNat(minDepth, maxDepth, 2n, true); //inclusive of end value
         
-    let msgs = tdepths.flatmap(fn(depth) => {
+    tdepths.map(ref msgs, fn(depth) => {
         let iterations = Nat::pow(2n, (maxDepth - depth) + minDepth);
         let iterrng = List::rangeOfNat(1n, iterations, inclusive=true); //inclusive of end value
 
         let checkvals = iterrng.map(fn(i) => (TreeNode.create(depth)).check());
-        let checksums = checkvals.sumPrefix();
+        let checksum = checkvals.sum();
 
-        return zipmap<Nat, Nat, CString>(checkvals, checksums, fn(c, s) => Interpolate::cstring($'${0}%t; check: ${1}', Nat::toString(c), Nat::toString(s)));
+        ref msgs.pushBack(Interpolate::cstring($'${0}%t; check: ${1}', Nat::toString(depth), Nat::toString(checksum)));
     });
 
-    let llmsg = Interpolate::cstring($'long lived tree of depth ${0}%t; check: ${1}', Nat::toString(maxDepth), Nat::toString(longLivedTree.check()));
+    ref msgs.pushBack(Interpolate::cstring($'long lived tree of depth ${0}%t; check: ${1}', Nat::toString(maxDepth), Nat::toString(longLivedTree.check())));
 
-    return msgs.pushFront(infomsg).pushBack(llmsg);
+    return msgs
 }
 
 entity TreeNode {
@@ -43,18 +44,18 @@ entity TreeNode {
         }
     }
     
-    method check(): Int {
-        var ld = 0i;
+    method check(): Nat {
+        var ld: Nat = 0n;
         if($l = this.left)@some {
             ld = $l.check();
         }
 
-        var rd = 0i;
+        var rd: Nat = 0n;
         if($r = this.right)@some {
             rd = $r.check();
         }
 
-        return 1i + ld + rd;
+        return 1n + ld + rd;
     }
 }
 

--- a/src/tecton/tecton.bsq
+++ b/src/tecton/tecton.bsq
@@ -2,21 +2,28 @@ declare namespace Tecton {
     using Assembly;
 }
 
-type ComponentPath = CString of /[A-Z][_a-zA-Z0-9]+('.'[_a-zA-Z0-9]+)*('@'(${Assembly::typeKeyRE}|'length'))?/c & {
+type ComponentPath = CString of /[_a-zA-Z0-9]+('.'[_a-zA-Z0-9]+)*('@'(${Assembly::typeKeyRE}|'length'))?/c & {
+    const dotPathExtension: FCString<CString, CString, CString> = $'${0}.${1}';
+    const specialPathExtension: FCString<CString, CString, CString> = $'${0}@${1}';
+
     method extendWithField(f: CString): ComponentPath {
-        return CString::concat(this.value, '.', f);
+        return ComponentPath::from(Interpolate::cstring(ComponentPath::dotPathExtension, this.value, f));
+    }
+
+    method extendWithValue(): ComponentPath {
+        return ComponentPath::from(Interpolate::cstring(ComponentPath::dotPathExtension, this.value, 'value'));
     }
 
     method extendWithIndex(i: CString): ComponentPath {
-        return CString::concat(this.value, '.', i);
+        return ComponentPath::from(Interpolate::cstring(ComponentPath::dotPathExtension, this.value, i));
     }
 
     method extendWithType(oftype: Assembly::TypeKey): ComponentPath {
-        return CString::concat(this.value, '@', oftype.value);
+        return ComponentPath::from(Interpolate::cstring(ComponentPath::specialPathExtension, this.value, oftype.value));
     }
 
     method extendWithLength(): ComponentPath {
-        return CString::concat(this.value, '@', 'length');
+        return ComponentPath::from(Interpolate::cstring(ComponentPath::specialPathExtension, this.value, 'length'));
     }
 }
 
@@ -41,23 +48,44 @@ entity PrimitiveComponent {
     field constraints: List<ComponentConstraint>;
 }
 
-function generatePrimitiveComponent(pdecl: Assembly::PrimitiveEntityTypeDecl, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): PrimitiveComponent {
-    return PrimitiveComponent{ pdecl.tkey, path, steps, constraints };
+function generateComponentsForPrimitive(pdecl: Assembly::PrimitiveEntityTypeDecl, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): List<PrimitiveComponent> {
+    return List<PrimitiveComponent>{ PrimitiveComponent{ pdecl.tkey, path, steps, constraints } };
 }
 
-function generateEnumComponent(edecl: Assembly::EnumTypeDecl, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): PrimitiveComponent {
-    abort;
+function generateComponentsForEnum(edecl: Assembly::EnumTypeDecl, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): List<PrimitiveComponent> {
+    return List<PrimitiveComponent>{ PrimitiveComponent{ edecl.tkey, path, steps, constraints } };
 }
 
-function generateTypeDeclType(tdecl: Assembly::TypedeclTypeDecl, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): PrimitiveComponent {
-    abort;
+recursive function generateComponentsForTypeDecl(tdecl: Assembly::TypedeclTypeDecl, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): List<PrimitiveComponent> {
+    let epath = path.extendWithValue();
+    let esteps = steps.pushBack('value');
+    
+    return generateComponentsForType[recursive](tdecl.valuetype.tkeystr, epath, esteps, constraints, assembly);
 }
 
-public function gatherPrimitveComponentsForType(gentype: Assembly::TypeKey, asm: Assembly::BapiAssembly): List<PrimitiveComponent> {
-    return xxxx;
+recursive function generateComponentsForNominalTypeSig(tsig: Assembly::NominalTypeSignature, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): List<PrimitiveComponent> {
+    let tdecl = assembly.alltypes.get(tsig.tkeystr);
+
+    match(tdecl) {
+        Assembly::PrimitiveEntityTypeDecl => { return generateComponentsForPrimitive($tdecl, path, steps, constraints, assembly); }
+        Assembly::EnumTypeDecl => { return generateComponentsForEnum($tdecl, path, steps, constraints, assembly); }
+        Assembly::TypedeclTypeDecl => { return generateComponentsForTypeDecl[recursive]($tdecl, path, steps, constraints, assembly); }
+    }
 }
 
-public function main(asm: Assembly::BapiAssembly, gentype: Assembly::TypeKey): Assembly::BapiAssembly {
-    return asm;
+recursive function generateComponentsForType(gentype: Assembly::TypeKey, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): List<PrimitiveComponent> {
+    let tsig = assembly.alltypesigs.get(gentype);
+
+    match(tsig) {
+        Assembly::VoidTypeSignature => { abort; } %%Should be handled prior to this point
+        Assembly::NominalTypeSignature => { return generateComponentsForNominalTypeSig[recursive]($tsig, path, steps, constraints, assembly); }
+        %%Need to implement other cases here
+    }
+}
+
+public function main(asm: Assembly::BapiAssembly, gentype: Assembly::TypeKey): List<PrimitiveComponent> {
+    let components = generateComponentsForType[recursive](gentype, ComponentPath::from('root'), List<CString>{'root'}, List<ComponentConstraint>{}, asm);
+
+    return components;
 }
 

--- a/src/tecton/tecton.bsq
+++ b/src/tecton/tecton.bsq
@@ -63,7 +63,7 @@ recursive function generateComponentsForTypeDecl(tdecl: Assembly::TypedeclTypeDe
     return generateComponentsForType[recursive](tdecl.valuetype.tkeystr, epath, esteps, constraints, assembly);
 }
 
-recursive function generateComponentsForNominalTypeSig(tsig: Assembly::NominalTypeSignature, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): List<PrimitiveComponent> {
+recursive function generateComponentsForNominalTypeSignature(tsig: Assembly::NominalTypeSignature, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): List<PrimitiveComponent> {
     let tdecl = assembly.alltypes.get(tsig.tkeystr);
 
     match(tdecl) {
@@ -73,12 +73,22 @@ recursive function generateComponentsForNominalTypeSig(tsig: Assembly::NominalTy
     }
 }
 
+recursive function generateComponentsForEListTypeSignature(tsig: Assembly::EListTypeSignature, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): List<PrimitiveComponent> {
+    return tsig.entries.flatmapIdx[recursive](recursive fn(entry, idx) => {
+        let epath = path.extendWithIndex(Nat::toCString(idx));
+        let esteps = steps.pushBack(Nat::toCString(idx));
+
+        return generateComponentsForType[recursive](entry.tkeystr, epath, esteps, constraints, assembly);
+    });
+}
+
 recursive function generateComponentsForType(gentype: Assembly::TypeKey, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): List<PrimitiveComponent> {
     let tsig = assembly.alltypesigs.get(gentype);
 
     match(tsig) {
         Assembly::VoidTypeSignature => { abort; } %%Should be handled prior to this point
-        Assembly::NominalTypeSignature => { return generateComponentsForNominalTypeSig[recursive]($tsig, path, steps, constraints, assembly); }
+        Assembly::NominalTypeSignature => { return generateComponentsForNominalTypeSignature[recursive]($tsig, path, steps, constraints, assembly); }
+        Assembly::EListTypeSignature => { return generateComponentsForEListTypeSignature[recursive]($tsig, path, steps, constraints, assembly); }
         %%Need to implement other cases here
     }
 }

--- a/src/tecton/tecton.bsq
+++ b/src/tecton/tecton.bsq
@@ -74,7 +74,7 @@ recursive function generateComponentsForNominalTypeSignature(tsig: Assembly::Nom
 }
 
 recursive function generateComponentsForEListTypeSignature(tsig: Assembly::EListTypeSignature, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): List<PrimitiveComponent> {
-    return tsig.entries.flatmapIdx[recursive](recursive fn(entry, idx) => {
+    return tsig.entries.flatmapIdx[recursive]<PrimitiveComponent>(recursive fn(entry, idx) => {
         let epath = path.extendWithIndex(Nat::toCString(idx));
         let esteps = steps.pushBack(Nat::toCString(idx));
 

--- a/src/tecton/tecton.bsq
+++ b/src/tecton/tecton.bsq
@@ -2,6 +2,62 @@ declare namespace Tecton {
     using Assembly;
 }
 
-public function main(asm: Assembly::BapiAssembly): Assembly::BapiAssembly {
+type ComponentPath = CString of /[A-Z][_a-zA-Z0-9]+('.'[_a-zA-Z0-9]+)*('@'(${Assembly::typeKeyRE}|'length'))?/c & {
+    method extendWithField(f: CString): ComponentPath {
+        return CString::concat(this.value, '.', f);
+    }
+
+    method extendWithIndex(i: CString): ComponentPath {
+        return CString::concat(this.value, '.', i);
+    }
+
+    method extendWithType(oftype: Assembly::TypeKey): ComponentPath {
+        return CString::concat(this.value, '@', oftype.value);
+    }
+
+    method extendWithLength(): ComponentPath {
+        return CString::concat(this.value, '@', 'length');
+    }
+}
+
+datatype ComponentConstraint using {
+    field onpath: ComponentPath;
+}
+of
+MinLengthConstraint { 
+    field minlen: Nat; 
+}
+OfTypeConstraint {
+    field vtype: Assembly::TypeKey;
+}
+;
+
+entity PrimitiveComponent {
+    field oftype: Assembly::TypeKey;
+
+    field path: ComponentPath;
+    field steps: List<CString>;
+
+    field constraints: List<ComponentConstraint>;
+}
+
+function generatePrimitiveComponent(pdecl: Assembly::PrimitiveEntityTypeDecl, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): PrimitiveComponent {
+    return PrimitiveComponent{ pdecl.tkey, path, steps, constraints };
+}
+
+function generateEnumComponent(edecl: Assembly::EnumTypeDecl, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): PrimitiveComponent {
+    abort;
+}
+
+function generateTypeDeclType(tdecl: Assembly::TypedeclTypeDecl, path: ComponentPath, steps: List<CString>, constraints: List<ComponentConstraint>, assembly: Assembly::BapiAssembly): PrimitiveComponent {
+    abort;
+}
+
+public function gatherPrimitveComponentsForType(gentype: Assembly::TypeKey, asm: Assembly::BapiAssembly): List<PrimitiveComponent> {
+    return xxxx;
+}
+
+public function main(asm: Assembly::BapiAssembly, gentype: Assembly::TypeKey): Assembly::BapiAssembly {
     return asm;
 }
+

--- a/test/stdlib/list/list_append.test.js
+++ b/test/stdlib/list/list_append.test.js
@@ -13,5 +13,13 @@ describe ("List -- append", () => {
         runTestSet('public function main(z: Int): List<Int> { return List<Int>{1i, 2i, 3i}.append(List<Int>{z, 4i}).prepend(List<Int>{ 10i, 11i, 12i }); }', [['1i', 'List<Int>{ 10i, 11i, 12i, 1i, 2i, 3i, 1i, 4i }']], []);
         runTestSet('public function main(z: Int): List<Int> { return List<Int>{1i, 2i, 3i}.prepend(List<Int>{z, 4i}).append(List<Int>{ 10i, 11i, 12i }); }', [['1i', 'List<Int>{ 1i, 4i, 1i, 2i, 3i, 10i, 11i, 12i }']], []);
     });
+
+    it("should concat/flatten", function () {
+        runTestSet('public function main(l: List<Int>): List<Int> { let lpre = List<Int>{ 1i, 2i, 3i }; let lpost = List<Int>{ 10i, 11i, 12i }; return List<Int>::concat(l, lpre, l, lpost); }', [['List<Int>{}', 'List<Int>{ 1i, 2i, 3i, 10i, 11i, 12i }'],['List<Int>{ 4i, 5i }', 'List<Int>{ 4i, 5i, 1i, 2i, 3i, 4i, 5i, 10i, 11i, 12i }']], []);
+        runTestSet('public function main(l: List<Int>): List<Int> { let lpre = List<Int>{ 1i, 2i, 3i }; let lpost = List<Int>{ 10i, 11i, 12i }; return List<Int>::concatAll(List<List<Int>>{l, lpre, l, lpost}); }', [['List<Int>{}', 'List<Int>{ 1i, 2i, 3i, 10i, 11i, 12i }'],['List<Int>{ 4i, 5i }', 'List<Int>{ 4i, 5i, 1i, 2i, 3i, 4i, 5i, 10i, 11i, 12i }']], []);
+        runTestSet('public function main(l: List<Int>): List<Int> { let lpre = List<Int>{ 1i, 2i, 3i }; let lpost = List<Int>{ 10i, 11i, 12i }; return List<List<Int>>{l, lpre, l, lpost}.flatten<Int>(); }', [['List<Int>{}', 'List<Int>{ 1i, 2i, 3i, 10i, 11i, 12i }'],['List<Int>{ 4i, 5i }', 'List<Int>{ 4i, 5i, 1i, 2i, 3i, 4i, 5i, 10i, 11i, 12i }']], []);
+
+        runTestSet("public function main(l: List<CString>): List<CString> { let lpre = List<CString>{ 'a', 'b', 'c' }; let lpost = List<CString>{ 'x', 'y' }; return List<CString>::concat(l, lpre, l, lpost); }", [['List<CString>{}', "List<CString>{ 'a', 'b', 'c', 'x', 'y' }"], ['List<CString>{"q"}', "List<CString>{ 'q', 'a', 'b', 'c', 'q', 'x', 'y' }"]], []);
+    });
 });
 

--- a/test/stdlib/list/list_map.test.js
+++ b/test/stdlib/list/list_map.test.js
@@ -21,7 +21,6 @@ describe ("List -- map index basic", () => {
     });
 });
 
-
 describe ("List -- convert", () => {
     it("should convert list", function () {
         runTestSet(`${datatypedef} public function main(b: Bool): List<F2> { return List<Foo>{}.convert<F2>(); }`, [['true', 'List<Main::F2>{ }']], []);
@@ -37,5 +36,15 @@ describe ("List -- convert", () => {
         runTestSet('public function main(b: Bool): List<Int> { return List<Option<Int>>{some(2i), some(1i), some(3i), some(1i), some(5i)}.convertsome<Int>(); }', [['true', 'List<Int>{ 2i, 1i, 3i, 1i, 5i }']], []);         
 
         runTestSet('public function main(b: Bool): List<Int> { return List<Option<Int>>{some(2i), none}.convertsome<Int>(); }', [], ['false']); 
+    });
+});
+
+describe ("List -- flatmap basic", () => {
+    it("should do simple flatmap", function () {
+        runTestSet('public function main(z: Int): List<Bool> { return List<Int>{1i, z, 5i}.flatmap<Bool>(fn(x) => List<Bool>{ x == 1i, x >= 0i }); }', [['1i', 'List<Bool>{ true, true, true, true, false, true }'], ['-1i', 'List<Bool>{ true, true, false, false, false, true }']], []);
+    });
+
+    it("should do simple flatmapIdx", function () {
+        runTestSet('public function main(z: Nat): List<Nat> { return List<Nat>{1n, z, 5n}.flatmapIdx<Nat>(fn(x, i) => List<Nat>{ x, i, x + i }); }', [['3n', 'List<Nat>{ 1n, 0n, 1n, 3n, 1n, 4n, 5n, 2n, 7n }']], []);
     });
 });

--- a/test/stdlib/numerics/numerics.test.js
+++ b/test/stdlib/numerics/numerics.test.js
@@ -3,9 +3,20 @@
 import { runTestSet } from "../../../bin/test/stdlib/stdlib_nf.js";
 import { describe, it } from "node:test";
 
-describe ("Nats Power", () => {
+describe ("Nat Operations", () => {
+    it("should compute tostring", function () {
+        runTestSet('public function main(n: Nat): CString { return Nat::toCString(n); }', [['0n', "'0'"], ['3n', "'3'"]], []);
+    });
+    
     it("should compute powers generally", function () {
         runTestSet('public function main(x: Nat): Nat { return Nat::pow(x, 5n); }', [['0n', '0n'], ['1n', '1n'], ['2n', '32n'], ['3n', '243n']], ['16777216n']);
         runTestSet('public function main(y: Nat): Nat { return Nat::pow(3n, y); }', [['0n', '1n'], ['1n', '3n'], ['2n', '9n'], ['3n', '27n']], ['904n']);
     });
 });
+
+describe ("Int Operations", () => {
+    it("should compute tostring", function () {
+        runTestSet('public function main(i: Int): CString { return Int::toCString(i); }', [['0i', "'0'"], ['3i', "'3'"], ['-3i', "'-3'"]], []);
+    });
+});
+


### PR DESCRIPTION
Work on tecton (some nontrival partition decomposition).

Stdlib additions
- flatmap
- concat/concatAll/flatten

Bug fix for checker areSameTypes
- Make sure we don't cache when there are templates (maybe change on mapping)
- Check possibility templates are equal if bound *AND* unique types